### PR TITLE
Clean some unused metrics fields

### DIFF
--- a/test/spoom/sorbet/metrics_test.rb
+++ b/test/spoom/sorbet/metrics_test.rb
@@ -33,10 +33,6 @@ module Spoom
            ]
           }
         ERR
-        assert_equal("MyRepo", metrics.repo)
-        assert_equal("1234", metrics.sha)
-        assert_equal("master", metrics.branch)
-        assert_equal("Success", metrics.status)
         assert_equal(1, metrics["error.total"])
         assert_equal(2094, metrics["types.input.sends.total"])
       end
@@ -62,10 +58,6 @@ module Spoom
            ]
           }
         ERR
-        assert_equal("MyRepo", metrics.repo)
-        assert_equal("1234", metrics.sha)
-        assert_equal("master", metrics.branch)
-        assert_equal("Success", metrics.status)
         assert_equal(1, metrics["error.total"])
         assert_equal(2094, metrics["types.input.sends.total"])
       end


### PR DESCRIPTION
Those metrics are only initialized if you pass specific options to Sorbet:

```
      --metrics-branch branch   Branch to report in metrics export (default:
                                none)
      --metrics-sha sha1        Sha1 to report in metrics export (default:
                                none)
      --metrics-repo repo       Repo to report in metrics export (default:
                                none)
      --metrics-extra-tags key1=value1,key2=value2
                                Extra tags to report, comma separated
                                (default: "")
```

We actually don't care about them so let's remove the fields.