### PR TITLE
Add `spoom tc metrics`

### DIFF
--- a/lib/spoom/cli/commands/run.rb
+++ b/lib/spoom/cli/commands/run.rb
@@ -53,6 +53,18 @@ module Spoom
           1
         end
 
+        desc "metrics", "run srb tc and display metrics"
+        def metrics
+          in_sorbet_project!
+
+          metrics = Spoom::Sorbet.srb_metrics(capture_err: false)
+          if metrics
+            metrics.show
+          else
+            puts "no data"
+          end
+        end
+
         no_commands do
           def colorize_code(code, colors = true)
             return code.to_s unless colors

--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -4,6 +4,7 @@
 require "spoom/sorbet/config"
 require "spoom/sorbet/errors"
 require "spoom/sorbet/lsp"
+require "spoom/sorbet/metrics"
 
 require "open3"
 
@@ -51,6 +52,19 @@ module Spoom
       out, res = srb(*T.unsafe(["--version", *arg]), path: path, capture_err: capture_err)
       return nil unless res
       out.split(" ")[2]
+    end
+
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns(T.nilable(Metrics)) }
+    def self.srb_metrics(*arg, path: '.', capture_err: false)
+      metrics_file = "metrics.tmp"
+      metrics_path = "#{path}/#{metrics_file}"
+      srb_tc(*T.unsafe(["--metrics-file=#{metrics_file}", *arg]), path: path, capture_err: capture_err)
+      if File.exist?(metrics_path)
+        metrics = Spoom::Sorbet::Metrics.parse_file(metrics_path)
+        File.delete(metrics_path)
+        return metrics
+      end
+      nil
     end
   end
 end

--- a/lib/spoom/sorbet/metrics.rb
+++ b/lib/spoom/sorbet/metrics.rb
@@ -1,0 +1,102 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Sorbet
+    class Metrics < T::Struct
+      extend T::Sig
+
+      DEFAULT_PREFIX = "ruby_typer.unknown.."
+      SIGILS = T.let(["ignore", "false", "true", "strict", "strong", "__STDLIB_INTERNAL"], T::Array[String])
+
+      const :repo, String
+      const :sha, String
+      const :status, String
+      const :branch, String
+      const :timestamp, Integer
+      const :uuid, String
+      const :metrics, T::Hash[String, T.nilable(Integer)]
+
+      sig { params(path: String, prefix: String).returns(Metrics) }
+      def self.parse_file(path, prefix = DEFAULT_PREFIX)
+        parse_string(File.read(path), prefix)
+      end
+
+      sig { params(string: String, prefix: String).returns(Metrics) }
+      def self.parse_string(string, prefix = DEFAULT_PREFIX)
+        parse_hash(JSON.parse(string), prefix)
+      end
+
+      sig { params(obj: T::Hash[String, T.untyped], prefix: String).returns(Metrics) }
+      def self.parse_hash(obj, prefix = DEFAULT_PREFIX)
+        Metrics.new(
+          repo: obj.fetch("repo"),
+          sha: obj.fetch("sha"),
+          status: obj.fetch("status"),
+          branch: obj.fetch("branch"),
+          timestamp: obj.fetch("timestamp").to_i,
+          uuid: obj.fetch("uuid"),
+          metrics: obj["metrics"].each_with_object({}) do |metric, all|
+            name = metric["name"]
+            name = name.sub(prefix, '')
+            all[name] = metric["value"].to_i
+          end,
+        )
+      end
+
+      sig { returns(T::Hash[String, T.nilable(Integer)]) }
+      def files_by_strictness
+        SIGILS.each_with_object({}) do |sigil, map|
+          map[sigil] = metrics["types.input.files.sigil.#{sigil}"]
+        end
+      end
+
+      sig { returns(Integer) }
+      def files_count
+        files_by_strictness.values.compact.sum
+      end
+
+      sig { params(key: String).returns(T.nilable(Integer)) }
+      def [](key)
+        metrics[key]
+      end
+
+      sig { returns(String) }
+      def to_s
+        "Metrics<#{repo}-#{timestamp}-#{status}>"
+      end
+
+      sig { params(out: T.any(IO, StringIO)).void }
+      def show(out = $stdout)
+        files = files_count
+
+        out.puts "Sigils:"
+        out.puts "  files: #{files}"
+        files_by_strictness.each do |sigil, value|
+          next unless value
+          out.puts "  #{sigil}: #{value}#{percent(value, files)}"
+        end
+
+        out.puts "\nMethods:"
+        m = metrics['types.input.methods.total']
+        s = metrics['types.sig.count']
+        out.puts "  methods: #{m}"
+        out.puts "  signatures: #{s}#{percent(s, m)}"
+
+        out.puts "\nSends:"
+        t = metrics['types.input.sends.typed']
+        s = metrics['types.input.sends.total']
+        out.puts "  sends: #{s}"
+        out.puts "  typed: #{t}#{percent(t, s)}"
+      end
+
+      private
+
+      sig { params(value: T.nilable(Integer), total: T.nilable(Integer)).returns(String) }
+      def percent(value, total)
+        return "" if value.nil? || total.nil? || total == 0
+        " (#{value * 100 / total}%)"
+      end
+    end
+  end
+end

--- a/test/spoom/cli/commands/run_test.rb
+++ b/test/spoom/cli/commands/run_test.rb
@@ -117,6 +117,25 @@ module Spoom
             Errors: 1 shown, 7 total
           MSG
         end
+
+        # Metrics
+
+        def test_display_metrics
+          out, _ = run_cli(PROJECT, "tc metrics")
+          assert_equal(<<~MSG, out)
+            Sigils:
+              files: 6
+              true: 6 (100%)
+
+            Methods:
+              methods: 22
+              signatures: 2 (9%)
+
+            Sends:
+              sends: 51
+              typed: 47 (92%)
+          MSG
+        end
       end
     end
   end

--- a/test/spoom/sorbet/metrics_test.rb
+++ b/test/spoom/sorbet/metrics_test.rb
@@ -1,0 +1,184 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Spoom
+  module Sorbet
+    class MetricsTest < Minitest::Test
+      def test_parses_metrics_error
+        assert_raises JSON::ParserError do
+          Spoom::Sorbet::Metrics.parse_string("")
+        end
+      end
+
+      def test_parses_metrics
+        metrics = Spoom::Sorbet::Metrics.parse_string(<<~ERR)
+          {
+           "repo": "MyRepo",
+           "sha": "1234",
+           "status": "Success",
+           "branch": "master",
+           "timestamp": "1594762766",
+           "uuid": "some-uuid",
+           "metrics": [
+            {
+             "name": "ruby_typer.unknown..error.total",
+             "value": 1
+            },
+            {
+             "name": "ruby_typer.unknown..types.input.sends.total",
+             "value": 2094
+            }
+           ]
+          }
+        ERR
+        assert_equal("MyRepo", metrics.repo)
+        assert_equal("1234", metrics.sha)
+        assert_equal("master", metrics.branch)
+        assert_equal("Success", metrics.status)
+        assert_equal(1, metrics["error.total"])
+        assert_equal(2094, metrics["types.input.sends.total"])
+      end
+
+      def test_parses_metrics_and_removes_prefix
+        metrics = Spoom::Sorbet::Metrics.parse_string(<<~ERR, "metrics.")
+          {
+           "repo": "MyRepo",
+           "sha": "1234",
+           "status": "Success",
+           "branch": "master",
+           "timestamp": "1594762766",
+           "uuid": "some-uuid",
+           "metrics": [
+            {
+             "name": "metrics.error.total",
+             "value": 1
+            },
+            {
+             "name": "metrics.types.input.sends.total",
+             "value": 2094
+            }
+           ]
+          }
+        ERR
+        assert_equal("MyRepo", metrics.repo)
+        assert_equal("1234", metrics.sha)
+        assert_equal("master", metrics.branch)
+        assert_equal("Success", metrics.status)
+        assert_equal(1, metrics["error.total"])
+        assert_equal(2094, metrics["types.input.sends.total"])
+      end
+
+      def test_show_metrics
+        metrics = Spoom::Sorbet::Metrics.parse_string(<<~ERR, "metrics.")
+          {
+           "repo": "MyRepo",
+           "sha": "1234",
+           "status": "Success",
+           "branch": "master",
+           "timestamp": "1594762766",
+           "uuid": "some-uuid",
+           "metrics": [
+            {
+             "name": "metrics.types.input.files.sigil.true",
+             "value": 2
+            },
+            {
+             "name": "metrics.types.input.files.sigil.false",
+             "value": 3
+            },
+            {
+             "name": "metrics.types.input.methods.total",
+             "value": 10
+            },
+            {
+             "name": "metrics.types.sig.count",
+             "value": 1
+            },
+            {
+             "name": "metrics.types.input.sends.total",
+             "value": 100
+            },
+            {
+             "name": "metrics.types.input.sends.typed",
+             "value": 10
+            }
+           ]
+          }
+        ERR
+        out = StringIO.new
+        metrics.show(out)
+        assert_equal(<<~OUT, out.string)
+          Sigils:
+            files: 5
+            false: 3 (60%)
+            true: 2 (40%)
+
+          Methods:
+            methods: 10
+            signatures: 1 (10%)
+
+          Sends:
+            sends: 100
+            typed: 10 (10%)
+        OUT
+      end
+
+      def test_show_metrics_with_0s
+        metrics = Spoom::Sorbet::Metrics.parse_string(<<~ERR, "metrics.")
+          {
+           "repo": "MyRepo",
+           "sha": "1234",
+           "status": "Success",
+           "branch": "master",
+           "timestamp": "1594762766",
+           "uuid": "some-uuid",
+           "metrics": [
+            {
+             "name": "metrics.types.input.files.sigil.true",
+             "value": 0
+            },
+            {
+             "name": "metrics.types.input.files.sigil.false",
+             "value": 0
+            },
+            {
+             "name": "metrics.types.input.methods.total",
+             "value": 0
+            },
+            {
+             "name": "metrics.types.sig.count",
+             "value": 0
+            },
+            {
+             "name": "metrics.types.input.sends.total",
+             "value": 0
+            },
+            {
+             "name": "metrics.types.input.sends.typed",
+             "value": 0
+            }
+           ]
+          }
+        ERR
+        out = StringIO.new
+        metrics.show(out)
+        assert_equal(<<~OUT, out.string)
+          Sigils:
+            files: 0
+            false: 0
+            true: 0
+
+          Methods:
+            methods: 0
+            signatures: 0
+
+          Sends:
+            sends: 0
+            typed: 0
+        OUT
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the command `spoom tc metrics` and the associated parsing methods.

This commands displays the metrics collected by Sorbet during typechecking (when the option `--metrics-file` is passed):

```
$ spoom tc metrics

Sigils:
  files: 6
  true: 6 (100%)
Methods:
  methods: 22
  signatures: 2 (9%)
Sends:
  sends: 51
  typed: 47 (92%)
```

As an example, the underlying methods are already used by the new version of SorbetMetrics: https://github.com/Shopify/sorbet-metrics/blob/master/lib/sorbet_metrics/actions/collect_sorbet_metrics.rb#L21