### PR TITLE
Add `--path` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ client = Spoom::LSP::Client.new(
   "--enable-all-experimental-lsp-features",
   "--disable-watchman",
 )
-client.open(Spoom::Config::WORKSPACE_PATH)
+client.open(".")
 ```
 
 Find all the symbols matching a string:

--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -16,6 +16,7 @@ module Spoom
       include Spoom::Cli::CommandHelper
 
       class_option :color, desc: "Use colors", type: :boolean, default: true
+      class_option :path, desc: "Run spoom in a specific path", type: :string, default: ".", aliases: :p
       map T.unsafe(%w[--version -v] => :__print_version)
 
       desc "bump", "bump Sorbet sigils from `false` to `true` when no errors"

--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -37,10 +37,12 @@ module Spoom
       desc "files", "list all the files typechecked by Sorbet"
       def files
         in_sorbet_project!
-        config = Spoom::Sorbet::Config.parse_file(Spoom::Config::SORBET_CONFIG)
-        files = Spoom::Sorbet.srb_files(config)
 
-        say("Files matching `#{Spoom::Config::SORBET_CONFIG}`:")
+        path = exec_path
+        config = Spoom::Sorbet::Config.parse_file(sorbet_config)
+        files = Spoom::Sorbet.srb_files(config, path: path)
+
+        say("Files matching `#{sorbet_config}`:")
         if files.empty?
           say(" NONE")
         else

--- a/lib/spoom/cli/command_helper.rb
+++ b/lib/spoom/cli/command_helper.rb
@@ -1,7 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-require 'stringio'
+require "pathname"
+require "stringio"
 
 module Spoom
   module Cli
@@ -27,7 +28,7 @@ module Spoom
       # Is `spoom` ran inside a project with a `sorbet/config` file?
       sig { returns(T::Boolean) }
       def in_sorbet_project?
-        File.file?(Spoom::Config::SORBET_CONFIG)
+        File.file?(sorbet_config)
       end
 
       # Enforce that `spoom` is ran inside a project with a `sorbet/config` file
@@ -39,6 +40,17 @@ module Spoom
           say_error("not in a Sorbet project (no sorbet/config)")
           Kernel.exit(1)
         end
+      end
+
+      # Return the path specified through `--path`
+      sig { returns(String) }
+      def exec_path
+        T.unsafe(self).options[:path] # TODO: requires_ancestor
+      end
+
+      sig { returns(String) }
+      def sorbet_config
+        Pathname.new("#{exec_path}/#{Spoom::Config::SORBET_CONFIG}").cleanpath.to_s
       end
     end
   end

--- a/lib/spoom/cli/commands/config.rb
+++ b/lib/spoom/cli/commands/config.rb
@@ -16,9 +16,9 @@ module Spoom
         desc "show", "show Sorbet config"
         def show
           in_sorbet_project!
-          config = Spoom::Sorbet::Config.parse_file(Spoom::Config::SORBET_CONFIG)
+          config = Spoom::Sorbet::Config.parse_file(sorbet_config)
 
-          say("Found Sorbet config at `#{Spoom::Config::SORBET_CONFIG}`.")
+          say("Found Sorbet config at `#{sorbet_config}`.")
 
           say("\nPaths typechecked:")
           if config.paths.empty?

--- a/lib/spoom/cli/commands/run.rb
+++ b/lib/spoom/cli/commands/run.rb
@@ -18,16 +18,17 @@ module Spoom
         def tc
           in_sorbet_project!
 
+          path = exec_path
           limit = options[:limit]
           sort = options[:sort]
           code = options[:code]
           colors = options[:color]
 
           unless limit || code || sort
-            return Spoom::Sorbet.srb_tc(capture_err: false).last
+            return Spoom::Sorbet.srb_tc(path: path, capture_err: false).last
           end
 
-          output, status = Spoom::Sorbet.srb_tc(capture_err: true)
+          output, status = Spoom::Sorbet.srb_tc(path: path, capture_err: true)
           if status
             $stderr.print(output)
             return 0

--- a/lib/spoom/config.rb
+++ b/lib/spoom/config.rb
@@ -6,6 +6,5 @@ module Spoom
     SORBET_CONFIG = "sorbet/config"
     SORBET_GEM_PATH = Gem::Specification.find_by_name("sorbet-static").full_gem_path
     SORBET_PATH = (Pathname.new(SORBET_GEM_PATH) / "libexec" / "sorbet").to_s
-    WORKSPACE_PATH = (Pathname.new(ENV['BUNDLE_GEMFILE']) / "..").to_s
   end
 end

--- a/lib/spoom/file_tree.rb
+++ b/lib/spoom/file_tree.rb
@@ -25,7 +25,7 @@ module Spoom
     def add_path(path)
       # TODO: return if path =~ /\/test\//
       parts = path.split("/")
-      if parts.size == 1
+      if path.empty? || parts.size == 1
         return @roots[path] ||= Node.new(parent: nil, name: path)
       end
       parent_path = T.must(parts[0...-1]).join("/")

--- a/lib/spoom/sorbet/lsp.rb
+++ b/lib/spoom/sorbet/lsp.rb
@@ -11,10 +11,12 @@ require_relative 'lsp/errors'
 module Spoom
   module LSP
     class Client
-      def initialize(sorbet_cmd, *sorbet_args)
+      def initialize(sorbet_cmd, *sorbet_args, path: ".")
         @id = 0
         Bundler.with_clean_env do
-          @in, @out, @err, @status = Open3.popen3([sorbet_cmd, *sorbet_args].join(" "))
+          opts = {}
+          opts[:chdir] = path
+          @in, @out, @err, @status = Open3.popen3([sorbet_cmd, *sorbet_args].join(" "), opts)
         end
       end
 

--- a/lib/spoom/sorbet/lsp/base.rb
+++ b/lib/spoom/sorbet/lsp/base.rb
@@ -56,13 +56,3 @@ module Spoom
     end
   end
 end
-
-class String
-  def to_uri
-    "file://" + File.join(Spoom::Config::WORKSPACE_PATH, self)
-  end
-
-  def from_uri
-    sub("file://#{Spoom::Config::WORKSPACE_PATH}", "")
-  end
-end

--- a/lib/spoom/sorbet/lsp/structures.rb
+++ b/lib/spoom/sorbet/lsp/structures.rb
@@ -106,7 +106,7 @@ module Spoom
 
       sig { override.params(printer: SymbolPrinter).void }
       def accept_printer(printer)
-        printer.print_colored("#{uri.from_uri}:", :light_black)
+        printer.print_colored("#{printer.clean_uri(uri)}:", :light_black)
         printer.print_object(range)
       end
 
@@ -262,15 +262,23 @@ module Spoom
     class SymbolPrinter < Printer
       extend T::Sig
 
-      attr_accessor :seen
+      attr_accessor :seen, :prefix
 
-      sig { params(out: T.any(IO, StringIO), colors: T::Boolean, indent_level: Integer).void }
-      def initialize(out: $stdout, colors: true, indent_level: 0)
+      sig do
+        params(
+          out: T.any(IO, StringIO),
+          colors: T::Boolean,
+          indent_level: Integer,
+          prefix: T.nilable(String)
+        ).void
+      end
+      def initialize(out: $stdout, colors: true, indent_level: 0, prefix: nil)
         super(out: out, colors: colors, indent_level: indent_level)
         @seen = Set.new
         @out = out
         @colors = colors
         @indent_level = indent_level
+        @prefix = prefix
       end
 
       sig { params(object: T.nilable(PrintableSymbol)).void }
@@ -282,6 +290,12 @@ module Spoom
       sig { params(objects: T::Array[PrintableSymbol]).void }
       def print_objects(objects)
         objects.each { |object| print_object(object) }
+      end
+
+      sig { params(uri: String).returns(String) }
+      def clean_uri(uri)
+        return uri unless prefix
+        uri.delete_prefix(prefix)
       end
 
       sig { params(objects: T::Array[PrintableSymbol]).void }

--- a/test/spoom/cli/commands/cli_test.rb
+++ b/test/spoom/cli/commands/cli_test.rb
@@ -43,8 +43,10 @@ module Spoom
               spoom tc              # run Sorbet and parses its output
 
             Options:
-              [--color], [--no-color]  # Use colors
-                                       # Default: true
+                  [--color], [--no-color]  # Use colors
+                                           # Default: true
+              p, [--path=PATH]             # Run spoom in a specific path
+                                           # Default: .
 
           OUT
         end

--- a/test/spoom/cli/commands/cli_test.rb
+++ b/test/spoom/cli/commands/cli_test.rb
@@ -119,6 +119,26 @@ module Spoom
                 a.rake (ignore)
           MSG
         end
+
+        def test_display_files_with_path_option
+          project = spoom_project("test_files")
+          project.sorbet_config(".")
+          project.write("lib/file1.rb", "# typed: true")
+          project.write("lib/file2.rb", "# typed: true")
+
+          out, _ = @project.bundle_exec("spoom files --no-color --path #{project.path}")
+          assert_equal(<<~MSG, out)
+            Files matching `/tmp/spoom/tests/test_files/sorbet/config`:
+              /
+                tmp/
+                  spoom/
+                    tests/
+                      test_files/
+                        lib/
+                          file1.rb (true)
+                          file2.rb (true)
+          MSG
+        end
       end
     end
   end

--- a/test/spoom/cli/commands/config_test.rb
+++ b/test/spoom/cli/commands/config_test.rb
@@ -140,6 +140,26 @@ module Spoom
              * .ru
           MSG
         end
+
+        def test_config_with_path_option
+          @project.sorbet_config(".")
+          project = spoom_project("test_config_with_path_option")
+          out, _ = project.bundle_exec("spoom config -p #{@project.path}")
+          assert_equal(<<~MSG, out)
+            Found Sorbet config at `/tmp/spoom/tests/test_config/sorbet/config`.
+
+            Paths typechecked:
+             * .
+
+            Paths ignored:
+             * (default: none)
+
+            Allowed extensions:
+             * .rb (default)
+             * .rbi (default)
+          MSG
+          project.destroy
+        end
       end
     end
   end

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -96,6 +96,31 @@ module Spoom
           MSG
         end
 
+        def test_display_metrics_with_path_option
+          project = spoom_project("test_display_metrics_with_path_option")
+          out, _ = project.bundle_exec("spoom coverage snapshot -p #{@project.path}")
+          assert_equal(<<~MSG, out)
+            Content:
+              files: 3
+              modules: 3
+              classes: 5 (including singleton classes)
+              methods: 9
+
+            Sigils:
+              false: 1 (33%)
+              true: 2 (67%)
+
+            Methods:
+              with signature: 1 (11%)
+              without signature: 8 (89%)
+
+            Calls:
+              typed: 8 (89%)
+              untyped: 1 (11%)
+          MSG
+          project.destroy
+        end
+
         def test_timeline_outside_sorbet_dir
           @project.remove("sorbet/config")
           out, err, status = @project.bundle_exec("spoom coverage snapshot")
@@ -256,6 +281,16 @@ module Spoom
           assert(status)
           assert_equal("", err)
           assert(3, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+        end
+
+        def test_timeline_with_path_option
+          create_git_history
+          project = spoom_project("test_display_metrics_with_path_option")
+          _, err, status = project.bundle_exec("spoom coverage timeline --save-dir spoom_data -p #{@project.path}")
+          assert(status)
+          assert_equal("", err)
+          assert(3, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+          project.destroy
         end
 
         private

--- a/test/spoom/cli/commands/lsp_test.rb
+++ b/test/spoom/cli/commands/lsp_test.rb
@@ -281,6 +281,23 @@ module Spoom
               * /lib/types.rb:2:6-2:14
           MSG
         end
+
+        # --path
+
+        def test_lsp_with_path_option
+          @project.write("lib/find.rb", <<~RB)
+            # typed: true
+
+            class Test; end
+          RB
+          project = spoom_project("test_lsp_with_path_option")
+          out, _ = project.bundle_exec("spoom lsp -p #{@project.path} --no-color find Test")
+          assert_equal(<<~MSG, out)
+            Symbols matching `Test`:
+              class Test (/lib/find.rb:2:0-2:10)
+          MSG
+          project.destroy
+        end
       end
     end
   end

--- a/test/spoom/cli/commands/run_test.rb
+++ b/test/spoom/cli/commands/run_test.rb
@@ -116,6 +116,16 @@ module Spoom
             Errors: 1 shown, 7 total
           MSG
         end
+
+        def test_display_errors_with_path_option
+          project = spoom_project("test_display_errors_with_path_option")
+          _, err = project.bundle_exec("spoom tc --no-color -s code -l 1 -p #{@project.path}")
+          assert_equal(<<~MSG, err)
+            5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+            Errors: 1 shown, 7 total
+          MSG
+          project.destroy
+        end
       end
     end
   end


### PR DESCRIPTION
This pull-request adds a `--path` option to `spoom` so it can run in a different directory.

Why is it useful?
* When working on new features, one can use `--path` to test the feature on different projects without having to change their Gemfiles.
* Spoom can be used as a system wide gem and ran on projects that does not use spoom (some commands even work if the project doesn't have sorbet installed).

I also added a few tests ensuring each command works correctly with the `--path` option.