### PR TITLE
Spoom displays the count of classes and modules found in the project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,10 +45,10 @@ GEM
     rubocop-sorbet (0.4.0)
       rubocop
     ruby-progressbar (1.10.1)
-    sorbet (0.5.5803)
-      sorbet-static (= 0.5.5803)
-    sorbet-runtime (0.5.5803)
-    sorbet-static (0.5.5803-universal-darwin-14)
+    sorbet (0.5.5916)
+      sorbet-static (= 0.5.5916)
+    sorbet-runtime (0.5.5916)
+    sorbet-static (0.5.5916-universal-darwin-14)
     thor (1.0.1)
     unicode-display_width (1.7.0)
 

--- a/lib/spoom/sorbet/metrics.rb
+++ b/lib/spoom/sorbet/metrics.rb
@@ -80,7 +80,7 @@ module Spoom
         out.puts "\nClasses & Modules:"
         cc = self['types.input.classes.total']
         cm = self['types.input.modules.total']
-        out.puts "  classes: #{cc}"
+        out.puts "  classes: #{cc} (including singleton classes)"
         out.puts "  modules: #{cm}"
 
         out.puts "\nMethods:"

--- a/lib/spoom/sorbet/metrics.rb
+++ b/lib/spoom/sorbet/metrics.rb
@@ -58,7 +58,7 @@ module Spoom
 
       sig { params(key: String).returns(T.nilable(Integer)) }
       def [](key)
-        metrics[key]
+        metrics[key] || 0
       end
 
       sig { returns(String) }
@@ -77,15 +77,21 @@ module Spoom
           out.puts "  #{sigil}: #{value}#{percent(value, files)}"
         end
 
+        out.puts "\nClasses & Modules:"
+        cc = self['types.input.classes.total']
+        cm = self['types.input.modules.total']
+        out.puts "  classes: #{cc}"
+        out.puts "  modules: #{cm}"
+
         out.puts "\nMethods:"
-        m = metrics['types.input.methods.total']
-        s = metrics['types.sig.count']
+        m = self['types.input.methods.total']
+        s = self['types.sig.count']
         out.puts "  methods: #{m}"
         out.puts "  signatures: #{s}#{percent(s, m)}"
 
         out.puts "\nSends:"
-        t = metrics['types.input.sends.typed']
-        s = metrics['types.input.sends.total']
+        t = self['types.input.sends.typed']
+        s = self['types.input.sends.total']
         out.puts "  sends: #{s}"
         out.puts "  typed: #{t}#{percent(t, s)}"
       end

--- a/sorbet/rbi/gems/colorize@0.8.1.rbi
+++ b/sorbet/rbi/gems/colorize@0.8.1.rbi
@@ -8,11 +8,11 @@ end
 
 module Colorize::ClassMethods
   def color_codes; end
-  def color_matrix(_ = _); end
+  def color_matrix(_ = T.unsafe(nil)); end
   def color_methods; end
   def color_samples; end
   def colors; end
-  def disable_colorization(value = _); end
+  def disable_colorization(value = T.unsafe(nil)); end
   def disable_colorization=(value); end
   def mode_codes; end
   def modes; end

--- a/sorbet/rbi/gems/thor@1.0.1.rbi
+++ b/sorbet/rbi/gems/thor@1.0.1.rbi
@@ -28,7 +28,7 @@ class Thor
   def self.method_options(options = _); end
   def self.option(name, options = _); end
   def self.options(options = _); end
-  def self.package_name(name, _ = _); end
+  def self.package_name(name, _ = T.unsafe(nil)); end
   def self.printable_commands(all = _, subcommand = _); end
   def self.printable_tasks(all = _, subcommand = _); end
   def self.register(klass, subcommand_name, usage, description, options = _); end

--- a/test/spoom/cli/commands/run_test.rb
+++ b/test/spoom/cli/commands/run_test.rb
@@ -127,6 +127,10 @@ module Spoom
               files: 6
               true: 6 (100%)
 
+            Classes & Modules:
+              classes: 16
+              modules: 2
+
             Methods:
               methods: 22
               signatures: 2 (9%)

--- a/test/spoom/cli/commands/run_test.rb
+++ b/test/spoom/cli/commands/run_test.rb
@@ -128,7 +128,7 @@ module Spoom
               true: 6 (100%)
 
             Classes & Modules:
-              classes: 16
+              classes: 16 (including singleton classes)
               modules: 2
 
             Methods:

--- a/test/spoom/sorbet/metrics_test.rb
+++ b/test/spoom/sorbet/metrics_test.rb
@@ -124,7 +124,7 @@ module Spoom
             true: 2 (40%)
 
           Classes & Modules:
-            classes: 20
+            classes: 20 (including singleton classes)
             modules: 15
 
           Methods:
@@ -183,7 +183,7 @@ module Spoom
             true: 0
 
           Classes & Modules:
-            classes: 0
+            classes: 0 (including singleton classes)
             modules: 0
 
           Methods:

--- a/test/spoom/sorbet/metrics_test.rb
+++ b/test/spoom/sorbet/metrics_test.rb
@@ -93,6 +93,14 @@ module Spoom
              "value": 10
             },
             {
+             "name": "metrics.types.input.classes.total",
+             "value": 20
+            },
+            {
+             "name": "metrics.types.input.modules.total",
+             "value": 15
+            },
+            {
              "name": "metrics.types.sig.count",
              "value": 1
             },
@@ -114,6 +122,10 @@ module Spoom
             files: 5
             false: 3 (60%)
             true: 2 (40%)
+
+          Classes & Modules:
+            classes: 20
+            modules: 15
 
           Methods:
             methods: 10
@@ -169,6 +181,10 @@ module Spoom
             files: 0
             false: 0
             true: 0
+
+          Classes & Modules:
+            classes: 0
+            modules: 0
 
           Methods:
             methods: 0

--- a/test/spoom/sorbet/version_test.rb
+++ b/test/spoom/sorbet/version_test.rb
@@ -28,7 +28,7 @@ module Spoom
       def test_return_version_string
         Bundler.with_clean_env do
           version = Spoom::Sorbet.srb_version(path: "#{Cli::TestHelper::TEST_PROJECTS_PATH}/project")
-          assert_equal("0.5.5808", version)
+          assert_match(/\d\.\d\.\d{4}/, version)
         end
       end
     end

--- a/test/support/project/Gemfile.lock
+++ b/test/support/project/Gemfile.lock
@@ -11,10 +11,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     colorize (0.8.1)
-    sorbet (0.5.5808)
-      sorbet-static (= 0.5.5808)
+    sorbet (0.5.5916)
+      sorbet-static (= 0.5.5916)
     sorbet-runtime (0.5.5808)
-    sorbet-static (0.5.5808-universal-darwin-14)
+    sorbet-static (0.5.5916-universal-darwin-14)
     thor (1.0.1)
 
 PLATFORMS


### PR DESCRIPTION
Running Spoom now displays the count of classes and modules in the project:

```
$ bundle exec spoom tc metrics
No errors! Great job.
Sigils:
  files: 52
  ignore: 1 (1%)
  true: 46 (88%)
  strict: 5 (9%)

Classes & Modules:
  classes: 276 (including singleton classes)
  modules: 46

Methods:
  methods: 1660
  signatures: 85 (5%)

Sends:
  sends: 2763
  typed: 2183 (79%)
```

Note that the classes count also include singleton classes.