### PR TITLE
Add a parser for Sorbet errors

### DIFF
--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -5,6 +5,7 @@ require "thor"
 
 require_relative "cli/commands/config"
 require_relative "cli/commands/lsp"
+require_relative "cli/commands/run"
 
 module Spoom
   module Cli
@@ -18,6 +19,9 @@ module Spoom
 
       desc "lsp", "send LSP requests to Sorbet"
       subcommand "lsp", Spoom::Cli::Commands::LSP
+
+      desc "tc", "run Sorbet and parses its output"
+      subcommand "tc", Spoom::Cli::Commands::Run
 
       # Utils
 

--- a/lib/spoom/cli/commands/run.rb
+++ b/lib/spoom/cli/commands/run.rb
@@ -1,0 +1,80 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "base"
+
+module Spoom
+  module Cli
+    module Commands
+      class Run < Base
+        default_task :tc
+
+        desc "tc", "run srb tc"
+        option :limit, type: :numeric, aliases: :l
+        option :code, type: :numeric, aliases: :c
+        option :sort, type: :string, aliases: :s
+        def tc
+          in_sorbet_project!
+
+          limit = options[:limit]
+          sort = options[:sort]
+          code = options[:code]
+          colors = !options[:no_color]
+
+          unless limit || code || sort
+            return Spoom::Sorbet.srb_tc(capture_err: false).last
+          end
+
+          output, status = Spoom::Sorbet.srb_tc(capture_err: true)
+          if status
+            $stderr.print(output)
+            return 0
+          end
+
+          errors = Spoom::Sorbet::Errors::Parser.parse_string(output)
+          errors_count = errors.size
+
+          errors = sort == "code" ? errors.sort_by { |e| [e.code, e.file, e.line, e.message] } : errors.sort
+          errors = errors.select { |e| e.code == code } if code
+          errors = T.must(errors.slice(0, limit)) if limit
+
+          errors.each do |e|
+            code = colorize_code(e.code, colors)
+            message = colorize_message(e.message, colors)
+            $stderr.puts "#{code} - #{e.file}:#{e.line}: #{message}"
+          end
+
+          if errors_count == errors.size
+            $stderr.puts "Errors: #{errors_count}"
+          else
+            $stderr.puts "Errors: #{errors.size} shown, #{errors_count} total"
+          end
+
+          1
+        end
+
+        no_commands do
+          def colorize_code(code, colors = true)
+            return code.to_s unless colors
+            code.to_s.light_black
+          end
+
+          def colorize_message(message, colors = true)
+            return message unless colors
+
+            cyan = T.let(false, T::Boolean)
+            word = StringIO.new
+            message.chars.each do |c|
+              if c == '`'
+                cyan = !cyan
+                next
+              end
+              word << (cyan ? c.cyan : c.red)
+            end
+            word.string
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spoom/sorbet/config"
+require "spoom/sorbet/errors"
 require "spoom/sorbet/lsp"
 
 require "open3"

--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -11,6 +11,31 @@ module Spoom
   module Sorbet
     extend T::Sig
 
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns([String, T::Boolean]) }
+    def self.srb(*arg, path: '.', capture_err: false)
+      opts = {}
+      opts[:chdir] = path
+      out = T.let("", T.nilable(String))
+      res = T.let(false, T::Boolean)
+      if capture_err
+        Open3.popen2e(["bundle", "exec", "srb", *arg].join(" "), opts) do |_, o, t|
+          out = o.read
+          res = T.cast(t.value, Process::Status).success?
+        end
+      else
+        Open3.popen2(["bundle", "exec", "srb", *arg].join(" "), opts) do |_, o, t|
+          out = o.read
+          res = T.cast(t.value, Process::Status).success?
+        end
+      end
+      [out || "", res]
+    end
+
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns([String, T::Boolean]) }
+    def self.srb_tc(*arg, path: '.', capture_err: false)
+      srb(*T.unsafe(["tc", *arg]), path: path, capture_err: capture_err)
+    end
+
     # List all files typechecked by Sorbet from its `config`
     sig { params(config: Config, path: String).returns(T::Array[String]) }
     def self.srb_files(config, path: '.')

--- a/lib/spoom/sorbet/errors.rb
+++ b/lib/spoom/sorbet/errors.rb
@@ -1,0 +1,100 @@
+# typed: true
+# frozen_string_literal: true
+
+module Spoom
+  module Sorbet
+    module Errors
+      # Parse errors from Sorbet output
+      class Parser
+        HEADER = [
+          "👋 Hey there! Heads up that this is not a release build of sorbet.",
+          "Release builds are faster and more well-supported by the Sorbet team.",
+          "Check out the README to learn how to build Sorbet in release mode.",
+          "To forcibly silence this error, either pass --silence-dev-message,",
+          "or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.",
+        ]
+
+        def self.parse_string(output)
+          parser = Spoom::Sorbet::Errors::Parser.new
+          parser.parse(output)
+        end
+
+        def initialize
+          @errors = []
+          @current_error = nil
+        end
+
+        def parse(output)
+          output.each_line do |line|
+            break @errors if /^No errors! Great job\./.match?(line)
+            break @errors if /^Errors: /.match?(line)
+            next if HEADER.include?(line.strip)
+
+            next if line == "\n"
+
+            if leading_spaces(line) == 0
+              close_error if @current_error
+              open_error(line)
+              next
+            end
+
+            append_error(line)
+          end
+          close_error if @current_error
+          @errors
+        end
+
+        def leading_spaces(line)
+          line.index(/[^ ]/)
+        end
+
+        def open_error(line)
+          raise "Error: Already parsing an error!" if @current_error
+          @current_error = Error.from_error_line(line)
+        end
+
+        def close_error
+          return unless @current_error
+          @errors << @current_error
+          @current_error = nil
+        end
+
+        def append_error(line)
+          raise "Error: Not already parsing an error!" unless @current_error
+          @current_error.more << line
+        end
+      end
+
+      class Error
+        include Comparable
+
+        attr_reader :file, :line, :message, :code, :details, :more
+
+        def initialize(file, line, message, code, more = [])
+          @file = file
+          @line = line
+          @message = message
+          @code = code
+          @more = more
+        end
+
+        def self.from_error_line(line)
+          file, rest = line.split(":", 2)
+          line, rest = rest&.split(": ", 2)
+          message, code = rest&.split(%r{ https://srb\.help/}, 2)
+          Error.new(file, line&.to_i, message, code&.to_i)
+        end
+
+        def <=>(other)
+          return 0 unless other.is_a?(Error)
+          return line <=> other.line if file == other.file
+          file <=> other.file
+        end
+
+        def to_s
+          "#{file}:#{line}: #{message} (#{code})"
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/cli/commands/config_test.rb
+++ b/test/spoom/cli/commands/config_test.rb
@@ -12,29 +12,27 @@ module Spoom
         include Spoom::Cli::TestHelper
         extend Spoom::Cli::TestHelper
 
-        def test_project
-          "project"
-        end
+        PROJECT = "project"
 
         before_all do
-          install_sorbet("project")
+          install_sorbet(PROJECT)
         end
 
         def teardown
-          use_sorbet_config(test_project, nil)
+          use_sorbet_config(PROJECT, nil)
         end
 
         def test_return_error_if_no_sorbet_config
-          use_sorbet_config(test_project, nil)
-          _, err = run_cli(test_project, "config")
+          use_sorbet_config(PROJECT, nil)
+          _, err = run_cli(PROJECT, "config")
           assert_equal(<<~MSG, err)
             Error: not in a Sorbet project (no sorbet/config)
           MSG
         end
 
         def test_display_empty_config
-          use_sorbet_config(test_project, "")
-          out, _ = run_cli(test_project, "config")
+          use_sorbet_config(PROJECT, "")
+          out, _ = run_cli(PROJECT, "config")
           assert_equal(<<~MSG, out)
             Found Sorbet config at `sorbet/config`.
 
@@ -51,8 +49,8 @@ module Spoom
         end
 
         def test_display_simple_config
-          use_sorbet_config(test_project, ".")
-          out, _ = run_cli(test_project, "config")
+          use_sorbet_config(PROJECT, ".")
+          out, _ = run_cli(PROJECT, "config")
           assert_equal(<<~MSG, out)
             Found Sorbet config at `sorbet/config`.
 
@@ -69,13 +67,13 @@ module Spoom
         end
 
         def test_display_multi_config
-          use_sorbet_config(test_project, <<~CFG)
+          use_sorbet_config(PROJECT, <<~CFG)
             lib
             --dir=test
             --dir
             tasks
           CFG
-          out, _ = run_cli(test_project, "config")
+          out, _ = run_cli(PROJECT, "config")
           assert_equal(<<~MSG, out)
             Found Sorbet config at `sorbet/config`.
 
@@ -94,13 +92,13 @@ module Spoom
         end
 
         def test_display_config_with_ignored_files
-          use_sorbet_config(test_project, <<~CFG)
+          use_sorbet_config(PROJECT, <<~CFG)
             lib/project.rb
             --ignore=lib/main
             --ignore
             test
           CFG
-          out, _ = run_cli(test_project, "config")
+          out, _ = run_cli(PROJECT, "config")
           assert_equal(<<~MSG, out)
             Found Sorbet config at `sorbet/config`.
 
@@ -118,7 +116,7 @@ module Spoom
         end
 
         def test_display_config_with_allowed_extensions
-          use_sorbet_config(test_project, <<~CFG)
+          use_sorbet_config(PROJECT, <<~CFG)
             lib/project.rb
             --ignore=lib/main
             --ignore
@@ -128,7 +126,7 @@ module Spoom
             --allowed-extension=.rake
             --allowed-extension=.ru
           CFG
-          out, _ = run_cli(test_project, "config")
+          out, _ = run_cli(PROJECT, "config")
           assert_equal(<<~MSG, out)
             Found Sorbet config at `sorbet/config`.
 
@@ -148,8 +146,8 @@ module Spoom
         end
 
         def test_display_files_from_config
-          use_sorbet_config(test_project, ".")
-          out, _ = run_cli(test_project, "config files")
+          use_sorbet_config(PROJECT, ".")
+          out, _ = run_cli(PROJECT, "config files")
           assert_equal(<<~MSG, out)
             Files matching `sorbet/config`:
              * errors/errors.rb
@@ -163,12 +161,12 @@ module Spoom
         end
 
         def test_display_files_from_config_with_ignored_files
-          use_sorbet_config(test_project, <<~CFG)
+          use_sorbet_config(PROJECT, <<~CFG)
             .
             --ignore=efs
             --ignore=errors
           CFG
-          out, _ = run_cli(test_project, "config files")
+          out, _ = run_cli(PROJECT, "config files")
           assert_equal(<<~MSG, out)
             Files matching `sorbet/config`:
              * lib/hover.rb
@@ -179,11 +177,11 @@ module Spoom
         end
 
         def test_display_files_from_config_with_allowed_exts
-          use_sorbet_config(test_project, <<~CFG)
+          use_sorbet_config(PROJECT, <<~CFG)
             .
             --allowed-extension=.rake
           CFG
-          out, _ = run_cli(test_project, "config files")
+          out, _ = run_cli(PROJECT, "config files")
           assert_equal(<<~MSG, out)
             Files matching `sorbet/config`:
              * task1.rake

--- a/test/spoom/cli/commands/lsp_test.rb
+++ b/test/spoom/cli/commands/lsp_test.rb
@@ -12,38 +12,36 @@ module Spoom
         include Spoom::Cli::TestHelper
         extend Spoom::Cli::TestHelper
 
-        def test_project
-          "project"
-        end
+        PROJECT = "project"
 
         before_all do
-          install_sorbet("project")
+          install_sorbet(PROJECT)
         end
 
         def setup
-          use_sorbet_config(test_project, <<~CFG)
+          use_sorbet_config(PROJECT, <<~CFG)
             .
             --ignore=errors
           CFG
         end
 
         def teardown
-          use_sorbet_config(test_project, nil)
+          use_sorbet_config(PROJECT, nil)
         end
 
         # Errors
 
         def test_cant_open_without_config
-          use_sorbet_config(test_project, nil)
-          _, err = run_cli(test_project, "lsp --no-color find Foo")
+          use_sorbet_config(PROJECT, nil)
+          _, err = run_cli(PROJECT, "lsp --no-color find Foo")
           assert_equal(<<~MSG, err)
             Error: not in a Sorbet project (no sorbet/config)
           MSG
         end
 
         def test_cant_open_with_errors
-          use_sorbet_config(test_project, "errors")
-          _, err = run_cli(test_project, "lsp --no-color find Foo")
+          use_sorbet_config(PROJECT, "errors")
+          _, err = run_cli(PROJECT, "lsp --no-color find Foo")
           assert_equal(<<~MSG, err)
             Error: Sorbet returned typechecking errors for `/errors.rb`
               9:4-9:15: Wrong number of arguments for constructor. Expected: `0`, got: `1` (7004)
@@ -59,7 +57,7 @@ module Spoom
         # Defs
 
         def test_list_defs
-          out, _ = run_cli(test_project, "lsp --no-color defs lib/defs.rb 3 6")
+          out, _ = run_cli(PROJECT, "lsp --no-color defs lib/defs.rb 3 6")
           assert_equal(<<~MSG, out)
             Definitions for `lib/defs.rb:3:6`:
              * /lib/defs.rb:3:7-3:17
@@ -69,7 +67,7 @@ module Spoom
         # Hover
 
         def test_list_hover_empty
-          out, _ = run_cli(test_project, "lsp --no-color hover lib/hover.rb 0 0")
+          out, _ = run_cli(PROJECT, "lsp --no-color hover lib/hover.rb 0 0")
           assert_equal(<<~MSG, out)
             Hovering `lib/hover.rb:0:0`:
             <no data>
@@ -77,7 +75,7 @@ module Spoom
         end
 
         def test_list_hover_class
-          out, _ = run_cli(test_project, "lsp --no-color hover lib/hover.rb 3 12")
+          out, _ = run_cli(PROJECT, "lsp --no-color hover lib/hover.rb 3 12")
           assert_equal(<<~MSG, out)
             Hovering `lib/hover.rb:3:12`:
             T.class_of(HoverTest)
@@ -85,7 +83,7 @@ module Spoom
         end
 
         def test_list_hover_def
-          out, _ = run_cli(test_project, "lsp --no-color hover lib/hover.rb 7 8")
+          out, _ = run_cli(PROJECT, "lsp --no-color hover lib/hover.rb 7 8")
           assert_equal(<<~MSG, out)
             Hovering `lib/hover.rb:7:8`:
             sig {params(a: Integer).returns(String)}
@@ -94,7 +92,7 @@ module Spoom
         end
 
         def test_list_hover_param
-          out, _ = run_cli(test_project, "lsp --no-color hover lib/hover.rb 7 11")
+          out, _ = run_cli(PROJECT, "lsp --no-color hover lib/hover.rb 7 11")
           assert_equal(<<~MSG, out)
             Hovering `lib/hover.rb:7:11`:
             Integer
@@ -102,7 +100,7 @@ module Spoom
         end
 
         def test_list_hover_call
-          out, _ = run_cli(test_project, "lsp hover lib/hover.rb 13 4")
+          out, _ = run_cli(PROJECT, "lsp hover lib/hover.rb 13 4")
           assert_equal(<<~MSG, out)
             Hovering `lib/hover.rb:13:4`:
             sig {params(a: Integer).returns(String)}
@@ -113,7 +111,7 @@ module Spoom
         # Find
 
         def test_find
-          out, _ = run_cli(test_project, "lsp --no-color find Hover")
+          out, _ = run_cli(PROJECT, "lsp --no-color find Hover")
           assert_equal(<<~MSG, out)
             Symbols matching `Hover`:
               class HoverTest (/lib/hover.rb:3:0-3:15)
@@ -123,7 +121,7 @@ module Spoom
         # Refs
 
         def test_list_refs
-          out, _ = run_cli(test_project, "lsp --no-color refs lib/refs.rb 2 1")
+          out, _ = run_cli(PROJECT, "lsp --no-color refs lib/refs.rb 2 1")
           assert_equal(<<~MSG, out)
             References to `lib/refs.rb:2:1`:
              * /lib/refs.rb:3:0-3:3
@@ -137,7 +135,7 @@ module Spoom
         # Sigs
 
         def test_list_sigs
-          out, _ = run_cli(test_project, "lsp --no-color sigs lib/sigs.rb 13 4")
+          out, _ = run_cli(PROJECT, "lsp --no-color sigs lib/sigs.rb 13 4")
           assert_equal(<<~MSG, out)
             Signature for `lib/sigs.rb:13:4`:
              * SigsTest#bar(a: Integer, <blk>: T.untyped)
@@ -147,7 +145,7 @@ module Spoom
         # Symbols
 
         def test_list_symbols
-          out, _ = run_cli(test_project, "lsp --no-color symbols lib/symbols.rb")
+          out, _ = run_cli(PROJECT, "lsp --no-color symbols lib/symbols.rb")
           assert_equal(<<~MSG, out)
             Symbols from `lib/symbols.rb`:
               module Symbols (3:0-3:14)
@@ -167,7 +165,7 @@ module Spoom
         # Types
 
         def test_list_types
-          out, _ = run_cli(test_project, "lsp --no-color types lib/types.rb 6 5")
+          out, _ = run_cli(PROJECT, "lsp --no-color types lib/types.rb 6 5")
           assert_equal(<<~MSG, out)
             Type for `lib/types.rb:6:5`:
              * /lib/types.rb:3:6-3:14

--- a/test/spoom/cli/commands/run_test.rb
+++ b/test/spoom/cli/commands/run_test.rb
@@ -1,0 +1,125 @@
+# typed: true
+# frozen_string_literal: true
+
+require "pathname"
+
+require_relative "../cli_test_helper"
+
+module Spoom
+  module Cli
+    module Commands
+      class RunTest < Minitest::Test
+        include Spoom::Cli::TestHelper
+        extend Spoom::Cli::TestHelper
+
+        def test_project
+          "project"
+        end
+
+        before_all do
+          install_sorbet("project")
+        end
+
+        def setup
+          use_sorbet_config(test_project, <<~CFG)
+            .
+            --ignore=errors
+          CFG
+        end
+
+        def teardown
+          use_sorbet_config(test_project, nil)
+        end
+
+        def test_return_error_if_no_sorbet_config
+          use_sorbet_config(test_project, nil)
+          _, err = run_cli(test_project, "tc")
+          assert_equal(<<~MSG, err)
+            Error: not in a Sorbet project (no sorbet/config)
+          MSG
+        end
+
+        def test_display_no_errors_without_filter
+          _, err = run_cli(test_project, "tc")
+          assert_equal(<<~MSG, err)
+            No errors! Great job.
+          MSG
+        end
+
+        def test_display_no_errors_with_sort
+          _, err = run_cli(test_project, "tc --no-color -s")
+          assert_equal(<<~MSG, err)
+            No errors! Great job.
+          MSG
+        end
+
+        def test_display_errors_with_sort_default
+          use_sorbet_config(test_project, ".")
+          _, err = run_cli(test_project, "tc --no-color -s")
+          assert_equal(<<~MSG, err)
+            5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+            5002 - errors/errors.rb:5: Unable to resolve constant `C`
+            7003 - errors/errors.rb:5: Method `params` does not exist on `T.class_of(Foo)`
+            7003 - errors/errors.rb:5: Method `sig` does not exist on `T.class_of(Foo)`
+            7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
+            7003 - errors/errors.rb:11: Method `c` does not exist on `T.class_of(<root>)`
+            7004 - errors/errors.rb:11: Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2`
+            Errors: 7
+          MSG
+        end
+
+        def test_display_errors_with_sort_code
+          use_sorbet_config(test_project, ".")
+          _, err = run_cli(test_project, "tc --no-color -s code")
+          assert_equal(<<~MSG, err)
+            5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+            5002 - errors/errors.rb:5: Unable to resolve constant `C`
+            7003 - errors/errors.rb:5: Method `params` does not exist on `T.class_of(Foo)`
+            7003 - errors/errors.rb:5: Method `sig` does not exist on `T.class_of(Foo)`
+            7003 - errors/errors.rb:11: Method `c` does not exist on `T.class_of(<root>)`
+            7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
+            7004 - errors/errors.rb:11: Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2`
+            Errors: 7
+          MSG
+        end
+
+        def test_display_errors_with_limit
+          use_sorbet_config(test_project, ".")
+          _, err = run_cli(test_project, "tc --no-color -l 1")
+          assert_equal(<<~MSG, err)
+            5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+            Errors: 1 shown, 7 total
+          MSG
+        end
+
+        def test_display_errors_with_code
+          use_sorbet_config(test_project, ".")
+          _, err = run_cli(test_project, "tc --no-color -c 7004")
+          assert_equal(<<~MSG, err)
+            7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
+            7004 - errors/errors.rb:11: Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2`
+            Errors: 2 shown, 7 total
+          MSG
+        end
+
+        def test_display_errors_with_limit_and_code
+          use_sorbet_config(test_project, ".")
+          _, err = run_cli(test_project, "tc --no-color -c 7004 -l 1")
+          assert_equal(<<~MSG, err)
+            7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
+            Errors: 1 shown, 7 total
+          MSG
+        end
+
+        def test_display_errors_with_sort_and_limit
+          use_sorbet_config(test_project, ".")
+          _, err = run_cli(test_project, "tc --no-color -s code -l 1")
+          assert_equal(<<~MSG, err)
+            5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+            Errors: 1 shown, 7 total
+          MSG
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/cli/commands/run_test.rb
+++ b/test/spoom/cli/commands/run_test.rb
@@ -12,50 +12,48 @@ module Spoom
         include Spoom::Cli::TestHelper
         extend Spoom::Cli::TestHelper
 
-        def test_project
-          "project"
-        end
+        PROJECT = "project"
 
         before_all do
-          install_sorbet("project")
+          install_sorbet(PROJECT)
         end
 
         def setup
-          use_sorbet_config(test_project, <<~CFG)
+          use_sorbet_config(PROJECT, <<~CFG)
             .
             --ignore=errors
           CFG
         end
 
         def teardown
-          use_sorbet_config(test_project, nil)
+          use_sorbet_config(PROJECT, nil)
         end
 
         def test_return_error_if_no_sorbet_config
-          use_sorbet_config(test_project, nil)
-          _, err = run_cli(test_project, "tc")
+          use_sorbet_config(PROJECT, nil)
+          _, err = run_cli(PROJECT, "tc")
           assert_equal(<<~MSG, err)
             Error: not in a Sorbet project (no sorbet/config)
           MSG
         end
 
         def test_display_no_errors_without_filter
-          _, err = run_cli(test_project, "tc")
+          _, err = run_cli(PROJECT, "tc")
           assert_equal(<<~MSG, err)
             No errors! Great job.
           MSG
         end
 
         def test_display_no_errors_with_sort
-          _, err = run_cli(test_project, "tc --no-color -s")
+          _, err = run_cli(PROJECT, "tc --no-color -s")
           assert_equal(<<~MSG, err)
             No errors! Great job.
           MSG
         end
 
         def test_display_errors_with_sort_default
-          use_sorbet_config(test_project, ".")
-          _, err = run_cli(test_project, "tc --no-color -s")
+          use_sorbet_config(PROJECT, ".")
+          _, err = run_cli(PROJECT, "tc --no-color -s")
           assert_equal(<<~MSG, err)
             5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
             5002 - errors/errors.rb:5: Unable to resolve constant `C`
@@ -69,8 +67,8 @@ module Spoom
         end
 
         def test_display_errors_with_sort_code
-          use_sorbet_config(test_project, ".")
-          _, err = run_cli(test_project, "tc --no-color -s code")
+          use_sorbet_config(PROJECT, ".")
+          _, err = run_cli(PROJECT, "tc --no-color -s code")
           assert_equal(<<~MSG, err)
             5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
             5002 - errors/errors.rb:5: Unable to resolve constant `C`
@@ -84,8 +82,8 @@ module Spoom
         end
 
         def test_display_errors_with_limit
-          use_sorbet_config(test_project, ".")
-          _, err = run_cli(test_project, "tc --no-color -l 1")
+          use_sorbet_config(PROJECT, ".")
+          _, err = run_cli(PROJECT, "tc --no-color -l 1")
           assert_equal(<<~MSG, err)
             5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
             Errors: 1 shown, 7 total
@@ -93,8 +91,8 @@ module Spoom
         end
 
         def test_display_errors_with_code
-          use_sorbet_config(test_project, ".")
-          _, err = run_cli(test_project, "tc --no-color -c 7004")
+          use_sorbet_config(PROJECT, ".")
+          _, err = run_cli(PROJECT, "tc --no-color -c 7004")
           assert_equal(<<~MSG, err)
             7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
             7004 - errors/errors.rb:11: Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2`
@@ -103,8 +101,8 @@ module Spoom
         end
 
         def test_display_errors_with_limit_and_code
-          use_sorbet_config(test_project, ".")
-          _, err = run_cli(test_project, "tc --no-color -c 7004 -l 1")
+          use_sorbet_config(PROJECT, ".")
+          _, err = run_cli(PROJECT, "tc --no-color -c 7004 -l 1")
           assert_equal(<<~MSG, err)
             7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
             Errors: 1 shown, 7 total
@@ -112,8 +110,8 @@ module Spoom
         end
 
         def test_display_errors_with_sort_and_limit
-          use_sorbet_config(test_project, ".")
-          _, err = run_cli(test_project, "tc --no-color -s code -l 1")
+          use_sorbet_config(PROJECT, ".")
+          _, err = run_cli(PROJECT, "tc --no-color -s code -l 1")
           assert_equal(<<~MSG, err)
             5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
             Errors: 1 shown, 7 total

--- a/test/spoom/sorbet/errors_test.rb
+++ b/test/spoom/sorbet/errors_test.rb
@@ -1,0 +1,223 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Spoom
+  module Sorbet
+    class ErrorsTest < Minitest::Test
+      def test_parses_empty_string
+        errors = Spoom::Sorbet::Errors::Parser.parse_string("")
+        assert_empty(errors)
+      end
+
+      def test_parses_no_errors
+        errors = Spoom::Sorbet::Errors::Parser.parse_string("No errors! Great job.")
+        assert_empty(errors)
+      end
+
+      def test_parses_a_token_error
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          lib/test/file.rb:80: unexpected token "end" https://srb.help/2001
+              80 |end
+                  ^^^
+        ERR
+        assert_equal(1, errors.size)
+
+        error = errors.first
+        assert_equal("lib/test/file.rb", error.file)
+        assert_equal(80, error.line)
+        assert_equal("unexpected token \"end\"", error.message)
+        assert_equal(2001, error.code)
+        assert_equal(["80 |end", "^^^"], error.more.each(&:strip!))
+      end
+
+      def test_parses_a_redefinition_error
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          test.rb:100: Method Foo#initialize redefined without matching argument count. Expected: 0, got: 2 https://srb.help/4010
+               100 |    class Foo < T::Struct
+               101 |    end
+              foo.rb:96: Previous definition
+                96 |    class Foo < T::Struct
+                97 |    end
+
+        ERR
+        assert_equal(1, errors.size)
+
+        error = errors.first
+        assert_equal("test.rb", error.file)
+        assert_equal(100, error.line)
+        exp_message = "Method Foo#initialize redefined without matching argument count. Expected: 0, got: 2"
+        assert_equal(exp_message, error.message)
+        assert_equal(4010, error.code)
+      end
+
+      def test_parses_a_method_missing_error
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          test.rb:105: Method foo does not exist on String https://srb.help/7003
+               105 |        printer.print "foo".light_black
+                                          ^^^^^^^^^^^^^^^^^
+        ERR
+        assert_equal(1, errors.size)
+
+        error = errors.first
+        assert_equal("test.rb", error.file)
+        assert_equal(105, error.line)
+        assert_equal("Method foo does not exist on String", error.message)
+        assert_equal(7003, error.code)
+      end
+
+      def test_parses_a_not_enough_arguments_error
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          test.rb:28: Not enough arguments provided for method Foo#bar. Expected: 1..2, got: 1 https://srb.help/7004
+              28 |              bar "hello"
+                                ^^^^^^^^^^^
+              test.rb:11: Foo#bar defined here
+              11 |          def bar(title = "Error", name)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        ERR
+        assert_equal(1, errors.size)
+
+        error = errors.first
+        assert_equal("test.rb", error.file)
+        assert_equal(28, error.line)
+        assert_equal("Not enough arguments provided for method Foo#bar. Expected: 1..2, got: 1", error.message)
+        assert_equal(7004, error.code)
+      end
+
+      def test_parses_multiple_errors
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          a.rb:80: unexpected token "end" https://srb.help/2001
+              80 |end
+                  ^^^
+
+          b.rb:28: Not enough arguments provided for method Foo#bar. Expected: 1..2, got: 1 https://srb.help/7004
+              28 |              bar "hello"
+                                ^^^^^^^^^^^
+              test.rb:11: Foo#bar defined here
+              11 |          def bar(title = "Error", name)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+          c.rb:100: Method Foo#initialize redefined without matching argument count. Expected: 0, got: 2 https://srb.help/4010
+               100 |    class Foo < T::Struct
+               101 |    end
+              foo.rb:96: Previous definition
+                96 |    class Foo < T::Struct
+                97 |    end
+
+
+          d.rb:105: Method foo does not exist on String https://srb.help/7003
+               105 |        printer.print "foo".light_black
+                                          ^^^^^^^^^^^^^^^^^
+        ERR
+        assert_equal(4, errors.size)
+        assert_equal(["a.rb", "b.rb", "c.rb", "d.rb"], errors.map(&:file))
+        assert_equal([80, 28, 100, 105], errors.map(&:line))
+        assert_equal([2001, 7004, 4010, 7003], errors.map(&:code))
+      end
+
+      def test_parses_no_errors_with_debug_string
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          👋 Hey there! Heads up that this is not a release build of sorbet.
+          Release builds are faster and more well-supported by the Sorbet team.
+          Check out the README to learn how to build Sorbet in release mode.
+          To forcibly silence this error, either pass --silence-dev-message,
+          or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.
+
+          No errors! Great job.
+        ERR
+        assert_empty(errors)
+      end
+
+      def test_parses_errors_with_debug_string
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          👋 Hey there! Heads up that this is not a release build of sorbet.
+          Release builds are faster and more well-supported by the Sorbet team.
+          Check out the README to learn how to build Sorbet in release mode.
+          To forcibly silence this error, either pass --silence-dev-message,
+          or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.
+
+          a.rb:80: unexpected token "end" https://srb.help/2001
+              80 |end
+                  ^^^
+
+          b.rb:105: Method foo does not exist on String https://srb.help/7003
+               105 |        printer.print "foo".light_black
+                                          ^^^^^^^^^^^^^^^^^
+        ERR
+        assert_equal(2, errors.size)
+        assert_equal(["a.rb", "b.rb"], errors.map(&:file))
+        assert_equal([80, 105], errors.map(&:line))
+        assert_equal([2001, 7003], errors.map(&:code))
+      end
+
+      def test_parses_errors_with_multiple_blank_lines
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          lib/a.rb:54: Method `foo` does not exist on `String` https://srb.help/7003
+              54 |                x << io.string.foo
+                                                 ^^^
+            Autocorrect: Use `-a` to autocorrect
+              lib/a.rb:54: Replace with `for`
+              54 |                x << io.string.foo
+                                                 ^^^
+
+
+          lib/a.rb:55: Changing the type of a variable in a loop is not permitted https://srb.help/7001
+              55 |                bar = !bar
+                                         ^^^
+            Existing variable has type: `FalseClass`
+            Attempting to change type to: `TrueClass`
+
+            Autocorrect: Use `-a` to autocorrect
+              lib/a.rb:50: Replace with `T.let(false, T::Boolean)`
+              50 |            bar = false
+                                    ^^^^^
+
+          lib/a.rb:64: Expected `T.any(TrueClass, FalseClass)` but found `String("")` for argument `x` https://srb.help/7002
+              64 |            foo("")
+                                  ^^
+              lib/b.rb:1140: Method `Foo#foo (overload.1)` has specified `x` as `T.any(TrueClass, FalseClass)`
+              1140 |        x: T.any(TrueClass, FalseClass),
+                            ^
+            Got String("") originating from:
+              lib/a.rb:64:
+              64 |            foo("")
+                                  ^^
+          Errors: 3
+        ERR
+        assert_equal(3, errors.size)
+        assert_equal(["lib/a.rb", "lib/a.rb", "lib/a.rb"], errors.map(&:file))
+        assert_equal([54, 55, 64], errors.map(&:line))
+        assert_equal([7003, 7001, 7002], errors.map(&:code))
+      end
+
+      def test_sort_errors
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          z.rb:80: unexpected token "end" https://srb.help/2001
+              80 |end
+                  ^^^
+
+          b.rb:100: Method Foo#initialize redefined without matching argument count. Expected: 0, got: 2 https://srb.help/4010
+               100 |    class Foo < T::Struct
+               101 |    end
+              foo.rb:96: Previous definition
+                96 |    class Foo < T::Struct
+                97 |    end
+
+          b.rb:28: Not enough arguments provided for method Foo#bar. Expected: 1..2, got: 1 https://srb.help/7004
+              28 |              bar "hello"
+                                ^^^^^^^^^^^
+              test.rb:11: Foo#bar defined here
+              11 |          def bar(title = "Error", name)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+          a.rb:105: Method foo does not exist on String https://srb.help/7003
+               105 |        printer.print "foo".light_black
+                                          ^^^^^^^^^^^^^^^^^
+        ERR
+        assert_equal(4, errors.size)
+        assert_equal([7003, 7004, 4010, 2001], errors.sort.map(&:code))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull-request introduces `Spoom::Sorbet::Errors::parser` that can be used to parse errors from Sorbet output:

```ruby
errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
    lib/test/file.rb:80: unexpected token "end" https://srb.help/2001
    80 |end
           ^^^
ERR
assert_equal(1, errors.size)

error = errors.first
assert_equal("lib/test/file.rb", error.file)
assert_equal(80, error.line)
assert_equal("unexpected token \"end\"", error.message)
assert_equal(2001, error.code)
assert_equal(["80 |end", "^^^"], error.more.each(&:strip!))
```

This can also be used in command line to filter the errors produced by Sorbet.

For example to show only the first 5 `7004` errors
```bash
spoom tc --code 7004 -limit 5
```

To sort  errors by their code instead of location:
```bash
spoom tc --sort code
```

See the tests for  more examples.