### PR TITLE
Uniformize help messages

### DIFF
--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -17,26 +17,27 @@ module Spoom
       extend T::Sig
       include Helper
 
-      class_option :color, desc: "Use colors", type: :boolean, default: true
-      class_option :path, desc: "Run spoom in a specific path", type: :string, default: ".", aliases: :p
+      class_option :color, type: :boolean, default: true, desc: "Use colors"
+      class_option :path, type: :string, default: ".", aliases: :p, desc: "Run spoom in a specific path"
+
       map T.unsafe(%w[--version -v] => :__print_version)
 
-      desc "bump", "bump Sorbet sigils from `false` to `true` when no errors"
+      desc "bump", "Bump Sorbet sigils from `false` to `true` when no errors"
       subcommand "bump", Spoom::Cli::Bump
 
-      desc "config", "manage Sorbet config"
+      desc "config", "Manage Sorbet config"
       subcommand "config", Spoom::Cli::Config
 
-      desc "coverage", "collect metrics related to Sorbet coverage"
+      desc "coverage", "Collect metrics related to Sorbet coverage"
       subcommand "coverage", Spoom::Cli::Coverage
 
-      desc "lsp", "send LSP requests to Sorbet"
+      desc "lsp", "Send LSP requests to Sorbet"
       subcommand "lsp", Spoom::Cli::LSP
 
-      desc "tc", "run Sorbet and parses its output"
+      desc "tc", "Run Sorbet and parses its output"
       subcommand "tc", Spoom::Cli::Run
 
-      desc "files", "list all the files typechecked by Sorbet"
+      desc "files", "List all the files typechecked by Sorbet"
       def files
         in_sorbet_project!
 
@@ -53,7 +54,7 @@ module Spoom
         end
       end
 
-      desc "--version", "show version"
+      desc "--version", "Show version"
       def __print_version
         puts "Spoom v#{Spoom::VERSION}"
       end

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -12,10 +12,13 @@ module Spoom
 
       default_task :bump
 
-      desc "bump DIRECTORY", "change Sorbet sigils from one strictness to another when no errors"
-      option :from, type: :string, default: Spoom::Sorbet::Sigils::STRICTNESS_FALSE
-      option :to, type: :string, default: Spoom::Sorbet::Sigils::STRICTNESS_TRUE
-      option :force, desc: "change strictness without type checking", type: :boolean, default: false, aliases: :f
+      desc "bump DIRECTORY", "Change Sorbet sigils from one strictness to another when no errors"
+      option :from, type: :string, default: Spoom::Sorbet::Sigils::STRICTNESS_FALSE,
+        desc: "Change only files from this strictness"
+      option :to, type: :string, default: Spoom::Sorbet::Sigils::STRICTNESS_TRUE,
+        desc: "Change files to this strictness"
+      option :force, type: :boolean, default: false, aliases: :f,
+        desc: "Change strictness without type checking"
       sig { params(directory: String).void }
       def bump(directory = ".")
         in_sorbet_project!

--- a/lib/spoom/cli/config.rb
+++ b/lib/spoom/cli/config.rb
@@ -11,7 +11,7 @@ module Spoom
 
       default_task :show
 
-      desc "show", "show Sorbet config"
+      desc "show", "Show Sorbet config"
       def show
         in_sorbet_project!
         config = Spoom::Sorbet::Config.parse_file(sorbet_config)

--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -13,8 +13,8 @@ module Spoom
 
       default_task :snapshot
 
-      desc "snapshot", "run srb tc and display metrics"
-      option :save, type: :string, desc: "Save snapshot data as json", lazy_default: DATA_DIR
+      desc "snapshot", "Run srb tc and display metrics"
+      option :save, type: :string, lazy_default: DATA_DIR, desc: "Save snapshot data as json"
       def snapshot
         in_sorbet_project!
 
@@ -30,10 +30,10 @@ module Spoom
         puts "\nSnapshot data saved under #{file}"
       end
 
-      desc "timeline", "replay a project and collect metrics"
-      option :from, type: :string
-      option :to, type: :string, default: Time.now.strftime("%F")
-      option :save, type: :string, desc: "Save snapshot data as json", lazy_default: DATA_DIR
+      desc "timeline", "Replay a project and collect metrics"
+      option :from, type: :string, desc: "From commit date"
+      option :to, type: :string, default: Time.now.strftime("%F"), desc: "To commit date"
+      option :save, type: :string, lazy_default: DATA_DIR, desc: "Save snapshot data as json"
       option :bundle_install, type: :boolean, desc: "Execute `bundle install` before collecting metrics"
       def timeline
         in_sorbet_project!
@@ -101,14 +101,20 @@ module Spoom
         Spoom::Git.checkout(sha_before, path: path)
       end
 
-      desc "report", "produce a typing coverage report"
-      option :data, type: :string, desc: "Snapshots JSON data", default: DATA_DIR
-      option :file, type: :string, default: "spoom_report.html", aliases: :f
-      option :color_ignore, type: :string, default: Spoom::Coverage::D3::COLOR_IGNORE
-      option :color_false, type: :string, default: Spoom::Coverage::D3::COLOR_FALSE
-      option :color_true, type: :string, default: Spoom::Coverage::D3::COLOR_TRUE
-      option :color_strict, type: :string, default: Spoom::Coverage::D3::COLOR_STRICT
-      option :color_strong, type: :string, default: Spoom::Coverage::D3::COLOR_STRONG
+      desc "report", "Produce a typing coverage report"
+      option :data, type: :string, default: DATA_DIR, desc: "Snapshots JSON data"
+      option :file, type: :string, default: "spoom_report.html", aliases: :f,
+        desc: "Save report to file"
+      option :color_ignore, type: :string, default: Spoom::Coverage::D3::COLOR_IGNORE,
+        desc: "Color used for typed: ignore"
+      option :color_false, type: :string, default: Spoom::Coverage::D3::COLOR_FALSE,
+        desc: "Color used for typed: false"
+      option :color_true, type: :string, default: Spoom::Coverage::D3::COLOR_TRUE,
+        desc: "Color used for typed: true"
+      option :color_strict, type: :string, default: Spoom::Coverage::D3::COLOR_STRICT,
+        desc: "Color used for typed: strict"
+      option :color_strong, type: :string, default: Spoom::Coverage::D3::COLOR_STRONG,
+        desc: "Color used for typed: strong"
       def report
         in_sorbet_project!
 
@@ -139,7 +145,7 @@ module Spoom
         puts "\nUse #{colorize('spoom coverage open', :blue)} to open it."
       end
 
-      desc "open", "open the typing coverage report"
+      desc "open", "Open the typing coverage report"
       def open(file = "spoom_report.html")
         unless File.exist?(file)
           say_error("No report file to open #{colorize(file, :blue)}")

--- a/lib/spoom/cli/lsp.rb
+++ b/lib/spoom/cli/lsp.rb
@@ -12,7 +12,7 @@ module Spoom
 
       default_task :show
 
-      desc "interactive", "interactive LSP mode"
+      desc "interactive", "Interactive LSP mode"
       def show
         in_sorbet_project!
         lsp = lsp_client
@@ -20,7 +20,7 @@ module Spoom
         puts lsp
       end
 
-      desc "list", "list all known symbols"
+      desc "list", "List all known symbols"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def list
         run do |client|
@@ -34,7 +34,7 @@ module Spoom
         end
       end
 
-      desc "hover", "request hover informations"
+      desc "hover", "Request hover informations"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def hover(file, line, col)
         run do |client|
@@ -48,7 +48,7 @@ module Spoom
         end
       end
 
-      desc "defs", "list definitions of a symbol"
+      desc "defs", "List definitions of a symbol"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def defs(file, line, col)
         run do |client|
@@ -58,7 +58,7 @@ module Spoom
         end
       end
 
-      desc "find", "find symbols matching a query"
+      desc "find", "Find symbols matching a query"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def find(query)
         run do |client|
@@ -68,7 +68,7 @@ module Spoom
         end
       end
 
-      desc "symbols", "list symbols from a file"
+      desc "symbols", "List symbols from a file"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def symbols(file)
         run do |client|
@@ -78,7 +78,7 @@ module Spoom
         end
       end
 
-      desc "refs", "list references to a symbol"
+      desc "refs", "List references to a symbol"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def refs(file, line, col)
         run do |client|
@@ -88,7 +88,7 @@ module Spoom
         end
       end
 
-      desc "sigs", "list signatures for a symbol"
+      desc "sigs", "List signatures for a symbol"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def sigs(file, line, col)
         run do |client|
@@ -98,7 +98,7 @@ module Spoom
         end
       end
 
-      desc "types", "display type of a symbol"
+      desc "types", "Display type of a symbol"
       # TODO: options, filter, limit, kind etc.. filter rbi
       def types(file, line, col)
         run do |client|

--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -8,10 +8,10 @@ module Spoom
 
       default_task :tc
 
-      desc "tc", "run srb tc"
-      option :limit, type: :numeric, aliases: :l
-      option :code, type: :numeric, aliases: :c
-      option :sort, type: :string, aliases: :s
+      desc "tc", "Run `srb tc`"
+      option :limit, type: :numeric, aliases: :l, desc: "Limit displayed errors"
+      option :code, type: :numeric, aliases: :c, desc: "Filter displayed errors by code"
+      option :sort, type: :string, aliases: :s, desc: "Sort errors by code"
       def tc
         in_sorbet_project!
 

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -32,14 +32,14 @@ module Spoom
         out, _ = @project.bundle_exec("spoom --help")
         assert_equal(<<~OUT, out)
           Commands:
-            spoom --version       # show version
-            spoom bump            # bump Sorbet sigils from `false` to `true` when no e...
-            spoom config          # manage Sorbet config
-            spoom coverage        # collect metrics related to Sorbet coverage
-            spoom files           # list all the files typechecked by Sorbet
+            spoom --version       # Show version
+            spoom bump            # Bump Sorbet sigils from `false` to `true` when no e...
+            spoom config          # Manage Sorbet config
+            spoom coverage        # Collect metrics related to Sorbet coverage
+            spoom files           # List all the files typechecked by Sorbet
             spoom help [COMMAND]  # Describe available commands or one specific command
-            spoom lsp             # send LSP requests to Sorbet
-            spoom tc              # run Sorbet and parses its output
+            spoom lsp             # Send LSP requests to Sorbet
+            spoom tc              # Run Sorbet and parses its output
 
           Options:
                 [--color], [--no-color]  # Use colors


### PR DESCRIPTION
Some cleaning around messages displayed from `--help`:

* Always start the description with an uppercase (Like the default help message from `thor`)
* Always use `desc` as the last parameter of the `option` method
* Add missing descriptions for a few options

No real functional change.