### PR TITLE
Fix tooltip for Sigs Pie

### DIFF
--- a/lib/spoom/coverage/d3/pie.rb
+++ b/lib/spoom/coverage/d3/pie.rb
@@ -164,7 +164,7 @@ module Spoom
           def tooltip
             <<~JS
               function tooltip_#{id}(d) {
-                tooltipPie(d, (d.data.key == "true" ? " with" : " without") + " a signature", "calls", sum_#{id})
+                tooltipPie(d, (d.data.key == "true" ? " with" : " without") + " a signature", "methods", sum_#{id})
               }
             JS
           end


### PR DESCRIPTION
Tooltip for the sigs piechart should talk about `methods`, not `calls`.

Before:

![image](https://user-images.githubusercontent.com/583144/99593027-0425a380-29bf-11eb-85d6-209df5d7f7db.png)

After:

![image](https://user-images.githubusercontent.com/583144/99592958-ebb58900-29be-11eb-89fc-efdd890e35ea.png)
