### PR TITLE
Manually parse version from Gemfile.lock

### DIFF
--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -28,7 +28,7 @@ module Spoom
         snapshot.sigils[strictness] = T.must(metrics["types.input.files.sigil.#{strictness}"])
       end
 
-      snapshot.sorbet_version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: path)
+      snapshot.sorbet_version = Spoom::Sorbet.version_from_gemfile_lock(path: path)
 
       snapshot
     end

--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -55,20 +55,6 @@ module Spoom
       out.split(" ")[2]
     end
 
-    # Get `sorbet` version from the `Gemfile.lock` content
-    #
-    # Returns `nil` if `sorbet` gem cannot be found in the Gemfile.
-    sig { params(path: String).returns(T.nilable(String)) }
-    def self.srb_version_from_gemfile_lock(path: '.')
-      gemfile_path = "#{path}/Gemfile.lock"
-      return nil unless File.exist?(gemfile_path)
-      gemfile_lock = Bundler.read_file(gemfile_path)
-      parser = Bundler::LockfileParser.new(gemfile_lock)
-      sorbet = parser.specs.find { |spec| spec.name == "sorbet" }
-      return nil unless sorbet
-      sorbet.version.to_s
-    end
-
     sig { params(arg: String, path: String, capture_err: T::Boolean).returns(T.nilable(T::Hash[String, Integer])) }
     def self.srb_metrics(*arg, path: '.', capture_err: false)
       metrics_file = "metrics.tmp"
@@ -80,6 +66,18 @@ module Spoom
         return metrics
       end
       nil
+    end
+
+    # Get `gem` version from the `Gemfile.lock` content
+    #
+    # Returns `nil` if `gem` cannot be found in the Gemfile.
+    sig { params(gem: String, path: String).returns(T.nilable(String)) }
+    def self.version_from_gemfile_lock(gem: 'sorbet', path: '.')
+      gemfile_path = "#{path}/Gemfile.lock"
+      return nil unless File.exist?(gemfile_path)
+      content = File.read(gemfile_path).match(/^    #{gem} \(.*(\d+\.\d+\.\d+).*\)/)
+      return nil unless content
+      content[1]
     end
   end
 end

--- a/test/spoom/sorbet/version_test.rb
+++ b/test/spoom/sorbet/version_test.rb
@@ -31,18 +31,18 @@ module Spoom
         assert_equal("X.X.XXXX", version)
       end
 
-      def test_srb_version_from_gemfile_lock_return_nil_if_no_gemfile_lock
-        version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: @project.path)
+      def test_version_from_gemfile_lock_return_nil_if_no_gemfile_lock
+        version = Spoom::Sorbet.version_from_gemfile_lock(path: @project.path)
         assert_nil(version)
       end
 
-      def test_srb_version_from_gemfile_lock_return_nil_if_gemfil_lock_does_not_contain_sorbet
+      def test_version_from_gemfile_lock_return_nil_if_gemfil_lock_does_not_contain_sorbet
         @project.write("Gemfile.lock", "")
-        version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: @project.path)
+        version = Spoom::Sorbet.version_from_gemfile_lock(path: @project.path)
         assert_nil(version)
       end
 
-      def test_srb_version_from_gemfile_lock_return_sorbet_version
+      def test_version_from_gemfile_lock_return_sorbet_version
         @project.write("Gemfile.lock", <<~STR)
           PATH
             remote: .
@@ -54,10 +54,10 @@ module Spoom
           GEM
             remote: https://rubygems.org/
             specs:
-              sorbet (0.5.5916)
-                sorbet-static (= 0.5.5916)
-              sorbet-runtime (0.5.5916)
-              sorbet-static (0.5.5916-universal-darwin-14)
+              sorbet (0.5.5001)
+                sorbet-static (= 0.X.XXXX)
+              sorbet-runtime (0.5.5002)
+              sorbet-static (0.5.5003)
 
           PLATFORMS
             ruby
@@ -69,8 +69,9 @@ module Spoom
           BUNDLED WITH
              1.17.3
         STR
-        version = Spoom::Sorbet.srb_version_from_gemfile_lock(path: @project.path)
-        assert_equal("0.5.5916", version)
+        assert_equal("0.5.5001", Spoom::Sorbet.version_from_gemfile_lock(gem: "sorbet", path: @project.path))
+        assert_equal("0.5.5002", Spoom::Sorbet.version_from_gemfile_lock(gem: "sorbet-runtime", path: @project.path))
+        assert_equal("0.5.5003", Spoom::Sorbet.version_from_gemfile_lock(gem: "sorbet-static", path: @project.path))
       end
     end
   end


### PR DESCRIPTION
It turns out that you can't even _parse_ a Gemfile.lock from another version Bundle version (it raises).

This PR gets the version from the `Gemfile.lock` manually instead.

I also added a way to specify which gem you want the version from, can be useful to collect the info about `sorbet-runtime` (see test).