### PR TITLE
Allow to customize colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,21 @@ Run `bundle install` for each commit of the timeline (may solve errors due to di
 $ spoom coverage timeline --bundle-install
 ```
 
-Generate a HTML typing coverage report:
+Generate an HTML typing coverage report:
 
 ```
 $ spoom coverage report
+```
+
+Change the colors used for strictnesses (useful for colorblind folks):
+
+```
+$ spoom coverage report \
+  --color-true "#648ffe" \
+  --color-false "#fe6002" \
+  --color-ignore "#feb000" \
+  --color-strict "#795ef0" \
+  --color-strong "#6444f1"
 ```
 
 Open the HTML typing coverage report:

--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -104,6 +104,11 @@ module Spoom
       desc "report", "produce a typing coverage report"
       option :data, type: :string, desc: "Snapshots JSON data", default: DATA_DIR
       option :file, type: :string, default: "spoom_report.html", aliases: :f
+      option :color_ignore, type: :string, default: Spoom::Coverage::D3::COLOR_IGNORE
+      option :color_false, type: :string, default: Spoom::Coverage::D3::COLOR_FALSE
+      option :color_true, type: :string, default: Spoom::Coverage::D3::COLOR_TRUE
+      option :color_strict, type: :string, default: Spoom::Coverage::D3::COLOR_STRICT
+      option :color_strong, type: :string, default: Spoom::Coverage::D3::COLOR_STRONG
       def report
         in_sorbet_project!
 
@@ -119,7 +124,15 @@ module Spoom
           Spoom::Coverage::Snapshot.from_json(json)
         end.filter(&:commit_timestamp).sort_by!(&:commit_timestamp)
 
-        report = Spoom::Coverage.report(snapshots, path: exec_path)
+        palette = Spoom::Coverage::D3::ColorPalette.new(
+          ignore: options[:color_ignore],
+          false: options[:color_false],
+          true: options[:color_true],
+          strict: options[:color_strict],
+          strong: options[:color_strong]
+        )
+
+        report = Spoom::Coverage.report(snapshots, palette: palette, path: exec_path)
         file = options[:file]
         File.write(file, report.html)
         puts "Report generated under #{file}"

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -44,13 +44,14 @@ module Spoom
       snapshot
     end
 
-    sig { params(snapshots: T::Array[Snapshot], path: String).returns(Report) }
-    def self.report(snapshots, path: ".")
+    sig { params(snapshots: T::Array[Snapshot], palette: D3::ColorPalette, path: String).returns(Report) }
+    def self.report(snapshots, palette:, path: ".")
       intro_commit = Git.sorbet_intro_commit(path: path)
       intro_date = intro_commit ? Git.commit_time(intro_commit, path: path) : nil
 
       Report.new(
         project_name: File.basename(File.expand_path(path)),
+        palette: palette,
         snapshots: snapshots,
         sigils_tree: sigils_tree(path: path),
         sorbet_intro_commit: intro_commit,

--- a/lib/spoom/coverage/d3.rb
+++ b/lib/spoom/coverage/d3.rb
@@ -10,6 +10,12 @@ module Spoom
     module D3
       extend T::Sig
 
+      COLOR_IGNORE = "#999"
+      COLOR_FALSE = "#db4437"
+      COLOR_TRUE = "#0f9d58"
+      COLOR_STRICT = "#0a7340"
+      COLOR_STRONG = "#064828"
+
       sig { returns(String) }
       def self.header_style
         <<~CSS
@@ -50,23 +56,25 @@ module Spoom
         CSS
       end
 
-      sig { returns(String) }
-      def self.header_script
+      sig { params(palette: ColorPalette).returns(String) }
+      def self.header_script(palette)
         <<~JS
           var parseDate = d3.timeParse("%s");
 
           function strictnessColor(strictness) {
             switch(strictness) {
+              case "ignore":
+                return "#{palette.ignore}";
               case "false":
-                return "#db4437";
+                return "#{palette.false}";
               case "true":
-                return "#0f9d58";
+                return "#{palette.true}";
               case "strict":
-                return "#0a7340";
+                return "#{palette.strict}";
               case "strong":
-                return "#064828";
+                return "#{palette.strong}";
             }
-            return "#999";
+            return "#{palette.false}";
           }
 
           function toPercent(value, sum) {
@@ -88,6 +96,14 @@ module Spoom
           #{CircleMap.header_script}
           #{Timeline.header_script}
         JS
+      end
+
+      class ColorPalette < T::Struct
+        prop :ignore, String
+        prop :false, String
+        prop :true, String
+        prop :strict, String
+        prop :strong, String
       end
     end
   end

--- a/lib/spoom/coverage/d3/circle_map.rb
+++ b/lib/spoom/coverage/d3/circle_map.rb
@@ -69,7 +69,7 @@ module Spoom
 
             var dirColor = d3.scaleLinear()
               .domain([1, 0])
-              .range(["#0f9d58", "#db4437"])
+              .range([strictnessColor("true"), strictnessColor("false")])
               .interpolate(d3.interpolateRgb);
 
             function redraw() {

--- a/lib/spoom/coverage/report.rb
+++ b/lib/spoom/coverage/report.rb
@@ -46,10 +46,14 @@ module Spoom
       sig { returns(String) }
       attr_reader :title
 
-      sig { params(title: String, template: String).void }
-      def initialize(title:, template: TEMPLATE)
+      sig { returns(D3::ColorPalette) }
+      attr_reader :palette
+
+      sig { params(title: String, palette: D3::ColorPalette, template: String).void }
+      def initialize(title:, palette:, template: TEMPLATE)
         super(template: template)
         @title = title
+        @palette = palette
       end
 
       sig { returns(String) }
@@ -59,7 +63,7 @@ module Spoom
 
       sig { returns(String) }
       def header_script
-        D3.header_script
+        D3.header_script(palette)
       end
 
       sig { returns(String) }
@@ -251,14 +255,22 @@ module Spoom
       sig do
         params(
           project_name: String,
+          palette: D3::ColorPalette,
           snapshots: T::Array[Snapshot],
           sigils_tree: FileTree,
           sorbet_intro_commit: T.nilable(String),
           sorbet_intro_date: T.nilable(Time),
         ).void
       end
-      def initialize(project_name:, snapshots:, sigils_tree:, sorbet_intro_commit: nil, sorbet_intro_date: nil)
-        super(title: project_name)
+      def initialize(
+        project_name:,
+        palette:,
+        snapshots:,
+        sigils_tree:,
+        sorbet_intro_commit: nil,
+        sorbet_intro_date: nil
+      )
+        super(title: project_name, palette: palette)
         @project_name = project_name
         @snapshots = snapshots
         @sigils_tree = sigils_tree


### PR DESCRIPTION
Add a bunch of options so the user can configure the colors used for each strictness in the visualizations:

```bash
$ spoom coverage report \
  --color-true "#648ffe" \
  --color-false "#fe6002" \
  --color-ignore "#feb000" \
  --color-strict "#795ef0" \
  --color-strong "#6444f1"
```

Will give the following output:

![image](https://user-images.githubusercontent.com/583144/99406276-b5dbac00-28bb-11eb-9b6c-feb39e2d5bfc.png)
![image](https://user-images.githubusercontent.com/583144/99406320-c2f89b00-28bb-11eb-9e7d-30dc6adb6e2d.png)
![image](https://user-images.githubusercontent.com/583144/99406376-d0158a00-28bb-11eb-9cf6-4dcc2a3c0362.png)

Helpful for colorblind folks.