### PR TITLE
Do not include RBI by default in coverage metrics

### DIFF
--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -15,12 +15,12 @@ module Spoom
 
       desc "snapshot", "Run srb tc and display metrics"
       option :save, type: :string, lazy_default: DATA_DIR, desc: "Save snapshot data as json"
-      option :include_rbi, type: :boolean, default: false, desc: "Include RBI files in metrics"
+      option :rbi, type: :boolean, default: true, desc: "Exclude RBI files from metrics"
       def snapshot
         in_sorbet_project!
 
         path = exec_path
-        snapshot = Spoom::Coverage.snapshot(path: path, rbi: options[:include_rbi])
+        snapshot = Spoom::Coverage.snapshot(path: path, rbi: options[:rbi])
         snapshot.print
 
         save_dir = options[:save]

--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -15,11 +15,12 @@ module Spoom
 
       desc "snapshot", "Run srb tc and display metrics"
       option :save, type: :string, lazy_default: DATA_DIR, desc: "Save snapshot data as json"
+      option :include_rbi, type: :boolean, default: false, desc: "Include RBI files in metrics"
       def snapshot
         in_sorbet_project!
 
         path = exec_path
-        snapshot = Spoom::Coverage.snapshot(path: path)
+        snapshot = Spoom::Coverage.snapshot(path: path, rbi: options[:include_rbi])
         snapshot.print
 
         save_dir = options[:save]

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -59,11 +59,14 @@ module Spoom
       )
     end
 
+    sig { params(path: String).returns(Sorbet::Config) }
+    def self.sorbet_config(path: ".")
+      Sorbet::Config.parse_file("#{path}/#{Spoom::Config::SORBET_CONFIG}")
+    end
+
     sig { params(path: String).returns(FileTree) }
     def self.sigils_tree(path: ".")
-      config_file = "#{path}/#{Spoom::Config::SORBET_CONFIG}"
-      return FileTree.new unless File.exist?(config_file)
-      config = Sorbet::Config.parse_file(config_file)
+      config = sorbet_config(path: path)
       files = Sorbet.srb_files(config, path: path)
       files.select! { |file| file =~ /\.rb$/ }
       files.reject! { |file| file =~ %r{/test/} }

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -11,10 +11,17 @@ module Spoom
   module Coverage
     extend T::Sig
 
-    sig { params(path: String).returns(Snapshot) }
-    def self.snapshot(path: '.')
+    sig { params(path: String, rbi: T::Boolean).returns(Snapshot) }
+    def self.snapshot(path: '.', rbi: false)
+      config = sorbet_config(path: path)
+      config.allowed_extensions.push(".rb", ".rbi") if config.allowed_extensions.empty?
+
+      new_config = config.copy
+      new_config.allowed_extensions.reject! { |ext| !rbi && ext == ".rbi" }
+
+      metrics = Spoom::Sorbet.srb_metrics("--no-config", new_config.options_string, path: path, capture_err: true)
+
       snapshot = Snapshot.new
-      metrics = Spoom::Sorbet.srb_metrics(path: path, capture_err: true)
       return snapshot unless metrics
 
       sha = Spoom::Git.last_commit(path: path)

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -12,7 +12,7 @@ module Spoom
     extend T::Sig
 
     sig { params(path: String, rbi: T::Boolean).returns(Snapshot) }
-    def self.snapshot(path: '.', rbi: false)
+    def self.snapshot(path: '.', rbi: true)
       config = sorbet_config(path: path)
       config.allowed_extensions.push(".rb", ".rbi") if config.allowed_extensions.empty?
 

--- a/lib/spoom/sorbet/config.rb
+++ b/lib/spoom/sorbet/config.rb
@@ -36,6 +36,15 @@ module Spoom
         @allowed_extensions = T.let([], T::Array[String])
       end
 
+      sig { returns(Config) }
+      def copy
+        new_config = Sorbet::Config.new
+        new_config.paths.concat(@paths)
+        new_config.ignore.concat(@ignore)
+        new_config.allowed_extensions.concat(@allowed_extensions)
+        new_config
+      end
+
       # Returns self as a string of options that can be passed to Sorbet
       #
       # Example:

--- a/lib/spoom/sorbet/config.rb
+++ b/lib/spoom/sorbet/config.rb
@@ -36,6 +36,27 @@ module Spoom
         @allowed_extensions = T.let([], T::Array[String])
       end
 
+      # Returns self as a string of options that can be passed to Sorbet
+      #
+      # Example:
+      # ~~~rb
+      # config = Sorbet::Config.new
+      # config.paths << "/foo"
+      # config.paths << "/bar"
+      # config.ignore << "/baz"
+      # config.allowed_extensions << ".rb"
+      #
+      # puts config.options_string # "/foo /bar --ignore /baz --allowed-extension .rb"
+      # ~~~
+      sig { returns(String) }
+      def options_string
+        opts = []
+        opts.concat(paths)
+        opts.concat(ignore.map { |p| "--ignore #{p}" })
+        opts.concat(allowed_extensions.map { |ext| "--allowed-extension #{ext}" })
+        opts.join(" ")
+      end
+
       class << self
         extend T::Sig
 

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -49,6 +49,16 @@ module Spoom
           A3.new.foo
           B1.foo
         RB
+        @project.write("lib/d.rbi", <<~RB)
+          # typed: true
+          module D1; end
+          module D2; end
+
+          class D3
+            sig { void }
+            def foo; end
+          end
+        RB
       end
 
       def teardown
@@ -119,6 +129,32 @@ module Spoom
             untyped: 4 (33%)
         MSG
         assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
+      end
+
+      def test_display_metrics_includes_rbi_metrics
+        out, _ = @project.bundle_exec("spoom coverage snapshot --include-rbi")
+        out = censor_sorbet_version(out) if out
+        assert_equal(<<~MSG, out)
+          Sorbet static: X.X.XXXX
+
+          Content:
+            files: 4
+            modules: 5
+            classes: 2
+            methods: 14
+
+          Sigils:
+            false: 1 (25%)
+            true: 3 (75%)
+
+          Methods:
+            with signature: 2 (14%)
+            without signature: 12 (86%)
+
+          Calls:
+            typed: 8 (89%)
+            untyped: 1 (11%)
+        MSG
       end
 
       def test_save_snapshot

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -41,6 +41,79 @@ module Spoom
         assert_equal(2, snapshot2.files)
         assert_equal(10, snapshot2.sigils["true"])
       end
+
+      def test_snapshot_project
+        project = self.project
+        snapshot = Spoom::Coverage.snapshot(path: project.path)
+        assert_equal(3, snapshot.files)
+        assert_equal({ "false" => 1, "true" => 2 }, snapshot.sigils)
+        assert_equal(3, snapshot.modules)
+        assert_equal(5, snapshot.classes)
+        assert_equal(1, snapshot.methods_with_sig)
+        assert_equal(8, snapshot.methods_without_sig)
+        assert_equal(8, snapshot.calls_typed)
+        assert_equal(1, snapshot.calls_untyped)
+        project.destroy
+      end
+
+      def test_snapshot_project_with_rbis
+        project = self.project
+        snapshot = Spoom::Coverage.snapshot(path: project.path, rbi: true)
+        assert_equal(4, snapshot.files)
+        assert_equal({ "false" => 1, "true" => 3 }, snapshot.sigils)
+        assert_equal(5, snapshot.modules)
+        assert_equal(9, snapshot.classes)
+        assert_equal(1, snapshot.methods_with_sig)
+        assert_equal(13, snapshot.methods_without_sig)
+        assert_equal(8, snapshot.calls_typed)
+        assert_equal(1, snapshot.calls_untyped)
+        project.destroy
+      end
+
+      def project
+        project = spoom_project("test_snapshot")
+        project.sorbet_config(<<~CONFIG)
+          .
+          --allowed-extension .rb
+          --allowed-extension .rbi
+        CONFIG
+        project.write("lib/a.rb", <<~RB)
+          # typed: false
+
+          module A1; end
+          module A2; end
+
+          class A3
+            def foo; end
+          end
+        RB
+        project.write("lib/b.rb", <<~RB)
+          # typed: true
+
+          module B1
+            extend T::Sig
+
+            sig { void }
+            def self.foo; end
+          end
+        RB
+        project.write("lib/c.rb", <<~RB)
+          # typed: true
+          A3.new.foo
+          B1.foo
+        RB
+        project.write("lib/d.rbi", <<~RB)
+          # typed: true
+
+          module D1; end
+          module D2; end
+
+          class D3
+            def foo; end
+          end
+        RB
+        project
+      end
     end
   end
 end

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -45,26 +45,26 @@ module Spoom
       def test_snapshot_project
         project = self.project
         snapshot = Spoom::Coverage.snapshot(path: project.path)
-        assert_equal(3, snapshot.files)
-        assert_equal({ "false" => 1, "true" => 2 }, snapshot.sigils)
-        assert_equal(3, snapshot.modules)
-        assert_equal(5, snapshot.classes)
-        assert_equal(1, snapshot.methods_with_sig)
-        assert_equal(8, snapshot.methods_without_sig)
-        assert_equal(8, snapshot.calls_typed)
-        assert_equal(1, snapshot.calls_untyped)
-        project.destroy
-      end
-
-      def test_snapshot_project_with_rbis
-        project = self.project
-        snapshot = Spoom::Coverage.snapshot(path: project.path, rbi: true)
         assert_equal(4, snapshot.files)
         assert_equal({ "false" => 1, "true" => 3 }, snapshot.sigils)
         assert_equal(5, snapshot.modules)
         assert_equal(9, snapshot.classes)
         assert_equal(1, snapshot.methods_with_sig)
         assert_equal(13, snapshot.methods_without_sig)
+        assert_equal(8, snapshot.calls_typed)
+        assert_equal(1, snapshot.calls_untyped)
+        project.destroy
+      end
+
+      def test_snapshot_project_without_rbi
+        project = self.project
+        snapshot = Spoom::Coverage.snapshot(path: project.path, rbi: false)
+        assert_equal(3, snapshot.files)
+        assert_equal({ "false" => 1, "true" => 2 }, snapshot.sigils)
+        assert_equal(3, snapshot.modules)
+        assert_equal(5, snapshot.classes)
+        assert_equal(1, snapshot.methods_with_sig)
+        assert_equal(8, snapshot.methods_without_sig)
         assert_equal(8, snapshot.calls_typed)
         assert_equal(1, snapshot.calls_untyped)
         project.destroy

--- a/test/spoom/sorbet/config_test.rb
+++ b/test/spoom/sorbet/config_test.rb
@@ -149,6 +149,21 @@ module Spoom
         assert_equal(['.idea/'], config.ignore)
         assert_equal(['.rake', '.ru'], config.allowed_extensions)
       end
+
+      def test_options_string_empty
+        config = Spoom::Sorbet::Config.parse_string("")
+        assert_equal("", config.options_string)
+      end
+
+      def test_options_string_with_options
+        config = Spoom::Sorbet::Config.parse_string(<<~CONFIG)
+          .
+          --ignore=.git/
+          --ignore=vendor/
+          --allowed-extension=.rb
+        CONFIG
+        assert_equal(". --ignore .git/ --ignore vendor/ --allowed-extension .rb", config.options_string)
+      end
     end
   end
 end


### PR DESCRIPTION
By default, running `spoom coverage` will output the coverage metrics **including** the RBi files.

This can give misleading metrics when having a large amount of RBIs (for example when they are generated by `tapicoa`).

This PR makes the default to not include RBIs and adds the `--include-rbi` option to count them:

Example for `spoom coverage` on `spoom` itself:

```
Content:
  files: 68
  modules: 52
  classes: 154
  methods: 1994

Sigils:
  true: 49 (72%)
  strict: 19 (28%)

Methods:
  with signature: 300 (15%)
  without signature: 1694 (85%)

Calls:
  typed: 4893 (80%)
  untyped: 1246 (20%)
```

Example for `spoom coverage --include-rbi`:

```
Content:
  files: 49
  modules: 16
  classes: 79
  methods: 687

Sigils:
  true: 30 (61%)
  strict: 19 (39%)

Methods:
  with signature: 300 (44%)
  without signature: 387 (56%)

Calls:
  typed: 4861 (79%)
  untyped: 1278 (21%)
```

Also added a bunch of tests.