### PR TITLE
Initialize metrics object with `0`s

### DIFF
--- a/lib/spoom/sorbet/metrics.rb
+++ b/lib/spoom/sorbet/metrics.rb
@@ -36,7 +36,7 @@ module Spoom
           branch: obj.fetch("branch"),
           timestamp: obj.fetch("timestamp").to_i,
           uuid: obj.fetch("uuid"),
-          metrics: obj["metrics"].each_with_object({}) do |metric, all|
+          metrics: obj["metrics"].each_with_object(Hash.new(0)) do |metric, all|
             name = metric["name"]
             name = name.sub(prefix, '')
             all[name] = metric["value"].to_i
@@ -58,7 +58,7 @@ module Spoom
 
       sig { params(key: String).returns(T.nilable(Integer)) }
       def [](key)
-        metrics[key] || 0
+        metrics[key]
       end
 
       sig { returns(String) }
@@ -73,7 +73,7 @@ module Spoom
         out.puts "Sigils:"
         out.puts "  files: #{files}"
         files_by_strictness.each do |sigil, value|
-          next unless value
+          next unless value && value > 0
           out.puts "  #{sigil}: #{value}#{percent(value, files)}"
         end
 

--- a/test/spoom/sorbet/metrics_test.rb
+++ b/test/spoom/sorbet/metrics_test.rb
@@ -179,8 +179,6 @@ module Spoom
         assert_equal(<<~OUT, out.string)
           Sigils:
             files: 0
-            false: 0
-            true: 0
 
           Classes & Modules:
             classes: 0 (including singleton classes)


### PR DESCRIPTION
Applying the nice trick showed by @paracycle here: https://github.com/Shopify/spoom/pull/11#discussion_r493772669

Signed-off-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>