### PR TITLE
Avoid crashing on non-existing path when calling `git`

### DIFF
--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -11,6 +11,7 @@ module Spoom
     # Execute a `command`
     sig { params(command: String, arg: String, path: String).returns([String, String, T::Boolean]) }
     def self.exec(command, *arg, path: '.')
+      return "", "Error: `#{path}` is not a directory.", false unless File.directory?(path)
       opts = {}
       opts[:chdir] = path
       _, o, e, s = Open3.popen3(*T.unsafe([command, *T.unsafe(arg), opts]))

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -17,6 +17,12 @@ module Spoom
         @project.destroy
       end
 
+      def test_exec_with_unexisting_path
+        _, err, status = Spoom::Git.exec("git ls", path: "/path/not/found")
+        assert_equal("Error: `/path/not/found` is not a directory.", err)
+        refute(status)
+      end
+
       def test_last_commit_if_not_git_dir
         @project.remove(".git")
         assert(Spoom::Git.last_commit(path: @project.path).nil?)


### PR DESCRIPTION
There is no way to reach this state with normal CLI use but it's possible to get to this state using the API directly.

Since all the methods in this module return an error string + status if something go wrong with the `git` command, we reuse the same mechanism instead of raising for this error so client only have one thing to check.

This change also makes testing with incomplete file hierarchies easier.