### PR TITLE
Fixes encoding issues

### DIFF
--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -56,14 +56,14 @@ module Spoom
       sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
       def self.file_strictness(path)
         return nil unless File.exist?(path)
-        content = File.read(path)
+        content = File.read(path, encoding: 'UTF-8')
         strictness_in_content(content)
       end
 
       # changes the sigil in the file at the passed path to the specified new strictness
       sig { params(path: T.any(String, Pathname), new_strictness: String).returns(T::Boolean) }
       def self.change_sigil_in_file(path, new_strictness)
-        content = File.read(path)
+        content = File.read(path, encoding: 'UTF-8')
         new_content = update_sigil(content, new_strictness)
 
         File.write(path, new_content)

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -74,6 +74,16 @@ module Spoom
         assert_equal("no", strictness)
       end
 
+      def test_file_with_non_utf8_encoding
+        content = <<~STR
+          # typed: true
+          "#{[0x89].pack('c*')}"
+        STR
+
+        strictness = Sigils.strictness_in_content(content.dup.force_encoding("ISO-8859-1"))
+        assert_equal("true", strictness)
+      end
+
       def test_update_sigil_to_use_valid_strictness
         content = <<~STR
           # typed: ignore


### PR DESCRIPTION
While running certain commands, spoom was chocking with some of our files containing € signs.