### PR TITLE
Add `srb_version` service

### DIFF
--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -45,5 +45,12 @@ module Spoom
         regs.any? { |re| re.match?(f) }
       end.sort
     end
+
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns(T.nilable(String)) }
+    def self.srb_version(*arg, path: '.', capture_err: false)
+      out, res = srb(*T.unsafe(["--version", *arg]), path: path, capture_err: capture_err)
+      return nil unless res
+      out.split(" ")[2]
+    end
   end
 end

--- a/test/spoom/sorbet/version_test.rb
+++ b/test/spoom/sorbet/version_test.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+require "pathname"
+
+require_relative "../cli/cli_test_helper"
+
+module Spoom
+  module Sorbet
+    class VersionTest < Minitest::Test
+      include Spoom::Cli::TestHelper
+      extend Spoom::Cli::TestHelper
+
+      def project_path
+        "#{Cli::TestHelper::TEST_PROJECTS_PATH}/project"
+      end
+
+      def test_return_nil_if_srb_not_installed
+        Bundler.with_clean_env do
+          version = Spoom::Sorbet.srb_version(
+            path: "#{Cli::TestHelper::TEST_PROJECTS_PATH}/project_without_sorbet",
+            capture_err: true,
+          )
+          assert_nil(version)
+        end
+      end
+
+      def test_return_version_string
+        Bundler.with_clean_env do
+          version = Spoom::Sorbet.srb_version(path: "#{Cli::TestHelper::TEST_PROJECTS_PATH}/project")
+          assert_equal("0.5.5808", version)
+        end
+      end
+    end
+  end
+end

--- a/test/support/project_without_sorbet/Gemfile
+++ b/test/support/project_without_sorbet/Gemfile
@@ -1,0 +1,4 @@
+# typed: true
+# frozen_string_literal: true
+
+source("https://rubygems.org")

--- a/test/support/project_without_sorbet/Gemfile.lock
+++ b/test/support/project_without_sorbet/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
Add a service to easily get the version from Sorbet:

```ruby
puts Spoom::Sorbet.srb_version("my_project") # "0.5.5808"
```

It returns `nil` if `srb` is not installed:

```ruby
puts Spoom::Sorbet.srb_version("my_project_without_srb") # nil
```