### PR TITLE
Add Snapshot metrics for singleton classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,10 +45,10 @@ GEM
     rubocop-sorbet (0.4.0)
       rubocop
     ruby-progressbar (1.10.1)
-    sorbet (0.5.5916)
-      sorbet-static (= 0.5.5916)
-    sorbet-runtime (0.5.5916)
-    sorbet-static (0.5.5916-universal-darwin-14)
+    sorbet (0.5.5943)
+      sorbet-static (= 0.5.5943)
+    sorbet-runtime (0.5.5943)
+    sorbet-static (0.5.5943-universal-darwin-14)
     thor (1.0.1)
     unicode-display_width (1.7.0)
 

--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -83,7 +83,7 @@ module Spoom
         snapshot.files = obj.fetch("files", 0)
         snapshot.modules = obj.fetch("modules", 0)
         snapshot.classes = obj.fetch("classes", 0)
-        snapshot.singleton_classes = obj.fetch("singleton_lasses", 0)
+        snapshot.singleton_classes = obj.fetch("singleton_classes", 0)
         snapshot.methods_with_sig = obj.fetch("methods_with_sig", 0)
         snapshot.methods_without_sig = obj.fetch("methods_without_sig", 0)
         snapshot.calls_typed = obj.fetch("calls_typed", 0)

--- a/lib/spoom/snapshot.rb
+++ b/lib/spoom/snapshot.rb
@@ -18,6 +18,7 @@ module Spoom
       snapshot.files = metrics.fetch("types.input.files", 0)
       snapshot.modules = metrics.fetch("types.input.modules.total", 0)
       snapshot.classes = metrics.fetch("types.input.classes.total", 0)
+      snapshot.singleton_classes = metrics.fetch("types.input.singleton_classes.total", 0)
       snapshot.methods_with_sig = metrics.fetch("types.sig.count", 0)
       snapshot.methods_without_sig = metrics.fetch("types.input.methods.total", 0) - snapshot.methods_with_sig
       snapshot.calls_typed = metrics.fetch("types.input.sends.typed", 0)
@@ -49,6 +50,7 @@ module Spoom
       prop :files, Integer, default: 0
       prop :modules, Integer, default: 0
       prop :classes, Integer, default: 0
+      prop :singleton_classes, Integer, default: 0
       prop :methods_without_sig, Integer, default: 0
       prop :methods_with_sig, Integer, default: 0
       prop :calls_untyped, Integer, default: 0
@@ -81,6 +83,7 @@ module Spoom
         snapshot.files = obj.fetch("files", 0)
         snapshot.modules = obj.fetch("modules", 0)
         snapshot.classes = obj.fetch("classes", 0)
+        snapshot.singleton_classes = obj.fetch("singleton_lasses", 0)
         snapshot.methods_with_sig = obj.fetch("methods_with_sig", 0)
         snapshot.methods_without_sig = obj.fetch("methods_without_sig", 0)
         snapshot.calls_typed = obj.fetch("calls_typed", 0)
@@ -120,7 +123,7 @@ module Spoom
         indent
         printl("files: #{snapshot.files}")
         printl("modules: #{snapshot.modules}")
-        printl("classes: #{snapshot.classes} (including singleton classes)")
+        printl("classes: #{snapshot.classes - snapshot.singleton_classes}")
         printl("methods: #{methods}")
         dedent
         printn

--- a/test/spoom/cli/commands/coverage_test.rb
+++ b/test/spoom/cli/commands/coverage_test.rb
@@ -67,7 +67,7 @@ module Spoom
             Content:
               files: 3
               modules: 3
-              classes: 5 (including singleton classes)
+              classes: 1
               methods: 9
 
             Sigils:
@@ -98,7 +98,7 @@ module Spoom
             Content:
               files: 4
               modules: 3
-              classes: 5 (including singleton classes)
+              classes: 1
               methods: 10
 
             Sigils:
@@ -138,7 +138,7 @@ module Spoom
             Content:
               files: 3
               modules: 3
-              classes: 5 (including singleton classes)
+              classes: 1
               methods: 9
 
             Sigils:
@@ -180,7 +180,7 @@ module Spoom
               Content:
                 files: 3
                 modules: 3
-                classes: 5 (including singleton classes)
+                classes: 1
                 methods: 9
 
               Sigils:
@@ -212,7 +212,7 @@ module Spoom
               Content:
                 files: 2
                 modules: 1
-                classes: 3 (including singleton classes)
+                classes: 1
                 methods: 6
 
               Sigils:
@@ -232,7 +232,7 @@ module Spoom
               Content:
                 files: 4
                 modules: 1
-                classes: 5 (including singleton classes)
+                classes: 2
                 methods: 9
 
               Sigils:
@@ -254,7 +254,7 @@ module Spoom
               Content:
                 files: 6
                 modules: 1
-                classes: 5 (including singleton classes)
+                classes: 2
                 methods: 10
 
               Sigils:
@@ -287,7 +287,7 @@ module Spoom
               Content:
                 files: 2
                 modules: 1
-                classes: 3 (including singleton classes)
+                classes: 1
                 methods: 6
 
               Sigils:
@@ -307,7 +307,7 @@ module Spoom
               Content:
                 files: 4
                 modules: 1
-                classes: 5 (including singleton classes)
+                classes: 2
                 methods: 9
 
               Sigils:


### PR DESCRIPTION
Since https://github.com/sorbet/sorbet/pull/3446 was merged upstream we can provide a more accurate number for the amount of classes in the project by subtracting the number of singleton classes.

This PR changes the output of `spoom coverage snapshot` and the related tests to reflect that.