### PR TITLE
Improvements to `spoom bump`

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -35,12 +35,11 @@ module Spoom
         end
 
         files_to_bump = Sorbet::Sigils.files_with_sigil_strictness(directory, from)
-
         Sorbet::Sigils.change_sigil_in_files(files_to_bump, to)
 
         return if force
 
-        output, no_errors = Sorbet.srb_tc(path: File.expand_path(directory), capture_err: true)
+        output, no_errors = Sorbet.srb_tc(path: exec_path, capture_err: true)
 
         return if no_errors
 

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -34,6 +34,7 @@ module Spoom
           exit(1)
         end
 
+        directory = File.expand_path(directory)
         files_to_bump = Sorbet::Sigils.files_with_sigil_strictness(directory, from)
         Sorbet::Sigils.change_sigil_in_files(files_to_bump, to)
 
@@ -46,8 +47,10 @@ module Spoom
         errors = Sorbet::Errors::Parser.parse_string(output)
 
         files_with_errors = errors.map do |err|
-          path = err.file
-          File.join(directory, path) if path && File.file?(path)
+          path = File.expand_path(err.file)
+          next unless path.start_with?(directory)
+          next unless File.file?(path)
+          path
         end.compact.uniq
 
         Sorbet::Sigils.change_sigil_in_files(files_with_errors, from)

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -51,9 +51,6 @@ module Spoom
 
         Sorbet::Sigils.change_sigil_in_files(files_with_errors, from)
       end
-
-      no_commands do
-      end
     end
   end
 end

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -18,6 +18,8 @@ module Spoom
       option :force, desc: "change strictness without type checking", type: :boolean, default: false, aliases: :f
       sig { params(directory: String).void }
       def bump(directory = ".")
+        in_sorbet_project!
+
         from = options[:from]
         to = options[:to]
         force = options[:force]

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -36,11 +36,11 @@ module Spoom
 
         Sorbet::Sigils.change_sigil_in_files(files_to_bump, to)
 
-        return [] if force
+        return if force
 
         output, no_errors = Sorbet.srb_tc(path: File.expand_path(directory), capture_err: true)
 
-        return [] if no_errors
+        return if no_errors
 
         errors = Sorbet::Errors::Parser.parse_string(output)
 

--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -37,7 +37,11 @@ module Spoom
       sig { void }
       def in_sorbet_project!
         unless in_sorbet_project?
-          say_error("not in a Sorbet project (no sorbet/config)")
+          say_error(
+            "not in a Sorbet project (#{colorize(sorbet_config, :yellow)} not found)\n\n" \
+            "When running spoom from another path than the project's root, " \
+            "use #{colorize('--path PATH', :blue)} to specify the path to the root."
+          )
           Kernel.exit(1)
         end
       end

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -42,16 +42,16 @@ module Spoom
       end
 
       def test_bump_doesnt_change_sigils_outside_directory
-        project = spoom_project("test_bump2")
-        project.write("file1.rb", "# typed: false")
-        @project.write("file2.rb", "# typed: false")
+        @project.write("lib/a/file.rb", "# typed: false")
+        @project.write("lib/b/file.rb", "# typed: false")
+        @project.write("lib/c/file.rb", "# typed: true\n\nfoo.bar")
+        @project.bundle_exec("spoom bump lib/b")
 
-        @project.bundle_exec("spoom bump")
+        assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/lib/a/file.rb"))
+        assert_equal("true", Sorbet::Sigils.file_strictness("#{@project.path}/lib/b/file.rb"))
+        assert_equal("true", Sorbet::Sigils.file_strictness("#{@project.path}/lib/c/file.rb"))
 
-        assert_equal("false", Sorbet::Sigils.file_strictness("#{project.path}/file1.rb"))
-        assert_equal("true", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
-
-        project.destroy
+        @project.destroy
       end
 
       def test_bump_nondefault_from_to_complete

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -17,6 +17,15 @@ module Spoom
         @project.destroy
       end
 
+      def test_bump_outside_sorbet_dir
+        @project.remove("sorbet/config")
+        out, err, status = @project.bundle_exec("spoom bump")
+
+        assert_empty(out)
+        assert_equal("Error: not in a Sorbet project (no sorbet/config)", err.strip)
+        refute(status)
+      end
+
       def test_bump_files_one_error_no_bump_one_no_error_bump
         @project.write("file1.rb", <<~RB)
           # typed: false

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -19,10 +19,9 @@ module Spoom
 
       def test_bump_outside_sorbet_dir
         @project.remove("sorbet/config")
-        out, err, status = @project.bundle_exec("spoom bump")
-
+        out, err, status = @project.bundle_exec("spoom bump --no-color")
         assert_empty(out)
-        assert_equal("Error: not in a Sorbet project (no sorbet/config)", err.strip)
+        assert_equal("Error: not in a Sorbet project (sorbet/config not found)", err.lines.first.chomp)
         refute(status)
       end
 

--- a/test/spoom/cli/config_test.rb
+++ b/test/spoom/cli/config_test.rb
@@ -17,10 +17,10 @@ module Spoom
       end
 
       def test_return_error_if_no_sorbet_config
-        _, err, _ = @project.bundle_exec("spoom config")
-        assert_equal(<<~MSG, err)
-          Error: not in a Sorbet project (no sorbet/config)
-        MSG
+        out, err, status = @project.bundle_exec("spoom config --no-color")
+        assert_empty(out)
+        assert_equal("Error: not in a Sorbet project (sorbet/config not found)", err.lines.first.chomp)
+        refute(status)
       end
 
       def test_display_empty_config

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -82,6 +82,14 @@ module Spoom
         assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
       end
 
+      def test_snapshot_outside_sorbet_dir
+        @project.remove("sorbet/config")
+        out, err, status = @project.bundle_exec("spoom coverage snapshot --no-color")
+        assert_empty(out)
+        assert_equal("Error: not in a Sorbet project (sorbet/config not found)", err.lines.first.chomp)
+        refute(status)
+      end
+
       def test_display_metrics_do_not_show_errors
         @project.write("lib/error.rb", <<~RB)
           # typed: true
@@ -156,12 +164,10 @@ module Spoom
 
       def test_timeline_outside_sorbet_dir
         @project.remove("sorbet/config")
-        out, err, status = @project.bundle_exec("spoom coverage snapshot")
+        out, err, status = @project.bundle_exec("spoom coverage timeline --no-color")
+        assert_empty(out)
+        assert_equal("Error: not in a Sorbet project (sorbet/config not found)", err.lines.first.chomp)
         refute(status)
-        assert_equal("", out)
-        assert_equal(<<~MSG, err)
-          Error: not in a Sorbet project (no sorbet/config)
-        MSG
       end
 
       def test_timeline_one_commit
@@ -341,6 +347,14 @@ module Spoom
         assert_equal("", err)
         assert_equal(3, Dir.glob("#{project.path}/spoom_data/*.json").size)
         project.destroy
+      end
+
+      def test_report_outside_sorbet_dir
+        @project.remove("sorbet/config")
+        out, err, status = @project.bundle_exec("spoom coverage report --no-color")
+        assert_empty(out)
+        assert_equal("Error: not in a Sorbet project (sorbet/config not found)", err.lines.first.chomp)
+        refute(status)
       end
 
       def test_report_without_any_data

--- a/test/spoom/cli/lsp_test.rb
+++ b/test/spoom/cli/lsp_test.rb
@@ -21,10 +21,10 @@ module Spoom
 
       def test_cant_open_without_config
         @project.remove("sorbet/config")
-        _, err = @project.bundle_exec("spoom lsp --no-color find Foo")
-        assert_equal(<<~MSG, err)
-          Error: not in a Sorbet project (no sorbet/config)
-        MSG
+        out, err, status = @project.bundle_exec("spoom lsp --no-color find Foo")
+        assert_empty(out)
+        assert_equal("Error: not in a Sorbet project (sorbet/config not found)", err.lines.first.chomp)
+        refute(status)
       end
 
       def test_cant_open_with_errors

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -31,12 +31,12 @@ module Spoom
         @project.destroy
       end
 
-      def test_return_error_if_no_sorbet_config
+      def test_timeline_outside_sorbet_dir
         @project.remove("sorbet/config")
-        _, err = @project.bundle_exec("spoom tc")
-        assert_equal(<<~MSG, err)
-          Error: not in a Sorbet project (no sorbet/config)
-        MSG
+        out, err, status = @project.bundle_exec("spoom tc --no-color")
+        assert_empty(out)
+        assert_equal("Error: not in a Sorbet project (sorbet/config not found)", err.lines.first.chomp)
+        refute(status)
       end
 
       def test_display_no_errors_without_filter

--- a/test/spoom/sorbet/errors_test.rb
+++ b/test/spoom/sorbet/errors_test.rb
@@ -16,6 +16,46 @@ module Spoom
         assert_empty(errors)
       end
 
+      def test_parses_no_config
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          No sorbet/ directory found. Maybe you want to run 'srb init'?
+
+          A type checker for Ruby
+
+          Usage:
+            srb                                 Same as "srb t"
+            srb (init | initialize)             Initializes the `sorbet` directory
+            srb rbi [options]                   Manage the `sorbet` directory
+            srb (t | tc | typecheck) [options]  Typechecks the code
+
+          Options:
+            -h, --help     View help for this subcommand.
+            --version      Show version.
+
+          For full help:
+            https://sorbet.org
+        ERR
+        assert_empty(errors)
+      end
+
+      def test_parses_no_file
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
+          You must pass either `-e` or at least one folder or ruby file.
+
+          Typechecker for Ruby
+          Usage:
+            sorbet [OPTION...] <path 1> <path 2> ...
+
+            -e, string     Parse an inline ruby string (default: "")
+            -q, --quiet    Silence all non-critical errors
+            -v, --verbose  Verbosity level [0-3]
+            -h,            Show short help
+                --help     Show long help
+                --version  Show version
+        ERR
+        assert_empty(errors)
+      end
+
       def test_parses_a_token_error
         errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
           lib/test/file.rb:80: unexpected token "end" https://srb.help/2001


### PR DESCRIPTION
This PR brings some improvements to the `spoom bump` command:

* `spoom bump` uses `in_sorbet_project!` and displays an error if ran outside of a Sorbet project
* Some improvements to the error message when ran outside a Sorbet project
* `spoom bump` uses the `--path` option, so we can `spoom bump lib/ --path my/project`
* Avoid reverting files from other directories when bumping files with errors

Also add a few tests to show all the new behavior.

Fixes #10 and #50.