### PR TITLE
Allow bumping files with non-utf8 content

### DIFF
--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -87,7 +87,7 @@ module Spoom
           extension: String
         ).returns(T::Array[String])
       end
-      def self.files_with_sigil_strictness(directory, strictness, extension = ".rb")
+      def self.files_with_sigil_strictness(directory, strictness, extension: ".rb")
         paths = Dir.glob("#{File.expand_path(directory)}/**/*#{extension}").sort.uniq
         paths.filter do |path|
           file_strictness(path) == strictness

--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -56,14 +56,14 @@ module Spoom
       sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
       def self.file_strictness(path)
         return nil unless File.exist?(path)
-        content = File.read(path)
+        content = File.read(path, encoding: Encoding::ASCII_8BIT)
         strictness_in_content(content)
       end
 
       # changes the sigil in the file at the passed path to the specified new strictness
       sig { params(path: T.any(String, Pathname), new_strictness: String).returns(T::Boolean) }
       def self.change_sigil_in_file(path, new_strictness)
-        content = File.read(path)
+        content = File.read(path, encoding: Encoding::ASCII_8BIT)
         new_content = update_sigil(content, new_strictness)
 
         File.write(path, new_content)

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -125,6 +125,21 @@ module Spoom
 
         assert_equal("true", Sorbet::Sigils.file_strictness("#{@project.path}/file.rb"))
       end
+
+      def test_bump_preserve_file_encoding
+        string = <<~RB
+          # typed: false
+          puts "À coûté 10€"
+        RB
+
+        @project.write("file.rb", string.encode("ISO-8859-15"))
+        _, _, status = @project.bundle_exec("spoom bump")
+        assert(status)
+
+        strictness = Sorbet::Sigils.file_strictness("#{@project.path}/file.rb")
+        assert_equal("true", strictness)
+        assert_match("ISO-8859", %x{file "#{@project.path}/file.rb"})
+      end
     end
   end
 end

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -169,14 +169,13 @@ module Spoom
         project = spoom_project("test_sigils")
         project.write("file1.rb", "# typed: false")
         project.write("file2.rb", "# typed: ignore")
+        files = ["#{project.path}/file1.rb", "#{project.path}/file2.rb"]
 
-        changed_files = Sigils.change_sigil_in_files(["#{project.path}/file1.rb", "#{project.path}/file2.rb"], "true")
-        assert_equal(["#{project.path}/file1.rb", "#{project.path}/file2.rb"], changed_files)
+        changed_files = Sigils.change_sigil_in_files(files, "true")
+        assert_equal(files, changed_files)
+        assert_equal("true", Sigils.file_strictness("#{project.path}/file1.rb"))
+        assert_equal("true", Sigils.file_strictness("#{project.path}/file2.rb"))
 
-        strictness1 = Sigils.file_strictness("#{project.path}/file1.rb")
-        strictness2 = Sigils.file_strictness("#{project.path}/file2.rb")
-        assert_equal("true", strictness1)
-        assert_equal("true", strictness2)
         project.destroy
       end
     end

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -134,6 +134,26 @@ module Spoom
         project.destroy
       end
 
+      def test_files_with_sigil_strictness_with_iso_content
+        project = spoom_project("test_sigils")
+
+        string_utf = <<~RB
+          # typed: true
+
+          puts "À coûté 10€"
+        RB
+
+        string_iso = string_utf.encode("ISO-8859-15")
+        project.write("file1.rb", string_iso)
+        project.write("file2.rb", string_iso)
+        expected_files = ["#{project.path}/file1.rb", "#{project.path}/file2.rb"]
+
+        files = Sigils.files_with_sigil_strictness(project.path, "true").sort
+        assert_equal(expected_files, files)
+
+        project.destroy
+      end
+
       def test_file_strictness_returns_nil_if_file_not_found
         strictness = Sigils.file_strictness("/file/not/found.rb")
         assert_nil(strictness)
@@ -155,6 +175,21 @@ module Spoom
         project.destroy
       end
 
+      def test_file_strictness_with_iso_content
+        project = spoom_project("test_sigils")
+
+        string = <<~RB
+          # typed: true
+
+          puts "À coûté 10€"
+        RB
+
+        project.write("file.rb", string.encode("ISO-8859-15"))
+        strictness = Sigils.file_strictness("#{project.path}/file.rb")
+        assert_equal("true", strictness)
+        project.destroy
+      end
+
       def test_change_sigil_in_file_false_to_true
         project = spoom_project("test_sigils")
         project.write("file.rb", "# typed: false")
@@ -162,6 +197,21 @@ module Spoom
         assert(updated)
         strictness = Sigils.file_strictness("#{project.path}/file.rb")
         assert_equal("true", strictness)
+        project.destroy
+      end
+
+      def test_change_sigil_in_file_with_iso_content
+        project = spoom_project("test_sigils")
+
+        string = <<~RB
+          # typed: true
+
+          puts "À coûté 10€"
+        RB
+
+        project.write("file.rb", string.encode("ISO-8859-15"))
+        Sigils.change_sigil_in_file("#{project.path}/file.rb", "strict")
+        assert_equal("strict", Sigils.file_strictness("#{project.path}/file.rb"))
         project.destroy
       end
 
@@ -176,6 +226,27 @@ module Spoom
         assert_equal("true", Sigils.file_strictness("#{project.path}/file1.rb"))
         assert_equal("true", Sigils.file_strictness("#{project.path}/file2.rb"))
 
+        project.destroy
+      end
+
+      def test_change_sigil_in_files_with_iso_content
+        project = spoom_project("test_sigils")
+
+        string_utf = <<~RB
+          # typed: true
+
+          puts "À coûté 10€"
+        RB
+
+        string_iso = string_utf.encode("ISO-8859-15")
+        project.write("file1.rb", string_iso)
+        project.write("file2.rb", string_iso)
+        files = ["#{project.path}/file1.rb", "#{project.path}/file2.rb"]
+
+        changed_files = Sigils.change_sigil_in_files(files, "true")
+        assert_equal(files, changed_files)
+        assert_equal("true", Sigils.file_strictness("#{project.path}/file1.rb"))
+        assert_equal("true", Sigils.file_strictness("#{project.path}/file2.rb"))
         project.destroy
       end
     end

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -144,6 +144,7 @@ module Spoom
         project.write("file.rb", "# typed: true")
         strictness = Sigils.file_strictness("#{project.path}/file.rb")
         assert_equal("true", strictness)
+        project.destroy
       end
 
       def test_file_strictness_with_invalid_sigil
@@ -151,6 +152,7 @@ module Spoom
         project.write("file.rb", "# typed: asdf")
         strictness = Sigils.file_strictness("#{project.path}/file.rb")
         assert_equal("asdf", strictness)
+        project.destroy
       end
 
       def test_change_sigil_in_file_false_to_true
@@ -160,6 +162,7 @@ module Spoom
         assert(updated)
         strictness = Sigils.file_strictness("#{project.path}/file.rb")
         assert_equal("true", strictness)
+        project.destroy
       end
 
       def test_change_sigil_in_files_false_to_true
@@ -174,6 +177,7 @@ module Spoom
         strictness2 = Sigils.file_strictness("#{project.path}/file2.rb")
         assert_equal("true", strictness1)
         assert_equal("true", strictness2)
+        project.destroy
       end
     end
   end


### PR DESCRIPTION
As @masylum found out, when trying to get the sigil from a file, we're reading it with the default encoding: `utf-8`.

This is problematic when reading a file from a different encoding, especially when the file contains special characters like `À coûté 10€`.

This pull-request allows the user to read and write the files with a specific encoding by adding:
* a `encoding:` keyword argument to `Sigils` services
* a `--encoding` option to the `bump` command

Thus, solving the issue raised by #52.