### PR TITLE
Add `--save` to `spoom coverage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,16 @@ Show typing coverage evolution based on the commits history between specific dat
 $ spoom coverage timeline --from YYYY-MM-DD --to YYYY-MM-DD
 ```
 
+Save the typing coverage evolution as JSON under `spoom_data/`:
+
+```
+$ spoom coverage timeline --save
+```
+
 Save the typing coverage evolution as JSON in a specific directory:
 
 ```
-$ spoom coverage timeline --save-dir data/
+$ spoom coverage timeline --save --save_dir my_data/
 ```
 
 Run `bundle install` for each commit of the timeline (may solve errors due to different Sorbet versions):

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Show metrics about the project contents and the typing coverage:
 $ spoom coverage
 ```
 
+Save coverage data under `spoom_data/`:
+
+```
+$ spoom coverage --save
+```
+
+Save coverage data under a specific directory:
+
+```
+$ spoom coverage --save --save-dir my_data/
+```
+
 Show typing coverage evolution based on the commits history:
 
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ spoom coverage --save
 Save coverage data under a specific directory:
 
 ```
-$ spoom coverage --save --save-dir my_data/
+$ spoom coverage --save my_data/
 ```
 
 Show typing coverage evolution based on the commits history:
@@ -115,7 +115,7 @@ $ spoom coverage timeline --save
 Save the typing coverage evolution as JSON in a specific directory:
 
 ```
-$ spoom coverage timeline --save --save_dir my_data/
+$ spoom coverage timeline --save my_data/
 ```
 
 Run `bundle install` for each commit of the timeline (may solve errors due to different Sorbet versions):

--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -25,7 +25,8 @@ module Spoom
         desc "timeline", "replay a project and collect metrics"
         option :from, type: :string
         option :to, type: :string, default: Time.now.strftime("%F")
-        option :save_dir, type: :string
+        option :save, type: :boolean, desc: "Save timeline data as json"
+        option :save_dir, type: :string, desc: "Save json data under a specific directory", default: "spoom_data"
         option :bundle_install, type: :boolean, desc: "Execute `bundle install` before collecting metrics"
         def timeline
           in_sorbet_project!
@@ -45,7 +46,7 @@ module Spoom
             exit(1)
           end
 
-          save_dir = options[:save_dir]
+          save_dir = options[:save] ? options[:save_dir] : nil
           FileUtils.mkdir_p(save_dir) if save_dir
 
           from = parse_date(options[:from], "--from")

--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -82,8 +82,6 @@ module Spoom
             end
             next unless snapshot
 
-            snapshot.commit_sha = sha
-            snapshot.commit_timestamp = date&.strftime('%s').to_i
             snapshot.print(indent_level: 2)
             puts "\n"
 

--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -11,11 +11,12 @@ module Spoom
       class Coverage < Thor
         include Spoom::Cli::CommandHelper
 
+        DATA_DIR = "spoom_data"
+
         default_task :snapshot
 
         desc "snapshot", "run srb tc and display metrics"
-        option :save, type: :boolean, desc: "Save snapshot data as json"
-        option :save_dir, type: :string, desc: "Save json data under a specific directory", default: "spoom_data"
+        option :save, type: :string, desc: "Save snapshot data as json", lazy_default: DATA_DIR
         def snapshot
           in_sorbet_project!
 
@@ -23,9 +24,8 @@ module Spoom
           snapshot = Spoom::Coverage.snapshot(path: path)
           snapshot.print
 
-          save_dir = options[:save] ? options[:save_dir] : nil
+          save_dir = options[:save]
           return unless save_dir
-
           FileUtils.mkdir_p(save_dir)
           name = snapshot.commit_sha
           name = Time.now.getutc.to_i unless name
@@ -37,8 +37,7 @@ module Spoom
         desc "timeline", "replay a project and collect metrics"
         option :from, type: :string
         option :to, type: :string, default: Time.now.strftime("%F")
-        option :save, type: :boolean, desc: "Save timeline data as json"
-        option :save_dir, type: :string, desc: "Save json data under a specific directory", default: "spoom_data"
+        option :save, type: :string, desc: "Save snapshot data as json", lazy_default: DATA_DIR
         option :bundle_install, type: :boolean, desc: "Execute `bundle install` before collecting metrics"
         def timeline
           in_sorbet_project!
@@ -58,7 +57,7 @@ module Spoom
             exit(1)
           end
 
-          save_dir = options[:save] ? options[:save_dir] : nil
+          save_dir = options[:save]
           FileUtils.mkdir_p(save_dir) if save_dir
 
           from = parse_date(options[:from], "--from")

--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -11,6 +11,10 @@ module Spoom
       metrics = Spoom::Sorbet.srb_metrics(path: path, capture_err: true)
       return snapshot unless metrics
 
+      sha = Spoom::Git.last_commit(path: path)
+      snapshot.commit_sha = sha
+      snapshot.commit_timestamp = Spoom::Git.commit_timestamp(sha, path: path).to_i if sha
+
       snapshot.files = metrics.fetch("types.input.files", 0)
       snapshot.modules = metrics.fetch("types.input.modules.total", 0)
       snapshot.classes = metrics.fetch("types.input.classes.total", 0)

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -82,6 +82,7 @@ module Spoom
               typed: 8 (89%)
               untyped: 1 (11%)
           MSG
+          assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
         end
 
         def test_display_metrics_do_not_show_errors
@@ -112,6 +113,19 @@ module Spoom
               typed: 8 (67%)
               untyped: 4 (33%)
           MSG
+          assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+        end
+
+        def test_save_snapshot
+          _, _, status = @project.bundle_exec("spoom coverage snapshot --save")
+          assert(status)
+          assert_equal(1, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+        end
+
+        def test_save_snapshot_with_custom_dir
+          _, _, status = @project.bundle_exec("spoom coverage snapshot --save --save-dir data")
+          assert(status)
+          assert_equal(1, Dir.glob("#{@project.path}/data/*.json").size)
         end
 
         def test_display_metrics_with_path_option
@@ -140,6 +154,7 @@ module Spoom
               untyped: 1 (11%)
           MSG
           project.destroy
+          assert_equal(0, Dir.glob("#{project.path}/spoom_data/*.json").size)
         end
 
         def test_timeline_outside_sorbet_dir

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -182,6 +182,7 @@ module Spoom
 
           OUT
           assert_equal("", err)
+          assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
         end
 
         def test_timeline_multiple_commits
@@ -255,6 +256,7 @@ module Spoom
 
           OUT
           assert_equal("", err)
+          assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
         end
 
         def test_timeline_multiple_commits_between_dates
@@ -306,23 +308,25 @@ module Spoom
 
           OUT
           assert_equal("", err)
+          assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
         end
 
         def test_timeline_multiple_commits_and_save_json
           create_git_history
-          _, err, status = @project.bundle_exec("spoom coverage timeline  --save-dir spoom_data")
+          assert(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+          _, err, status = @project.bundle_exec("spoom coverage timeline --save --save-dir data")
           assert(status)
           assert_equal("", err)
-          assert(3, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+          assert_equal(3, Dir.glob("#{@project.path}/data/*.json").size)
         end
 
         def test_timeline_with_path_option
           create_git_history
           project = spoom_project("test_display_metrics_with_path_option")
-          _, err, status = project.bundle_exec("spoom coverage timeline --save-dir spoom_data -p #{@project.path}")
+          _, err, status = project.bundle_exec("spoom coverage timeline --save -p #{@project.path}")
           assert(status)
           assert_equal("", err)
-          assert(3, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+          assert_equal(3, Dir.glob("#{project.path}/spoom_data/*.json").size)
           project.destroy
         end
 

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -123,7 +123,7 @@ module Spoom
         end
 
         def test_save_snapshot_with_custom_dir
-          _, _, status = @project.bundle_exec("spoom coverage snapshot --save --save-dir data")
+          _, _, status = @project.bundle_exec("spoom coverage snapshot --save data")
           assert(status)
           assert_equal(1, Dir.glob("#{@project.path}/data/*.json").size)
         end
@@ -329,7 +329,7 @@ module Spoom
         def test_timeline_multiple_commits_and_save_json
           create_git_history
           assert(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
-          _, err, status = @project.bundle_exec("spoom coverage timeline --save --save-dir data")
+          _, err, status = @project.bundle_exec("spoom coverage timeline --save data")
           assert(status)
           assert_equal("", err)
           assert_equal(3, Dir.glob("#{@project.path}/data/*.json").size)


### PR DESCRIPTION
This PR does two things: 

1. First, this PR splits the current `--save-dir PATH` into two options: `--save` to ask for save and `--save-dir` to specify the path. This is because I'm tired of typing `--save-dir PATH` when I just want to save to the default dir.

2. Then it reuses these two options on `spoom coverage snapshot` so I don't have to run `spoom coverage snapshot --from F --to T` just to save the snapshot on the current commit (this also makes it easier to get the upcoming `spoom report` feature working with default dirs).