### PR TITLE
Adds byebug and pry-byebug to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,6 @@ gemspec
 group(:development) do
   gem('rubocop-shopify', require: false)
   gem('rubocop-sorbet', require: false)
+  gem('byebug')
+  gem('pry-byebug')
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,11 +11,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
+    byebug (11.1.3)
+    coderay (1.1.3)
     colorize (0.8.1)
+    method_source (1.0.0)
     minitest (5.14.1)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rainbow (3.0.0)
     rake (10.5.0)
     regexp_parser (1.7.1)
@@ -48,7 +57,9 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
+  byebug
   minitest (~> 5.0)
+  pry-byebug
   rake (~> 10.0)
   rubocop-shopify
   rubocop-sorbet


### PR DESCRIPTION
This change allows debugging with `pry`. Pause execution and inspect by adding `require 'pry'; binding.pry`.