### PR TITLE
Add `spoom coverage timeline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ Show metrics about the project contents and the typing coverage:
 $ spoom coverage
 ```
 
+Show typing coverage evolution based on the commits history:
+
+```
+$ spoom coverage timeline
+```
+
+Show typing coverage evolution based on the commits history between specific dates:
+
+```
+$ spoom coverage timeline --from YYYY-MM-DD --to YYYY-MM-DD
+```
+
+Save the typing coverage evolution as JSON in a specific directory:
+
+```
+$ spoom coverage timeline --save-dir data/
+```
+
 #### Change the sigil used in files
 
 Bump the strictness from all files currently at `typed: false` to `typed: true` where it does not create typechecking errors:

--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require_relative '../../snapshot'
+require_relative '../../timeline'
 require_relative '../command_helper'
 
 module Spoom
@@ -18,6 +19,76 @@ module Spoom
 
           snapshot = Spoom::Coverage.snapshot
           snapshot.print
+        end
+
+        desc "timeline", "replay a project and collect metrics"
+        option :from, type: :string
+        option :to, type: :string, default: Time.now.strftime("%F")
+        option :save_dir, type: :string
+        def timeline
+          in_sorbet_project!
+
+          sha_before = Spoom::Git.last_commit
+          unless sha_before
+            say_error("Not in a git repository")
+            $stderr.puts "\nSpoom needs to checkout into your previous commits to build the timeline."
+            exit(1)
+          end
+
+          unless Spoom::Git.workdir_clean?
+            say_error("Uncommited changes")
+            $stderr.puts "\nSpoom needs to checkout into your previous commits to build the timeline."
+            $stderr.puts "\nPlease git commit or git stash your changes then try again."
+            exit(1)
+          end
+
+          save_dir = options[:save_dir]
+          FileUtils.mkdir_p(save_dir) if save_dir
+
+          from = parse_date(options[:from], "--from")
+          to = parse_date(options[:to], "--to")
+
+          unless from
+            intro_sha = Spoom::Git.sorbet_intro_commit
+            intro_sha = T.must(intro_sha) # we know it's in there since in_sorbet_project!
+            from = Spoom::Git.commit_date(intro_sha)
+          end
+
+          timeline = Spoom::Timeline.new(from, to)
+          ticks = timeline.ticks
+
+          if ticks.empty?
+            say_error("No commits to replay, try different --from and --to options")
+            exit(1)
+          end
+
+          ticks.each_with_index do |sha, i|
+            date = Spoom::Git.commit_date(sha)
+            puts "Analyzing commit #{sha} - #{date&.strftime('%F')} (#{i + 1} / #{ticks.size})"
+
+            Spoom::Git.checkout(sha)
+            snapshot = Spoom::Coverage.snapshot
+            snapshot.commit_sha = sha
+            snapshot.commit_timestamp = date&.strftime('%s').to_i
+            snapshot.print(indent_level: 2)
+            puts "\n"
+
+            next unless save_dir
+            file = "#{save_dir}/#{sha}.json"
+            puts "  Snapshot data saved under #{file}\n\n"
+            File.write(file, snapshot.serialize.to_json)
+          end
+          Spoom::Git.checkout(sha_before)
+        end
+
+        no_commands do
+          def parse_date(string, option)
+            return nil unless string
+            Time.parse(string)
+          rescue ArgumentError
+            say_error("Invalid date `#{string}` for option #{option} (expected format YYYY-MM-DD)")
+            exit(1)
+          end
         end
       end
     end

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -1,0 +1,97 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "time"
+
+module Spoom
+  # Execute git commands
+  module Git
+    extend T::Sig
+
+    # Execute a `command`
+    sig { params(command: String, arg: String, path: String).returns([String, String, T::Boolean]) }
+    def self.exec(command, *arg, path: '.')
+      opts = {}
+      opts[:chdir] = path
+      _, o, e, s = Open3.popen3(*T.unsafe([command, *T.unsafe(arg), opts]))
+      out = o.read.to_s
+      o.close
+      err = e.read.to_s
+      e.close
+      [out, err, T.cast(s.value, Process::Status).success?]
+    end
+
+    # Git commands
+
+    sig { params(arg: String, path: String).returns([String, String, T::Boolean]) }
+    def self.checkout(*arg, path: ".")
+      exec("git checkout -q #{arg.join(' ')}", path: path)
+    end
+
+    sig { params(arg: String, path: String).returns([String, String, T::Boolean]) }
+    def self.diff(*arg, path: ".")
+      exec("git diff #{arg.join(' ')}", path: path)
+    end
+
+    sig { params(arg: String, path: String).returns([String, String, T::Boolean]) }
+    def self.log(*arg, path: ".")
+      exec("git log #{arg.join(' ')}", path: path)
+    end
+
+    sig { params(arg: String, path: String).returns([String, String, T::Boolean]) }
+    def self.rev_parse(*arg, path: ".")
+      exec("git rev-parse --short #{arg.join(' ')}", path: path)
+    end
+
+    sig { params(arg: String, path: String).returns([String, String, T::Boolean]) }
+    def self.show(*arg, path: ".")
+      exec("git show #{arg.join(' ')}", path: path)
+    end
+
+    # Utils
+
+    # Get the commit epoch timestamp for a `sha`
+    sig { params(sha: String, path: String).returns(T.nilable(Integer)) }
+    def self.commit_timestamp(sha, path: ".")
+      out, _, status = show("--no-notes --no-patch --pretty=%at #{sha}", path: path)
+      return nil unless status
+      out.strip.to_i
+    end
+
+    # Get the commit Time for a `sha`
+    sig { params(sha: String, path: String).returns(T.nilable(Time)) }
+    def self.commit_date(sha, path: ".")
+      timestamp = commit_timestamp(sha, path: path)
+      return nil unless timestamp
+      timestamp_to_date(timestamp.to_s)
+    end
+
+    # Get the last commit sha
+    sig { params(path: String).returns(T.nilable(String)) }
+    def self.last_commit(path: ".")
+      out, _, status = rev_parse("HEAD", path: path)
+      return nil unless status
+      out.strip
+    end
+
+    # Translate a git epoch timestamp into a Time
+    sig { params(timestamp: String).returns(Time) }
+    def self.timestamp_to_date(timestamp)
+      Time.strptime(timestamp, "%s")
+    end
+
+    # Is there uncommited changes in `path`?
+    sig { params(path: String).returns(T::Boolean) }
+    def self.workdir_clean?(path: ".")
+      diff("HEAD", path: path).first.empty?
+    end
+
+    # Get the hash of the commit introducing the `sorbet/config` file
+    sig { params(path: String).returns(T.nilable(String)) }
+    def self.sorbet_intro_commit(path: ".")
+      res, _, status = Spoom::Git.log("--diff-filter=A --format='%h'  -- sorbet/config", path: path)
+      return nil unless status
+      res
+    end
+  end
+end

--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -30,6 +30,8 @@ module Spoom
     class Snapshot < T::Struct
       extend T::Sig
 
+      prop :commit_sha, T.nilable(String), default: nil
+      prop :commit_timestamp, T.nilable(Integer), default: nil
       prop :files, Integer, default: 0
       prop :modules, Integer, default: 0
       prop :classes, Integer, default: 0

--- a/lib/spoom/timeline.rb
+++ b/lib/spoom/timeline.rb
@@ -1,0 +1,53 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative "git"
+
+module Spoom
+  class Timeline
+    extend T::Sig
+
+    sig { params(from: Time, to: Time, path: String).void }
+    def initialize(from, to, path: ".")
+      @from = from
+      @to = to
+      @path = path
+    end
+
+    # Return one commit for each month between `from` and `to`
+    sig { returns(T::Array[String]) }
+    def ticks
+      commits_for_dates(months)
+    end
+
+    # Return all months between `from` and `to`
+    sig { returns(T::Array[Time]) }
+    def months
+      d = Date.new(@from.year, @from.month, 1)
+      to = Date.new(@to.year, @to.month, 1)
+      res = [d.to_time]
+      while d < to
+        d = d.next_month
+        res << d.to_time
+      end
+      res
+    end
+
+    # Return one commit for each date in `dates`
+    sig { params(dates: T::Array[Time]).returns(T::Array[String]) }
+    def commits_for_dates(dates)
+      dates.map do |t|
+        out, _, _ = Spoom::Git.log(
+          "--since='#{t}'",
+          "--until='#{t.to_date.next_month}'",
+          "--format='format:%h'",
+          "--author-date-order",
+          "-1",
+          path: @path,
+        )
+        next if out.empty?
+        out
+      end.compact.uniq
+    end
+  end
+end

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -3,14 +3,17 @@
 
 require "pathname"
 
+require_relative "../../git_test_helper"
 require_relative "../cli_test_helper"
 
 module Spoom
   module Cli
     module Commands
       class CoverageTest < Minitest::Test
-        include Spoom::Cli::TestHelper
+        extend T::Sig
         extend Spoom::Cli::TestHelper
+        include Spoom::Cli::TestHelper
+        include Spoom::Git::TestHelper
 
         PROJECT = "project"
 
@@ -68,6 +71,207 @@ module Spoom
               typed: 53 (87%)
               untyped: 8 (13%)
           MSG
+        end
+
+        def test_timeline_outside_sorbet_dir
+          repo = repo("test_timeline_outside_sorbet_dir")
+          out, err, status = run_cli(repo.name, "coverage timeline")
+          refute(status)
+          assert_equal("", out)
+          assert_equal(<<~MSG, err)
+            Error: not in a Sorbet project (no sorbet/config)
+          MSG
+          repo.destroy
+        end
+
+        def test_timeline_one_commit
+          repo = repo("test_timeline_one_commit")
+          repo.write_file("sorbet/config", ".")
+          repo.commit
+          out, err, status = run_cli(repo.name, "coverage timeline")
+          assert(status)
+          out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
+          assert_equal(<<~OUT, out)
+            Analyzing COMMIT (1 / 1)
+              Content:
+                files: 0
+                modules: 0
+                classes: 0 (including singleton classes)
+                methods: 0
+
+              Sigils:
+
+              Methods:
+
+              Calls:
+
+          OUT
+          assert_equal("", err)
+          repo.destroy
+        end
+
+        def test_timeline_multiple_commits
+          repo = repo_with_history("test_timeline_multiple_commits")
+          out, err, status = run_cli(repo.name, "coverage timeline")
+          assert(status)
+          out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
+          assert_equal(<<~OUT, out)
+            Analyzing COMMIT (1 / 3)
+              Content:
+                files: 2
+                modules: 1
+                classes: 3 (including singleton classes)
+                methods: 6
+
+              Sigils:
+                false: 1 (50%)
+                strict: 1 (50%)
+
+              Methods:
+                with signature: 1 (17%)
+                without signature: 5 (83%)
+
+              Calls:
+                typed: 6 (100%)
+
+            Analyzing COMMIT (2 / 3)
+              Content:
+                files: 4
+                modules: 1
+                classes: 5 (including singleton classes)
+                methods: 9
+
+              Sigils:
+                false: 2 (50%)
+                true: 1 (25%)
+                strict: 1 (25%)
+
+              Methods:
+                with signature: 1 (11%)
+                without signature: 8 (89%)
+
+              Calls:
+                typed: 7 (100%)
+
+            Analyzing COMMIT (3 / 3)
+              Content:
+                files: 6
+                modules: 1
+                classes: 5 (including singleton classes)
+                methods: 10
+
+              Sigils:
+                ignore: 1 (17%)
+                false: 3 (50%)
+                true: 1 (17%)
+                strict: 1 (17%)
+
+              Methods:
+                with signature: 1 (10%)
+                without signature: 9 (90%)
+
+              Calls:
+                typed: 7 (100%)
+
+          OUT
+          assert_equal("", err)
+          repo.destroy
+        end
+
+        def test_timeline_multiple_commits_between_dates
+          repo = repo_with_history("test_timeline_multiple_commits_between_dates")
+          out, err, status = run_cli(repo.name, "coverage timeline --from 2010-01-02 --to 2010-02-02")
+          assert(status)
+          out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
+          assert_equal(<<~OUT, out)
+            Analyzing COMMIT (1 / 2)
+              Content:
+                files: 2
+                modules: 1
+                classes: 3 (including singleton classes)
+                methods: 6
+
+              Sigils:
+                false: 1 (50%)
+                strict: 1 (50%)
+
+              Methods:
+                with signature: 1 (17%)
+                without signature: 5 (83%)
+
+              Calls:
+                typed: 6 (100%)
+
+            Analyzing COMMIT (2 / 2)
+              Content:
+                files: 4
+                modules: 1
+                classes: 5 (including singleton classes)
+                methods: 9
+
+              Sigils:
+                false: 2 (50%)
+                true: 1 (25%)
+                strict: 1 (25%)
+
+              Methods:
+                with signature: 1 (11%)
+                without signature: 8 (89%)
+
+              Calls:
+                typed: 7 (100%)
+
+          OUT
+          assert_equal("", err)
+          repo.destroy
+        end
+
+        def test_timeline_multiple_commits_and_save_json
+          repo = repo_with_history("test_timeline_multiple_commits_and_save_json")
+          _, err, status = run_cli(repo.name, "coverage timeline --save-dir spoom_data")
+          assert(status)
+          assert_equal("", err)
+          assert(3, Dir.glob("#{repo.path}/spoom_data/*.json").size)
+          repo.destroy
+        end
+
+        private
+
+        sig { params(name: String).returns(Spoom::Git::TestHelper::TestRepo) }
+        def repo_with_history(name)
+          repo = repo(name)
+          repo.write_file("sorbet/config", ".")
+          repo.write_file("a.rb", <<~RB)
+            # typed: false
+            class Foo
+              def foo
+                Bar.bar
+              end
+            end
+          RB
+          repo.write_file("b.rb", <<~RB)
+            # typed: strict
+            module Bar
+              extend T::Sig
+
+              sig { void}
+              def self.bar; end
+            end
+          RB
+          repo.commit(date: Time.parse("2010-01-02 03:04:05"))
+          repo.write_file("c.rb", <<~RB)
+            # typed: false
+            class Baz; end
+          RB
+          repo.write_file("d.rb", <<~RB)
+            # typed: true
+            Baz.new
+          RB
+          repo.commit(date: Time.parse("2010-02-02 03:04:05"))
+          repo.write_file("e.rb", "# typed: ignore")
+          repo.write_file("f.rb", "# typed: __INTERNAL_STDLIB")
+          repo.commit(date: Time.parse("2010-03-02 03:04:05"))
+          repo
         end
       end
     end

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -1,0 +1,118 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "git_test_helper"
+
+module Spoom
+  module Git
+    class GitTest < Minitest::Test
+      include Spoom::Git::TestHelper
+
+      def test_last_commit_if_no_commit
+        repo = repo("test_is_git_dir_true_if_no_commit")
+        assert(Spoom::Git.last_commit(path: repo.path).nil?)
+        repo.destroy
+      end
+
+      def test_last_commit
+        repo = repo("test_last_commit")
+        repo.write_file("file")
+        repo.commit
+        assert(Spoom::Git.last_commit(path: repo.path))
+        repo.destroy
+      end
+
+      def test_clean_workdir_on_clean_repo
+        repo = repo("test_clean_workdir_on_clean_repo")
+        repo.write_file("file")
+        repo.commit
+        assert(Spoom::Git.workdir_clean?(path: repo.path))
+        repo.destroy
+      end
+
+      def test_clean_workdir_on_dirty_repo
+        repo = repo("test_clean_workdir_on_dirty_repo")
+        repo.write_file("file", "content")
+        repo.commit
+        repo.write_file("file", "content2")
+        refute(Spoom::Git.workdir_clean?(path: repo.path))
+        repo.destroy
+      end
+
+      def test_commit_timestamp
+        date = Time.parse("1987-02-05 09:00:00")
+        repo = repo("test_commit_timestamp")
+        repo.write_file("file")
+        repo.commit(date: date)
+        sha = Spoom::Git.last_commit(path: repo.path)
+        assert_equal(date.strftime("%s").to_i, Spoom::Git.commit_timestamp(T.must(sha), path: repo.path))
+        repo.destroy
+      end
+
+      def test_commit_date
+        date = Time.parse("1987-02-05 09:00:00")
+        repo = repo("test_commit_date")
+        repo.write_file("file")
+        repo.commit(date: date)
+        sha = Spoom::Git.last_commit(path: repo.path)
+        assert_equal(date, Spoom::Git.commit_date(T.must(sha), path: repo.path))
+        repo.destroy
+      end
+
+      def test_git_diff
+        repo = repo("test_git_diff")
+        assert_equal("", Spoom::Git.diff("HEAD", path: repo.path).first)
+        repo.write_file("file", "content")
+        assert_equal("", Spoom::Git.diff("HEAD", path: repo.path).first)
+        repo.commit
+        assert_equal("", Spoom::Git.diff("HEAD", path: repo.path).first)
+        repo.write_file("file", "content2")
+        assert_match(/content2/, Spoom::Git.diff("HEAD", path: repo.path).first)
+        repo.commit
+        assert_equal("", Spoom::Git.diff("HEAD", path: repo.path).first)
+        repo.destroy
+      end
+
+      def test_git_log
+        repo = repo("test_git_log")
+        repo.write_file("file")
+        repo.commit(date: Time.parse("1987-02-05 09:00:00 +0000"))
+        assert_equal("Thu Feb 5 09:00:00 1987 +0000", Spoom::Git.log("--format='format:%ad'", path: repo.path).first)
+        repo.destroy
+      end
+
+      def test_git_rev_parse
+        repo = repo("test_git_rev_parse")
+        repo.write_file("file")
+        repo.commit
+        assert_match(/^[a-f0-9]+$/, Spoom::Git.rev_parse("master", path: repo.path).first.strip)
+        repo.destroy
+      end
+
+      def test_git_show
+        repo = repo("test_git_show")
+        repo.write_file("file")
+        repo.commit(date: Time.parse("1987-02-05 09:00:00"))
+        assert_match(/Thu Feb 5 09:00:00 1987/, Spoom::Git.show(path: repo.path).first)
+        repo.destroy
+      end
+
+      def test_sorbet_intro_not_found
+        repo = repo("test_sorbet_intro_not_found")
+        sha = Spoom::Git.sorbet_intro_commit(path: repo.path)
+        assert_nil(sha)
+        repo.destroy
+      end
+
+      def test_sorbet_intro_found
+        repo = repo("test_sorbet_intro_found")
+        repo.write_file("sorbet/config")
+        repo.commit
+        sha = Spoom::Git.sorbet_intro_commit(path: repo.path)
+        assert(sha)
+        repo.destroy
+      end
+    end
+  end
+end

--- a/test/spoom/git_test_helper.rb
+++ b/test/spoom/git_test_helper.rb
@@ -29,6 +29,8 @@ module Spoom
           FileUtils.rm_rf(@path)
           FileUtils.mkdir_p(@path)
           Spoom::Git.exec("git init -q", path: @path)
+          Spoom::Git.exec("git config user.name 'spoom-tests'", path: @path)
+          Spoom::Git.exec("git config user.email 'spoom@shopify.com'", path: @path)
         end
 
         sig { params(path: String, content: String).void }

--- a/test/spoom/git_test_helper.rb
+++ b/test/spoom/git_test_helper.rb
@@ -1,0 +1,54 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative "../../lib/spoom/git"
+require_relative "cli/cli_test_helper"
+
+require "fileutils"
+
+module Spoom
+  module Git
+    module TestHelper
+      extend T::Sig
+
+      sig { params(name: String).returns(TestRepo) }
+      def repo(name)
+        TestRepo.new(name)
+      end
+
+      class TestRepo
+        extend T::Sig
+
+        sig { returns(String) }
+        attr_reader :name, :path
+
+        sig { params(name: String).void }
+        def initialize(name)
+          @name = name
+          @path = T.let("#{Cli::TestHelper::TEST_PROJECTS_PATH}/#{name}", String)
+          FileUtils.rm_rf(@path)
+          FileUtils.mkdir_p(@path)
+          Spoom::Git.exec("git init -q", path: @path)
+        end
+
+        sig { params(path: String, content: String).void }
+        def write_file(path, content = "")
+          full_path = "#{self.path}/#{path}"
+          FileUtils.mkdir_p(File.dirname(full_path))
+          File.write(full_path, content)
+        end
+
+        sig { params(message: String, date: Time).void }
+        def commit(message = "message", date: Time.now.utc)
+          Spoom::Git.exec("git add --all", path: path)
+          Spoom::Git.exec("GIT_COMMITTER_DATE=\"#{date}\" git commit -m '#{message}' --date '#{date}'", path: path)
+        end
+
+        sig { void }
+        def destroy
+          FileUtils.rm_rf(path)
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/git_test_helper.rb
+++ b/test/spoom/git_test_helper.rb
@@ -1,8 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-require_relative "../../lib/spoom/git"
 require_relative "cli/cli_test_helper"
+require_relative "../../lib/spoom/git"
 
 require "fileutils"
 
@@ -36,6 +36,12 @@ module Spoom
           full_path = "#{self.path}/#{path}"
           FileUtils.mkdir_p(File.dirname(full_path))
           File.write(full_path, content)
+        end
+
+        sig { params(path: String).void }
+        def remove_file(path)
+          full_path = "#{self.path}/#{path}"
+          FileUtils.rm_rf(full_path)
         end
 
         sig { params(message: String, date: Time).void }

--- a/test/spoom/timeline_test.rb
+++ b/test/spoom/timeline_test.rb
@@ -1,0 +1,81 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "git_test_helper"
+require_relative "../../lib/spoom/timeline.rb"
+
+module Spoom
+  module Sorbet
+    class TimelineTest < Minitest::Test
+      include Spoom::Git::TestHelper
+
+      def test_timeline_months
+        from = Time.parse("2010-01-02 03:04:05")
+        to = Time.parse("2010-03-02 03:04:05")
+        timeline = Spoom::Timeline.new(from, to)
+        assert_equal(["2010-01", "2010-02", "2010-03"], timeline.months.map { |d| d.strftime("%Y-%m") })
+      end
+
+      def test_timeline_commits_for_dates
+        repo = test_repo("test_timeline_commits_for_dates")
+
+        timeline = Spoom::Timeline.new(
+          Time.parse("2010-01-01 00:00:00"),
+          Time.parse("2020-01-01 00:00:00"),
+          path: repo.path
+        )
+
+        dates = [
+          Time.parse("2000-01-01 00:00:00"),
+          Time.parse("2000-02-01 00:00:00"),
+        ]
+        assert_equal(0, timeline.commits_for_dates(dates).size)
+
+        dates << Time.parse("2010-01-01 00:00:00")
+        assert_equal(1, timeline.commits_for_dates(dates).size)
+
+        dates << Time.parse("2010-04-01 00:00:00")
+        assert_equal(2, timeline.commits_for_dates(dates).size)
+
+        dates << Time.parse("2010-05-01 00:00:00")
+        assert_equal(2, timeline.commits_for_dates(dates).size)
+
+        dates << Time.parse("2010-06-01 00:00:00")
+        assert_equal(3, timeline.commits_for_dates(dates).size)
+
+        dates << Time.parse("2011-01-01 00:00:00")
+        assert_equal(4, timeline.commits_for_dates(dates).size)
+
+        repo.destroy
+      end
+
+      def test_timeline_ticks
+        repo = test_repo("test_timeline_ticks")
+
+        timeline = Spoom::Timeline.new(
+          Time.parse("2010-01-01 00:00:00"),
+          Time.parse("2020-01-01 00:00:00"),
+          path: repo.path
+        )
+        assert_equal(4, timeline.ticks.size)
+        repo.destroy
+      end
+
+      private
+
+      def test_repo(name)
+        repo = repo(name)
+        repo.write_file("sorbet/config", "")
+        repo.commit("commit 1", date: Time.parse("2010-01-02 03:04:05"))
+        repo.write_file("file2", "")
+        repo.commit("commit 2", date: Time.parse("2010-04-01 03:04:05"))
+        repo.write_file("file3", "")
+        repo.commit("commit 3", date: Time.parse("2010-06-30 03:04:05"))
+        repo.write_file("file4", "")
+        repo.commit("commit 4", date: Time.parse("2011-01-02 03:04:05"))
+        repo
+      end
+    end
+  end
+end


### PR DESCRIPTION
This command basically run `spoom coverage snapshot` for each month your project has existed.

It finds the first commit sorbet was introduced, then selects one commit by month until now to build the timeline.
This can be controlled with the `--from` and `--to` options.

The `--save-dir` option allows the user the save the timeline in JSON format.