### PR TITLE
Speed up the bump task

### DIFF
--- a/lib/spoom/cli/commands/bump.rb
+++ b/lib/spoom/cli/commands/bump.rb
@@ -49,7 +49,7 @@ module Spoom
 
           files_with_errors = errors.map do |err|
             File.join(directory, err.file)
-          end.compact
+          end.compact.uniq
 
           Sorbet::Sigils.change_sigil_in_files(files_with_errors, from)
         end


### PR DESCRIPTION
`srb tc` could return many errors from the same file. Only change sigil once per file.