### PR TITLE
Require `fileutils`

### DIFF
--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "fileutils"
 require "pathname"
 require "stringio"
 


### PR DESCRIPTION
`fileutils` was never explicitly required outside of tests (see `test_helpers/project.rb`) and reading the [documentation](https://ruby-doc.org/stdlib-2.7.2/libdoc/fileutils/rdoc/FileUtils.html) it seems `fileutils` needs to be required.

No idea how this was working before 🤷‍♂️ 

Closes #57.

cc. @connorshea