### PR TITLE
Save sorbet-version used in snapshots

### DIFF
--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -17,7 +17,9 @@ module Spoom
         def snapshot
           in_sorbet_project!
 
-          snapshot = Spoom::Coverage.snapshot(path: exec_path)
+          path = exec_path
+          snapshot = Spoom::Coverage.snapshot(path: path)
+          snapshot.sorbet_version = Spoom::Sorbet.srb_version(path: path)
           snapshot.print
         end
 

--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -77,9 +77,11 @@ module Spoom
               Bundler.with_clean_env do
                 next unless bundle_install(path, sha)
                 snapshot = Spoom::Coverage.snapshot(path: path)
+                snapshot.sorbet_version = Spoom::Sorbet.srb_version(path: path) if snapshot
               end
             else
               snapshot = Spoom::Coverage.snapshot(path: path)
+              snapshot.sorbet_version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: path)
             end
             next unless snapshot
 

--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -19,7 +19,6 @@ module Spoom
 
           path = exec_path
           snapshot = Spoom::Coverage.snapshot(path: path)
-          snapshot.sorbet_version = Spoom::Sorbet.srb_version(path: path)
           snapshot.print
         end
 
@@ -77,11 +76,9 @@ module Spoom
               Bundler.with_clean_env do
                 next unless bundle_install(path, sha)
                 snapshot = Spoom::Coverage.snapshot(path: path)
-                snapshot.sorbet_version = Spoom::Sorbet.srb_version(path: path) if snapshot
               end
             else
               snapshot = Spoom::Coverage.snapshot(path: path)
-              snapshot.sorbet_version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: path)
             end
             next unless snapshot
 

--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -30,6 +30,7 @@ module Spoom
     class Snapshot < T::Struct
       extend T::Sig
 
+      prop :sorbet_version, T.nilable(String), default: nil
       prop :commit_sha, T.nilable(String), default: nil
       prop :commit_timestamp, T.nilable(Integer), default: nil
       prop :files, Integer, default: 0
@@ -59,6 +60,10 @@ module Spoom
         methods = snapshot.methods_with_sig + snapshot.methods_without_sig
         calls = snapshot.calls_typed + snapshot.calls_untyped
 
+        if snapshot.sorbet_version
+          printl("Sorbet version: #{snapshot.sorbet_version}")
+          printn
+        end
         printl("Content:")
         indent
         printl("files: #{snapshot.files}")

--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -24,6 +24,8 @@ module Spoom
         snapshot.sigils[strictness] = T.must(metrics["types.input.files.sigil.#{strictness}"])
       end
 
+      snapshot.sorbet_version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: path)
+
       snapshot
     end
 

--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -55,6 +55,20 @@ module Spoom
       out.split(" ")[2]
     end
 
+    # Get `sorbet` version from the `Gemfile.lock` content
+    #
+    # Returns `nil` if `sorbet` gem cannot be found in the Gemfile.
+    sig { params(path: String).returns(T.nilable(String)) }
+    def self.srb_version_from_gemfile_lock(path: '.')
+      gemfile_path = "#{path}/Gemfile.lock"
+      return nil unless File.exist?(gemfile_path)
+      gemfile_lock = Bundler.read_file(gemfile_path)
+      parser = Bundler::LockfileParser.new(gemfile_lock)
+      sorbet = parser.specs.find { |spec| spec.name == "sorbet" }
+      return nil unless sorbet
+      sorbet.version.to_s
+    end
+
     sig { params(arg: String, path: String, capture_err: T::Boolean).returns(T.nilable(T::Hash[String, Integer])) }
     def self.srb_metrics(*arg, path: '.', capture_err: false)
       metrics_file = "metrics.tmp"

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -177,6 +177,8 @@ module Spoom
           out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
           assert_equal(<<~OUT, out)
             Analyzing COMMIT (1 / 3)
+              Sorbet version: 0.5.0000
+
               Content:
                 files: 2
                 modules: 1
@@ -195,6 +197,8 @@ module Spoom
                 typed: 6 (100%)
 
             Analyzing COMMIT (2 / 3)
+              Sorbet version: 0.5.1000
+
               Content:
                 files: 4
                 modules: 1
@@ -214,6 +218,8 @@ module Spoom
                 typed: 7 (100%)
 
             Analyzing COMMIT (3 / 3)
+              Sorbet version: 0.5.2000
+
               Content:
                 files: 6
                 modules: 1
@@ -244,6 +250,8 @@ module Spoom
           out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
           assert_equal(<<~OUT, out)
             Analyzing COMMIT (1 / 2)
+              Sorbet version: 0.5.0000
+
               Content:
                 files: 2
                 modules: 1
@@ -262,6 +270,8 @@ module Spoom
                 typed: 6 (100%)
 
             Analyzing COMMIT (2 / 2)
+              Sorbet version: 0.5.1000
+
               Content:
                 files: 4
                 modules: 1
@@ -307,6 +317,18 @@ module Spoom
         def create_git_history
           @project.remove("lib")
           @project.git_init
+          @project.write("Gemfile.lock", <<~RB)
+            PATH
+              remote: .
+              specs:
+                test (1.0.0)
+                  sorbet (~> 0.5.5)
+
+            GEM
+              remote: https://rubygems.org/
+              specs:
+                sorbet (0.5.0000)
+          RB
           @project.write("a.rb", <<~RB)
             # typed: false
             class Foo
@@ -325,6 +347,18 @@ module Spoom
             end
           RB
           @project.commit(date: Time.parse("2010-01-02 03:04:05"))
+          @project.write("Gemfile.lock", <<~RB)
+            PATH
+              remote: .
+              specs:
+                test (1.0.0)
+                  sorbet (~> 0.5.5)
+
+            GEM
+              remote: https://rubygems.org/
+              specs:
+                sorbet (0.5.1000)
+          RB
           @project.write("c.rb", <<~RB)
             # typed: false
             class Baz; end
@@ -334,6 +368,18 @@ module Spoom
             Baz.new
           RB
           @project.commit(date: Time.parse("2010-02-02 03:04:05"))
+          @project.write("Gemfile.lock", <<~RB)
+            PATH
+              remote: .
+              specs:
+                test (1.0.0)
+                  sorbet (~> 0.5.5)
+
+            GEM
+              remote: https://rubygems.org/
+              specs:
+                sorbet (0.5.2000)
+          RB
           @project.write("e.rb", "# typed: ignore")
           @project.write("f.rb", "# typed: __INTERNAL_STDLIB")
           @project.commit(date: Time.parse("2010-03-02 03:04:05"))

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -48,7 +48,10 @@ module Spoom
 
         def test_display_metrics
           out, _ = @project.bundle_exec("spoom coverage snapshot")
+          out = censor_sorbet_version(out) if out
           assert_equal(<<~MSG, out)
+            Sorbet version: X.X.XXXX
+
             Content:
               files: 3
               modules: 3
@@ -75,7 +78,10 @@ module Spoom
             A3.error.error.error
           RB
           out, _ = @project.bundle_exec("spoom coverage snapshot")
+          out = censor_sorbet_version(out) if out
           assert_equal(<<~MSG, out)
+            Sorbet version: X.X.XXXX
+
             Content:
               files: 4
               modules: 3
@@ -99,7 +105,10 @@ module Spoom
         def test_display_metrics_with_path_option
           project = spoom_project("test_display_metrics_with_path_option")
           out, _ = project.bundle_exec("spoom coverage snapshot -p #{@project.path}")
+          out = censor_sorbet_version(out) if out
           assert_equal(<<~MSG, out)
+            Sorbet version: X.X.XXXX
+
             Content:
               files: 3
               modules: 3

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -15,6 +15,18 @@ module Spoom
         def setup
           @project = spoom_project("test_coverage")
           @project.sorbet_config(".")
+          @project.write("Gemfile.lock", <<~RB)
+            PATH
+              remote: .
+              specs:
+                test (1.0.0)
+                  sorbet (~> 0.5.5)
+
+            GEM
+              remote: https://rubygems.org/
+              specs:
+                sorbet (0.5.0000)
+          RB
           @project.write("lib/a.rb", <<~RB)
             # typed: false
 
@@ -148,6 +160,8 @@ module Spoom
           out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
           assert_equal(<<~OUT, out)
             Analyzing COMMIT (1 / 1)
+              Sorbet version: 0.5.0000
+
               Content:
                 files: 3
                 modules: 3
@@ -317,18 +331,6 @@ module Spoom
         def create_git_history
           @project.remove("lib")
           @project.git_init
-          @project.write("Gemfile.lock", <<~RB)
-            PATH
-              remote: .
-              specs:
-                test (1.0.0)
-                  sorbet (~> 0.5.5)
-
-            GEM
-              remote: https://rubygems.org/
-              specs:
-                sorbet (0.5.0000)
-          RB
           @project.write("a.rb", <<~RB)
             # typed: false
             class Foo

--- a/test/spoom/sorbet/version_test.rb
+++ b/test/spoom/sorbet/version_test.rb
@@ -29,6 +29,48 @@ module Spoom
         version = Spoom::Sorbet.srb_version(path: @project.path)
         assert_match(/\d\.\d\.\d{4}/, version)
       end
+
+      def test_srb_version_from_gemfile_lock_return_nil_if_no_gemfile_lock
+        version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: @project.path)
+        assert_nil(version)
+      end
+
+      def test_srb_version_from_gemfile_lock_return_nil_if_gemfil_lock_does_not_contain_sorbet
+        @project.write("Gemfile.lock", "")
+        version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: @project.path)
+        assert_nil(version)
+      end
+
+      def test_srb_version_from_gemfile_lock_return_sorbet_version
+        @project.write("Gemfile.lock", <<~STR)
+          PATH
+            remote: .
+            specs:
+              test (1.0.0)
+                sorbet (~> 0.5.5)
+                sorbet-runtime
+
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              sorbet (0.5.5916)
+                sorbet-static (= 0.5.5916)
+              sorbet-runtime (0.5.5916)
+              sorbet-static (0.5.5916-universal-darwin-14)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            bundler (~> 1.17)
+            test!
+
+          BUNDLED WITH
+             1.17.3
+        STR
+        version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: @project.path)
+        assert_equal("0.5.5916", version)
+      end
     end
   end
 end

--- a/test/spoom/sorbet/version_test.rb
+++ b/test/spoom/sorbet/version_test.rb
@@ -8,22 +8,26 @@ module Spoom
     class VersionTest < Minitest::Test
       include Spoom::TestHelper
 
-      def test_return_nil_if_srb_not_installed
-        project = spoom_project("test_return_nil_if_srb_not_installed")
-        project.gemfile("")
-        Bundler.with_clean_env do
-          version = Spoom::Sorbet.srb_version(path: project.path, capture_err: true)
-          assert_nil(version)
-        end
-        project.destroy
+      def setup
+        @project = spoom_project("test_version")
       end
 
-      def test_return_version_string
-        project = spoom_project("test_return_version_string")
-        project.sorbet_config(".")
-        version = Spoom::Sorbet.srb_version(path: project.path)
+      def teardown
+        @project.destroy
+      end
+
+      def test_srb_version_return_nil_if_srb_not_installed
+        @project.gemfile("")
+        Bundler.with_clean_env do
+          version = Spoom::Sorbet.srb_version(path: @project.path, capture_err: true)
+          assert_nil(version)
+        end
+      end
+
+      def test_srb_version_return_version_string
+        @project.sorbet_config(".")
+        version = Spoom::Sorbet.srb_version(path: @project.path)
         assert_match(/\d\.\d\.\d{4}/, version)
-        project.destroy
       end
     end
   end

--- a/test/spoom/sorbet/version_test.rb
+++ b/test/spoom/sorbet/version_test.rb
@@ -27,7 +27,8 @@ module Spoom
       def test_srb_version_return_version_string
         @project.sorbet_config(".")
         version = Spoom::Sorbet.srb_version(path: @project.path)
-        assert_match(/\d\.\d\.\d{4}/, version)
+        version = censor_sorbet_version(version) if version
+        assert_equal("X.X.XXXX", version)
       end
 
       def test_srb_version_from_gemfile_lock_return_nil_if_no_gemfile_lock

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,12 @@ module Spoom
       path = File.dirname(path)       # spoom/
       File.expand_path(path)
     end
+
+    # Replace all sorbet-like version "0.5.5888" in `test` by "X.X.XXXX"
+    sig { params(text: String).returns(String) }
+    def censor_sorbet_version(text)
+      text.gsub(/\d\.\d\.\d{4}/, "X.X.XXXX")
+    end
   end
 end
 


### PR DESCRIPTION
Spoom now provides two ways to get the Sorbet version used:

1. Through `Spoom::Sorbet.srb_version` which runs `bundle exec sorbet --version`.
2. Through `Spoom::Sorbet.srb_version_from_gemfile_lock` which parses the content of the `Gemfile.lock` for the current commit.

This makes us able to save the sorbet version used for a snapshot for the two cases we have in `spoom timeline`:

1. We don't use `--bundle-install` so we read the version from the `Gemfile.lock` (useful when running the timeline from another context, like we do in `sorbet-metrics` for core).
2. We use `--bundle-install` so we can just ask Sorbet.