### PR TITLE
Some renaming inside Spoom::Git

### DIFF
--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -60,8 +60,8 @@ module Spoom
           save_dir = options[:save]
           FileUtils.mkdir_p(save_dir) if save_dir
 
-          from = parse_date(options[:from], "--from")
-          to = parse_date(options[:to], "--to")
+          from = parse_time(options[:from], "--from")
+          to = parse_time(options[:to], "--to")
 
           unless from
             intro_sha = Spoom::Git.sorbet_intro_commit(path: path)
@@ -106,7 +106,7 @@ module Spoom
         end
 
         no_commands do
-          def parse_date(string, option)
+          def parse_time(string, option)
             return nil unless string
             Time.parse(string)
           rescue ArgumentError

--- a/lib/spoom/cli/commands/coverage.rb
+++ b/lib/spoom/cli/commands/coverage.rb
@@ -66,7 +66,7 @@ module Spoom
           unless from
             intro_sha = Spoom::Git.sorbet_intro_commit(path: path)
             intro_sha = T.must(intro_sha) # we know it's in there since in_sorbet_project!
-            from = Spoom::Git.commit_date(intro_sha, path: path)
+            from = Spoom::Git.commit_time(intro_sha, path: path)
           end
 
           timeline = Spoom::Timeline.new(from, to, path: path)
@@ -78,7 +78,7 @@ module Spoom
           end
 
           ticks.each_with_index do |sha, i|
-            date = Spoom::Git.commit_date(sha, path: path)
+            date = Spoom::Git.commit_time(sha, path: path)
             puts "Analyzing commit #{sha} - #{date&.strftime('%F')} (#{i + 1} / #{ticks.size})"
 
             Spoom::Git.checkout(sha, path: path)

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -63,7 +63,7 @@ module Spoom
     def self.commit_date(sha, path: ".")
       timestamp = commit_timestamp(sha, path: path)
       return nil unless timestamp
-      timestamp_to_date(timestamp.to_s)
+      epoch_to_time(timestamp.to_s)
     end
 
     # Get the last commit sha
@@ -76,7 +76,7 @@ module Spoom
 
     # Translate a git epoch timestamp into a Time
     sig { params(timestamp: String).returns(Time) }
-    def self.timestamp_to_date(timestamp)
+    def self.epoch_to_time(timestamp)
       Time.strptime(timestamp, "%s")
     end
 

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -60,7 +60,7 @@ module Spoom
 
     # Get the commit Time for a `sha`
     sig { params(sha: String, path: String).returns(T.nilable(Time)) }
-    def self.commit_date(sha, path: ".")
+    def self.commit_time(sha, path: ".")
       timestamp = commit_timestamp(sha, path: path)
       return nil unless timestamp
       epoch_to_time(timestamp.to_s)

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -53,12 +53,12 @@ module Spoom
         assert_equal(date.strftime("%s").to_i, Spoom::Git.commit_timestamp(T.must(sha), path: @project.path))
       end
 
-      def test_commit_date
+      def test_commit_time
         date = Time.parse("1987-02-05 09:00:00")
         @project.write("file")
         @project.commit(date: date)
         sha = Spoom::Git.last_commit(path: @project.path)
-        assert_equal(date, Spoom::Git.commit_date(T.must(sha), path: @project.path))
+        assert_equal(date, Spoom::Git.commit_time(T.must(sha), path: @project.path))
       end
 
       def test_git_diff


### PR DESCRIPTION
It's named `_date` but returns a `Time`.

I was about to do the same thing for `Spoom::Timeline::commits_for_dates` but `commits_for_times` was confusing along with `ticks` (like in "one times two"). Let me know if you want me to rename it too.