### PR TITLE
Bump: ignore paths that don't exist (with test)

### DIFF
--- a/lib/spoom/cli/commands/bump.rb
+++ b/lib/spoom/cli/commands/bump.rb
@@ -48,7 +48,8 @@ module Spoom
           errors = Sorbet::Errors::Parser.parse_string(output)
 
           files_with_errors = errors.map do |err|
-            File.join(directory, err.file)
+            path = err.file
+            File.join(directory, path) if path && File.file?(path)
           end.compact.uniq
 
           Sorbet::Sigils.change_sigil_in_files(files_with_errors, from)

--- a/test/spoom/cli/commands/bump_test.rb
+++ b/test/spoom/cli/commands/bump_test.rb
@@ -94,6 +94,30 @@ module Spoom
           assert_equal("strong", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
           assert_equal("strong", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
         end
+
+        def test_bump_with_multiline_error
+          @project.write("file.rb", <<~RB)
+            # typed: true
+            require "test_helper"
+
+            class Test
+              def self.foo(*arg); end
+              def self.something; end
+              def self.something_else; end
+
+              foo "foo" do
+                q = something do
+                  q = something_else.new
+                end
+              end
+            end
+          RB
+
+          _, _, status = @project.bundle_exec("spoom bump --from true --to strict")
+          assert(status)
+
+          assert_equal("true", Sorbet::Sigils.file_strictness("#{@project.path}/file.rb"))
+        end
       end
     end
   end


### PR DESCRIPTION
Rebasing the fix provided in https://github.com/Shopify/spoom/pull/25 and adding a test.