### PR TITLE
Add spoom coverage timeline --bundle-install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Save the typing coverage evolution as JSON in a specific directory:
 $ spoom coverage timeline --save-dir data/
 ```
 
+Run `bundle install` for each commit of the timeline (may solve errors due to different Sorbet versions):
+
+```
+$ spoom coverage timeline --bundle-install
+```
+
+
 #### Change the sigil used in files
 
 Bump the strictness from all files currently at `typed: false` to `typed: true` where it does not create typechecking errors:


### PR DESCRIPTION
As discussed in #23 with @paracycle we should provide a way to collect the snapshot data from an installed bundle.

This PR introduces `spoom coverage timeline --bundle-install` which will run `bundle install` for each commit in the timeline before running Sorbet to collect the metrics.

If a `--bundle-install` is used and bundle install doesn't finishes properly, the commit is skipped.