### PR TITLE
Also store sorbet-runtime version

### DIFF
--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -31,7 +31,8 @@ module Spoom
         snapshot.sigils[strictness] = T.must(metrics["types.input.files.sigil.#{strictness}"])
       end
 
-      snapshot.sorbet_version = Spoom::Sorbet.version_from_gemfile_lock(path: path)
+      snapshot.version_static = Spoom::Sorbet.version_from_gemfile_lock(gem: "sorbet-static", path: path)
+      snapshot.version_runtime = Spoom::Sorbet.version_from_gemfile_lock(gem: "sorbet-runtime", path: path)
 
       snapshot
     end
@@ -40,7 +41,8 @@ module Spoom
       extend T::Sig
 
       prop :timestamp, Integer, default: Time.new.getutc.to_i
-      prop :sorbet_version, T.nilable(String), default: nil
+      prop :version_static, T.nilable(String), default: nil
+      prop :version_runtime, T.nilable(String), default: nil
       prop :duration, Integer, default: 0
       prop :commit_sha, T.nilable(String), default: nil
       prop :commit_timestamp, T.nilable(Integer), default: nil
@@ -71,7 +73,8 @@ module Spoom
       def self.from_obj(obj)
         snapshot = Snapshot.new
         snapshot.timestamp = obj.fetch("timestamp", 0)
-        snapshot.sorbet_version = obj.fetch("sorbet_version", nil)
+        snapshot.version_static = obj.fetch("version_static", nil)
+        snapshot.version_runtime = obj.fetch("version_runtime", nil)
         snapshot.duration = obj.fetch("duration", 0)
         snapshot.commit_sha = obj.fetch("commit_sha", nil)
         snapshot.commit_timestamp = obj.fetch("commit_timestamp", nil)
@@ -108,8 +111,9 @@ module Spoom
         methods = snapshot.methods_with_sig + snapshot.methods_without_sig
         calls = snapshot.calls_typed + snapshot.calls_untyped
 
-        if snapshot.sorbet_version
-          printl("Sorbet version: #{snapshot.sorbet_version}")
+        if snapshot.version_static || snapshot.version_runtime
+          printl("Sorbet static: #{snapshot.version_static}") if snapshot.version_static
+          printl("Sorbet runtime: #{snapshot.version_runtime}") if snapshot.version_runtime
           printn
         end
         printl("Content:")

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -20,12 +20,12 @@ module Spoom
               remote: .
               specs:
                 test (1.0.0)
-                  sorbet (~> 0.5.5)
+                  sorbet-static (~> 0.5.5)
 
             GEM
               remote: https://rubygems.org/
               specs:
-                sorbet (0.5.0000)
+                sorbet-static (0.5.0000)
           RB
           @project.write("lib/a.rb", <<~RB)
             # typed: false
@@ -62,7 +62,7 @@ module Spoom
           out, _ = @project.bundle_exec("spoom coverage snapshot")
           out = censor_sorbet_version(out) if out
           assert_equal(<<~MSG, out)
-            Sorbet version: X.X.XXXX
+            Sorbet static: X.X.XXXX
 
             Content:
               files: 3
@@ -93,7 +93,7 @@ module Spoom
           out, _ = @project.bundle_exec("spoom coverage snapshot")
           out = censor_sorbet_version(out) if out
           assert_equal(<<~MSG, out)
-            Sorbet version: X.X.XXXX
+            Sorbet static: X.X.XXXX
 
             Content:
               files: 4
@@ -133,7 +133,7 @@ module Spoom
           out, _ = project.bundle_exec("spoom coverage snapshot -p #{@project.path}")
           out = censor_sorbet_version(out) if out
           assert_equal(<<~MSG, out)
-            Sorbet version: X.X.XXXX
+            Sorbet static: X.X.XXXX
 
             Content:
               files: 3
@@ -175,7 +175,7 @@ module Spoom
           out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
           assert_equal(<<~OUT, out)
             Analyzing COMMIT (1 / 1)
-              Sorbet version: 0.5.0000
+              Sorbet static: 0.5.0000
 
               Content:
                 files: 3
@@ -207,7 +207,7 @@ module Spoom
           out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
           assert_equal(<<~OUT, out)
             Analyzing COMMIT (1 / 3)
-              Sorbet version: 0.5.0000
+              Sorbet static: 0.5.0000
 
               Content:
                 files: 2
@@ -227,7 +227,7 @@ module Spoom
                 typed: 6 (100%)
 
             Analyzing COMMIT (2 / 3)
-              Sorbet version: 0.5.1000
+              Sorbet static: 0.5.1000
 
               Content:
                 files: 4
@@ -248,7 +248,8 @@ module Spoom
                 typed: 7 (100%)
 
             Analyzing COMMIT (3 / 3)
-              Sorbet version: 0.5.2000
+              Sorbet static: 0.5.2000
+              Sorbet runtime: 0.5.3000
 
               Content:
                 files: 6
@@ -281,7 +282,7 @@ module Spoom
           out&.gsub!(/commit [a-f0-9]+ - \d{4}-\d{2}-\d{2}/, "COMMIT")
           assert_equal(<<~OUT, out)
             Analyzing COMMIT (1 / 2)
-              Sorbet version: 0.5.0000
+              Sorbet static: 0.5.0000
 
               Content:
                 files: 2
@@ -301,7 +302,7 @@ module Spoom
                 typed: 6 (100%)
 
             Analyzing COMMIT (2 / 2)
-              Sorbet version: 0.5.1000
+              Sorbet static: 0.5.1000
 
               Content:
                 files: 4
@@ -373,12 +374,12 @@ module Spoom
               remote: .
               specs:
                 test (1.0.0)
-                  sorbet (~> 0.5.5)
+                  sorbet-static (~> 0.5.5)
 
             GEM
               remote: https://rubygems.org/
               specs:
-                sorbet (0.5.1000)
+                sorbet-static (0.5.1000)
           RB
           @project.write("c.rb", <<~RB)
             # typed: false
@@ -394,12 +395,13 @@ module Spoom
               remote: .
               specs:
                 test (1.0.0)
-                  sorbet (~> 0.5.5)
+                  sorbet-static (~> 0.5.5)
 
             GEM
               remote: https://rubygems.org/
               specs:
-                sorbet (0.5.2000)
+                sorbet-static (0.5.2000)
+                sorbet-runtime (0.5.3000)
           RB
           @project.write("e.rb", "# typed: ignore")
           @project.write("f.rb", "# typed: __INTERNAL_STDLIB")

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -20,7 +20,7 @@ module Spoom
 
       def test_serialize_snapshot_data
         snapshot1 = Spoom::Coverage::Snapshot.new
-        snapshot1.sorbet_version = "sorbet_version"
+        snapshot1.version_static = "sorbet_version"
         snapshot1.commit_sha = "commit_sha"
         snapshot1.commit_timestamp = 1
         snapshot1.files = 2
@@ -37,7 +37,7 @@ module Spoom
         json2 = snapshot2.to_json
 
         assert_equal(json1, json2)
-        assert_equal("sorbet_version", snapshot2.sorbet_version)
+        assert_equal("sorbet_version", snapshot2.version_static)
         assert_equal(2, snapshot2.files)
         assert_equal(10, snapshot2.sigils["true"])
       end


### PR DESCRIPTION
Use #36 to keep track of both `sorbet-static` and `sorbet-runtime` versions.

This can be used to build a graph showing when the versions are diverging:

![image](https://user-images.githubusercontent.com/583144/95608842-bd41a700-0a2b-11eb-9312-1f082937cfdd.png)
