### PR TITLE
Introduce FileTree and command `spoom files`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,8 @@ Sorbet/ValidSigil:
 
 Sorbet/TrueSigil:
   Enabled: true
+  Exclude:
+    - test/support/project/task1.rake
 
 Sorbet/EnforceSigilOrder:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ Show Sorbet config options:
 $ spoom config
 ```
 
-List the files that will be typchecked with the current Sorbet config options:
+#### Listing files
+
+List the files (and related strictness) that will be typchecked with the current Sorbet config options:
 
 ```
-$ spoom config files
+$ spoom files
 ```
 
 #### Errors sorting and filtering

--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -12,6 +12,7 @@ module Spoom
   module Cli
     class Main < Thor
       extend T::Sig
+      include Spoom::Cli::CommandHelper
 
       class_option :no_color, desc: "Don't use colors", type: :boolean
       map T.unsafe(%w[--version -v] => :__print_version)
@@ -27,6 +28,21 @@ module Spoom
 
       desc "tc", "run Sorbet and parses its output"
       subcommand "tc", Spoom::Cli::Commands::Run
+
+      desc "files", "list all the files typechecked by Sorbet"
+      def files
+        in_sorbet_project!
+        config = Spoom::Sorbet::Config.parse_file(Spoom::Config::SORBET_CONFIG)
+        files = Spoom::Sorbet.srb_files(config)
+
+        say("Files matching `#{Spoom::Config::SORBET_CONFIG}`:")
+        if files.empty?
+          say(" NONE")
+        else
+          tree = FileTree.new(files)
+          tree.print(colors: !options[:no_color], indent: 2)
+        end
+      end
 
       desc "--version", "show version"
       def __print_version

--- a/lib/spoom/cli/commands/config.rb
+++ b/lib/spoom/cli/commands/config.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require_relative "../../file_tree"
 require_relative "../../sorbet/config"
 require_relative '../command_helper'
 
@@ -44,22 +45,6 @@ module Spoom
           else
             config.allowed_extensions.each do |ext|
               say(" * #{ext}")
-            end
-          end
-        end
-
-        desc "files", "show files matching Sorbet config"
-        def files
-          in_sorbet_project!
-          config = Spoom::Sorbet::Config.parse_file(Spoom::Config::SORBET_CONFIG)
-          files = Spoom::Sorbet.srb_files(config)
-
-          say("Files matching `#{Spoom::Config::SORBET_CONFIG}`:")
-          if files.empty?
-            say(" NONE")
-          else
-            files.each do |path|
-              say(" * #{path}")
             end
           end
         end

--- a/lib/spoom/file_tree.rb
+++ b/lib/spoom/file_tree.rb
@@ -1,0 +1,164 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  # Build a file hierarchy from a set of file paths.
+  class FileTree
+    extend T::Sig
+
+    sig { params(paths: T::Enumerable[String]).void }
+    def initialize(paths = [])
+      @roots = T.let({}, T::Hash[String, Node])
+      add_paths(paths)
+    end
+
+    # Add all `paths` to the tree
+    sig { params(paths: T::Enumerable[String]).void }
+    def add_paths(paths)
+      paths.each { |path| add_path(path) }
+    end
+
+    # Add a `path` to the tree
+    #
+    # This will create all nodes until the root of `path`.
+    sig { params(path: String).returns(Node) }
+    def add_path(path)
+      # TODO: return if path =~ /\/test\//
+      parts = path.split("/")
+      if parts.size == 1
+        return @roots[path] ||= Node.new(parent: nil, name: path)
+      end
+      parent_path = T.must(parts[0...-1]).join("/")
+      parent = add_path(parent_path)
+      name = T.must(parts.last)
+      parent.children[name] ||= Node.new(parent: parent, name: name)
+    end
+
+    # All root nodes
+    sig { returns(T::Array[Node]) }
+    def roots
+      @roots.values
+    end
+
+    # All the nodes in this tree
+    sig { returns(T::Array[Node]) }
+    def nodes
+      all_nodes = []
+      @roots.values.each { |root| collect_nodes(root, all_nodes) }
+      all_nodes
+    end
+
+    # All the paths in this tree
+    sig { returns(T::Array[String]) }
+    def paths
+      nodes.collect(&:path)
+    end
+
+    sig { params(out: T.any(IO, StringIO), show_strictness: T::Boolean, colors: T::Boolean, indent: Integer).void }
+    def print(out: $stdout, show_strictness: true, colors: true, indent: 0)
+      printer = Printer.new(out: out, show_strictness: show_strictness, colors: colors, indent: indent)
+      printer.print_tree(self)
+    end
+
+    private
+
+    sig { params(node: FileTree::Node, collected_nodes: T::Array[Node]).returns(T::Array[String]) }
+    def collect_nodes(node, collected_nodes = [])
+      collected_nodes << node
+      node.children.values.each { |child| collect_nodes(child, collected_nodes) }
+      collected_nodes
+    end
+
+    # A node representing either a file or a directory inside a FileTree
+    class Node < T::Struct
+      extend T::Sig
+
+      # Node parent or `nil` if the node is a root one
+      const :parent, T.nilable(Node)
+
+      # File or dir name
+      const :name, String
+
+      # Children of this node (if not empty, it means it's a dir)
+      const :children, T::Hash[String, Node], default: {}
+
+      # Full path to this node from root
+      sig { returns(String) }
+      def path
+        parent = self.parent
+        return name unless parent
+        "#{parent.path}/#{name}"
+      end
+
+      # Strictness of this file (or `nil` if no strictness or the node is a directory)
+      sig { returns(T.nilable(String)) }
+      def strictness
+        Spoom::Sorbet::Sigils.file_strictness(path)
+      end
+    end
+
+    # An internal class used to print a FileTree
+    #
+    # See `FileTree#print`
+    class Printer
+      extend T::Sig
+
+      sig { params(out: T.any(IO, StringIO), show_strictness: T::Boolean, colors: T::Boolean, indent: Integer).void }
+      def initialize(out: $stdout, show_strictness: true, colors: true, indent: 0)
+        @out = out
+        @show_strictness = show_strictness
+        @colors = colors
+        @indent = indent
+      end
+
+      sig { params(tree: FileTree).void }
+      def print_tree(tree)
+        print_nodes(tree.roots)
+      end
+
+      sig { params(node: FileTree::Node).void }
+      def print_node(node)
+        @out.print(" " * @indent)
+        if node.children.empty?
+          if @show_strictness
+            strictness = node.strictness
+            if @colors
+              @out.print(node.name.colorize(strictness_color(strictness)))
+            elsif strictness
+              @out.print("#{node.name} (#{strictness})")
+            else
+              @out.print(node.name.to_s)
+            end
+          else
+            @out.print(node.name.to_s)
+          end
+          @out.print("\n")
+        else
+          @out.print("#{@colors ? node.name.colorize(:blue) : node.name}/\n")
+          @indent += 2
+          print_nodes(node.children.values)
+          @indent -= 2
+        end
+      end
+
+      sig { params(nodes: T::Array[FileTree::Node]).void }
+      def print_nodes(nodes)
+        nodes.each { |node| print_node(node) }
+      end
+
+      private
+
+      sig { params(strictness: T.nilable(String)).returns(Symbol) }
+      def strictness_color(strictness)
+        case strictness
+        when "false"
+          :red
+        when "true", "strict", "strong"
+          :green
+        else
+          :uncolored
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/cli/commands/cli_test.rb
+++ b/test/spoom/cli/commands/cli_test.rb
@@ -10,6 +10,8 @@ module Spoom
         include Spoom::Cli::TestHelper
         extend Spoom::Cli::TestHelper
 
+        PROJECT = "project"
+
         def test_display_current_version_short_option
           out, _ = run_cli("", "-v")
           assert_equal("Spoom v#{Spoom::VERSION}", out&.strip)
@@ -18,6 +20,53 @@ module Spoom
         def test_display_current_version_long_option
           out, _ = run_cli("", "--version")
           assert_equal("Spoom v#{Spoom::VERSION}", out&.strip)
+        end
+
+        def test_display_files_from_config
+          use_sorbet_config(PROJECT, ".")
+          out, _ = run_cli(PROJECT, "files --no-color")
+          assert_equal(<<~MSG, out)
+            Files matching `sorbet/config`:
+              errors/
+                errors.rb (true)
+              lib/
+                defs.rb (true)
+                hover.rb (true)
+                refs.rb (true)
+                sigs.rb (true)
+                symbols.rb (true)
+                types.rb (true)
+          MSG
+        end
+
+        def test_display_files_from_config_with_ignored_files
+          use_sorbet_config(PROJECT, <<~CFG)
+            .
+            --ignore=efs
+            --ignore=errors
+          CFG
+          out, _ = run_cli(PROJECT, "files --no-color")
+          assert_equal(<<~MSG, out)
+            Files matching `sorbet/config`:
+              lib/
+                hover.rb (true)
+                sigs.rb (true)
+                symbols.rb (true)
+                types.rb (true)
+          MSG
+        end
+
+        def test_display_files_from_config_with_allowed_exts
+          use_sorbet_config(PROJECT, <<~CFG)
+            .
+            --allowed-extension=.rake
+          CFG
+          out, _ = run_cli(PROJECT, "files --no-color")
+          assert_equal(<<~MSG, out)
+            Files matching `sorbet/config`:
+              task1.rake (false)
+              task2.rake (strong)
+          MSG
         end
       end
     end

--- a/test/spoom/cli/commands/config_test.rb
+++ b/test/spoom/cli/commands/config_test.rb
@@ -144,50 +144,6 @@ module Spoom
              * .ru
           MSG
         end
-
-        def test_display_files_from_config
-          use_sorbet_config(PROJECT, ".")
-          out, _ = run_cli(PROJECT, "config files")
-          assert_equal(<<~MSG, out)
-            Files matching `sorbet/config`:
-             * errors/errors.rb
-             * lib/defs.rb
-             * lib/hover.rb
-             * lib/refs.rb
-             * lib/sigs.rb
-             * lib/symbols.rb
-             * lib/types.rb
-          MSG
-        end
-
-        def test_display_files_from_config_with_ignored_files
-          use_sorbet_config(PROJECT, <<~CFG)
-            .
-            --ignore=efs
-            --ignore=errors
-          CFG
-          out, _ = run_cli(PROJECT, "config files")
-          assert_equal(<<~MSG, out)
-            Files matching `sorbet/config`:
-             * lib/hover.rb
-             * lib/sigs.rb
-             * lib/symbols.rb
-             * lib/types.rb
-          MSG
-        end
-
-        def test_display_files_from_config_with_allowed_exts
-          use_sorbet_config(PROJECT, <<~CFG)
-            .
-            --allowed-extension=.rake
-          CFG
-          out, _ = run_cli(PROJECT, "config files")
-          assert_equal(<<~MSG, out)
-            Files matching `sorbet/config`:
-             * task1.rake
-             * task2.rake
-          MSG
-        end
       end
     end
   end

--- a/test/spoom/file_tree_test.rb
+++ b/test/spoom/file_tree_test.rb
@@ -1,0 +1,68 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../lib/spoom/file_tree.rb"
+
+require "stringio"
+
+module Spoom
+  module Sorbet
+    class FileTreeTest < Minitest::Test
+      def test_empty_file_tree_contains_no_path
+        tree = Spoom::FileTree.new
+        assert(tree.paths.empty?)
+      end
+
+      def test_file_tree_one_root
+        tree = Spoom::FileTree.new(["a.rb"])
+        paths = ["a.rb"]
+        assert_equal(paths, tree.paths)
+      end
+
+      def test_file_tree_multiple_roots
+        tree = Spoom::FileTree.new(["a.rb", "b.rb", "c"])
+        paths = ["a.rb", "b.rb", "c"]
+        assert_equal(paths, tree.paths)
+      end
+
+      def test_file_tree_from_a_path
+        tree = Spoom::FileTree.new(["a/b.rb"])
+        paths = ["a", "a/b.rb"]
+        assert_equal(paths, tree.paths)
+      end
+
+      def test_file_tree_from_a_long_path
+        tree = Spoom::FileTree.new(["a/b/c/d/e.rb"])
+        paths = ["a", "a/b", "a/b/c", "a/b/c/d", "a/b/c/d/e.rb"]
+        assert_equal(paths, tree.paths)
+      end
+
+      def test_file_tree_printer
+        tree = Spoom::FileTree.new([
+          "a/b/c/d/e1.rb",
+          "a/b/c/d/e2.rb",
+          "a/b.rb",
+          "a/b/c.rb",
+          "b/c/d/e.rb",
+        ])
+        out = StringIO.new
+        tree.print(out: out, show_strictness: false, colors: false)
+        assert_equal(<<~EXP, out.string)
+          a/
+            b/
+              c/
+                d/
+                  e1.rb
+                  e2.rb
+              c.rb
+            b.rb
+          b/
+            c/
+              d/
+                e.rb
+        EXP
+      end
+    end
+  end
+end

--- a/test/support/project/task1.rake
+++ b/test/support/project/task1.rake
@@ -1,0 +1,2 @@
+# typed: false
+# frozen_string_literal: true

--- a/test/support/project/task2.rake
+++ b/test/support/project/task2.rake
@@ -1,0 +1,2 @@
+# typed: strong
+# frozen_string_literal: true


### PR DESCRIPTION
This PR introduces `FileTree` a representation for files hierarchy so we can print them properly in terminal.

Demo `spoom files` (the color depends on the strictness level of the file):
![image](https://user-images.githubusercontent.com/583144/94497233-96ca7300-01c4-11eb-9e2e-5532aabf04ad.png)

Demo `spoom files --no-color`:
![image](https://user-images.githubusercontent.com/583144/94497243-a053db00-01c4-11eb-989d-37609fdfbe50.png)
