### PR TITLE
Allow stripping prefix path from FileTree

### DIFF
--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -48,7 +48,7 @@ module Spoom
         if files.empty?
           say(" NONE")
         else
-          tree = FileTree.new(files)
+          tree = FileTree.new(files, strip_prefix: path)
           tree.print(colors: options[:color], indent_level: 2)
         end
       end

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -67,7 +67,7 @@ module Spoom
       files = Sorbet.srb_files(config, path: path)
       files.select! { |file| file =~ /\.rb$/ }
       files.reject! { |file| file =~ %r{/test/} }
-      FileTree.new(files)
+      FileTree.new(files, strip_prefix: path)
     end
   end
 end

--- a/lib/spoom/coverage/d3/circle_map.rb
+++ b/lib/spoom/coverage/d3/circle_map.rb
@@ -167,7 +167,7 @@ module Spoom
 
           sig { params(node: FileTree::Node).returns(T.nilable(String)) }
           def tree_node_strictness(node)
-            @strictnesses[node] ||= node.strictness
+            @strictnesses[node] ||= Spoom::Sorbet::Sigils.file_strictness(node.path)
           end
 
           sig { params(node: FileTree::Node).returns(Float) }

--- a/lib/spoom/coverage/d3/circle_map.rb
+++ b/lib/spoom/coverage/d3/circle_map.rb
@@ -150,6 +150,7 @@ module Spoom
           def initialize(id, sigils_tree)
             @scores = T.let({}, T::Hash[FileTree::Node, Float])
             @strictnesses = T.let({}, T::Hash[FileTree::Node, T.nilable(String)])
+            @sigils_tree = sigils_tree
             super(id, sigils_tree.roots.map { |r| tree_node_to_json(r) })
           end
 
@@ -167,7 +168,10 @@ module Spoom
 
           sig { params(node: FileTree::Node).returns(T.nilable(String)) }
           def tree_node_strictness(node)
-            @strictnesses[node] ||= Spoom::Sorbet::Sigils.file_strictness(node.path)
+            prefix = @sigils_tree.strip_prefix
+            path = node.path
+            path = "#{prefix}/#{path}" if prefix
+            @strictnesses[node] ||= Spoom::Sorbet::Sigils.file_strictness(path)
           end
 
           sig { params(node: FileTree::Node).returns(Float) }

--- a/lib/spoom/file_tree.rb
+++ b/lib/spoom/file_tree.rb
@@ -95,12 +95,6 @@ module Spoom
         return name unless parent
         "#{parent.path}/#{name}"
       end
-
-      # Strictness of this file (or `nil` if no strictness or the node is a directory)
-      sig { returns(T.nilable(String)) }
-      def strictness
-        Spoom::Sorbet::Sigils.file_strictness(path)
-      end
     end
 
     # An internal class used to print a FileTree
@@ -132,7 +126,7 @@ module Spoom
         printt
         if node.children.empty?
           if @show_strictness
-            strictness = node.strictness
+            strictness = node_strictness(node)
             if @colors
               print_colored(node.name, strictness_color(strictness))
             elsif strictness
@@ -160,6 +154,11 @@ module Spoom
       end
 
       private
+
+      sig { params(node: FileTree::Node).returns(T.nilable(String)) }
+      def node_strictness(node)
+        Spoom::Sorbet::Sigils.file_strictness(node.path)
+      end
 
       sig { params(strictness: T.nilable(String)).returns(Symbol) }
       def strictness_color(strictness)

--- a/lib/spoom/file_tree.rb
+++ b/lib/spoom/file_tree.rb
@@ -62,8 +62,14 @@ module Spoom
       ).void
     end
     def print(out: $stdout, show_strictness: true, colors: true, indent_level: 0)
-      printer = TreePrinter.new(out: out, show_strictness: show_strictness, colors: colors, indent_level: indent_level)
-      printer.print_tree(self)
+      printer = TreePrinter.new(
+        tree: self,
+        out: out,
+        show_strictness: show_strictness,
+        colors: colors,
+        indent_level: indent_level
+      )
+      printer.print_tree
     end
 
     private
@@ -103,21 +109,26 @@ module Spoom
     class TreePrinter < Spoom::Printer
       extend T::Sig
 
+      sig { returns(FileTree) }
+      attr_reader :tree
+
       sig do
         params(
+          tree: FileTree,
           out: T.any(IO, StringIO),
           show_strictness: T::Boolean,
           colors: T::Boolean,
           indent_level: Integer
         ).void
       end
-      def initialize(out: $stdout, show_strictness: true, colors: true, indent_level: 0)
+      def initialize(tree:, out: $stdout, show_strictness: true, colors: true, indent_level: 0)
         super(out: out, colors: colors, indent_level: indent_level)
+        @tree = tree
         @show_strictness = show_strictness
       end
 
-      sig { params(tree: FileTree).void }
-      def print_tree(tree)
+      sig { void }
+      def print_tree
         print_nodes(tree.roots)
       end
 

--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -55,6 +55,7 @@ module Spoom
       # * returns nil if no sigil
       sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
       def self.file_strictness(path)
+        return nil unless File.exist?(path)
         content = File.read(path)
         strictness_in_content(content)
       end

--- a/lib/spoom/test_helpers/project.rb
+++ b/lib/spoom/test_helpers/project.rb
@@ -53,6 +53,12 @@ module Spoom
         FileUtils.rm_rf(absolute_path(rel_path))
       end
 
+      # List all files in this project
+      sig { returns(T::Array[String]) }
+      def files
+        Dir.glob("#{@path}/**/*").sort
+      end
+
       # Actions
 
       # Run `git init` in this project

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -128,14 +128,9 @@ module Spoom
         out, _ = @project.bundle_exec("spoom files --no-color --path #{project.path}")
         assert_equal(<<~MSG, out)
           Files matching `/tmp/spoom/tests/test_files/sorbet/config`:
-            /
-              tmp/
-                spoom/
-                  tests/
-                    test_files/
-                      lib/
-                        file1.rb (true)
-                        file2.rb (true)
+            lib/
+              file1.rb (true)
+              file2.rb (true)
         MSG
       end
     end

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -134,6 +134,11 @@ module Spoom
         project.destroy
       end
 
+      def test_file_strictness_returns_nil_if_file_not_found
+        strictness = Sigils.file_strictness("/file/not/found.rb")
+        assert_nil(strictness)
+      end
+
       def test_file_strictness_with_valid_sigil
         project = spoom_project("test_sigils")
         project.write("file.rb", "# typed: true")


### PR DESCRIPTION
Small improvement to the way we generate the FileTree by allowing the user to specify a prefix path to be stripped.

This is particularly useful when running `spoom` from another directory.

For example if I run `spoom files --path /path/to/project` the file tree will be displayed as:

```
/path
  /to
    /project
      file1.rb
      file2.rb
```

This is okay for most case but becomes problematic when working with relative paths or really long one.

It's also problematic for the circle map where it create useless circles.

Here's an example before:

![image](https://user-images.githubusercontent.com/583144/99589309-cbcf9680-29b9-11eb-84df-94d58b45229f.png)

After:

![image](https://user-images.githubusercontent.com/583144/99589788-7a73d700-29ba-11eb-85d6-eb580398eae3.png)

Overall it makes the FileTree API easier to use from other tools such as SorbetMetrics.