### PR TITLE
Bump: ignore paths that don't exist

### DIFF
--- a/lib/spoom/cli/commands/bump.rb
+++ b/lib/spoom/cli/commands/bump.rb
@@ -48,8 +48,8 @@ module Spoom
           errors = Sorbet::Errors::Parser.parse_string(output)
 
           files_with_errors = errors.map do |err|
-            File.join(directory, err.file)
-          end.compact.select {|path| File.file?(path)}
+            File.join(directory, err.file) if File.file?(err.file)
+          end.compact
 
           Sorbet::Sigils.change_sigil_in_files(files_with_errors, from)
         end

--- a/lib/spoom/cli/commands/bump.rb
+++ b/lib/spoom/cli/commands/bump.rb
@@ -48,7 +48,8 @@ module Spoom
           errors = Sorbet::Errors::Parser.parse_string(output)
 
           files_with_errors = errors.map do |err|
-            File.join(directory, err.file) if File.file?(err.file)
+            path = err.file
+            File.join(directory, path) if path && File.file?(path)
           end.compact
 
           Sorbet::Sigils.change_sigil_in_files(files_with_errors, from)

--- a/lib/spoom/cli/commands/bump.rb
+++ b/lib/spoom/cli/commands/bump.rb
@@ -49,7 +49,7 @@ module Spoom
 
           files_with_errors = errors.map do |err|
             File.join(directory, err.file)
-          end.compact
+          end.compact.select {|path| File.file?(path)}
 
           Sorbet::Sigils.change_sigil_in_files(files_with_errors, from)
         end


### PR DESCRIPTION
This task was crashing in our code base, due to an extremely large `srb tc` error that wasn't parsed correctly.

I can't copy the error trace because it's basically an entire file, but the gist is that it's trying to wrap that whole class in `T.let(KLASS_NAME...end, T.untyped)`. Anyway, the filename is parsing totally wrong. To avoid errors I'm just ignoring paths that aren't really file paths.