### PR TITLE
Add useful options to filter errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ spoom files
 List all typechecking errors sorted by location:
 
 ```
-$ spoom tc -s
+$ spoom tc -s loc
 ```
 
 List all typechecking errors sorted by error code first:
@@ -94,6 +94,31 @@ These options can be combined:
 
 ```
 $ spoom tc -s -c 7004 -l 10
+```
+
+Remove duplicated error lines:
+
+```
+$ spoom tc -u
+```
+
+Format each error line:
+
+```
+$ spoom tc -f '%C - %F:%L: %M'
+```
+
+Where:
+
+* `%C` is the error code
+* `%F` is the file the error is from
+* `%L` is the line the error is from
+* `%M` is the error message
+
+Hide the `Errors: X` at the end of the list:
+
+```
+$ spoom tc --no-count
 ```
 
 #### Typing coverage

--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -19,6 +19,7 @@ module Spoom
       option :code, type: :numeric, aliases: :c, desc: "Filter displayed errors by code"
       option :sort, type: :string, aliases: :s, desc: "Sort errors", enum: SORT_ENUM, lazy_default: SORT_LOC
       option :format, type: :string, aliases: :f, desc: "Format line output"
+      option :count, type: :boolean, default: true, desc: "Show errors count"
       def tc
         in_sorbet_project!
 
@@ -27,8 +28,9 @@ module Spoom
         sort = options[:sort]
         code = options[:code]
         format = options[:format]
+        count = options[:count]
 
-        unless limit || code || sort || format
+        unless limit || code || sort || format || count
           exit(Spoom::Sorbet.srb_tc(path: path, capture_err: false).last)
         end
 
@@ -57,10 +59,12 @@ module Spoom
           $stderr.puts format_error(error, format || DEFAULT_FORMAT)
         end
 
-        if errors_count == errors.size
-          $stderr.puts "Errors: #{errors_count}"
-        else
-          $stderr.puts "Errors: #{errors.size} shown, #{errors_count} total"
+        if count
+          if errors_count == errors.size
+            $stderr.puts "Errors: #{errors_count}"
+          else
+            $stderr.puts "Errors: #{errors.size} shown, #{errors_count} total"
+          end
         end
 
         exit(1)

--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -34,7 +34,7 @@ module Spoom
         errors = Spoom::Sorbet::Errors::Parser.parse_string(output)
         errors_count = errors.size
 
-        errors = sort == "code" ? errors.sort_by { |e| [e.code, e.file, e.line, e.message] } : errors.sort
+        errors = sort == "code" ? Spoom::Sorbet::Errors.sort_errors_by_code(errors) : errors.sort
         errors = errors.select { |e| e.code == code } if code
         errors = T.must(errors.slice(0, limit)) if limit
 

--- a/lib/spoom/sorbet/errors.rb
+++ b/lib/spoom/sorbet/errors.rb
@@ -4,6 +4,8 @@
 module Spoom
   module Sorbet
     module Errors
+      extend T::Sig
+
       # Parse errors from Sorbet output
       class Parser
         extend T::Sig
@@ -123,6 +125,7 @@ module Spoom
           @more = more
         end
 
+        # By default errors are sorted by location
         sig { params(other: T.untyped).returns(Integer) }
         def <=>(other)
           return 0 unless other.is_a?(Error)
@@ -133,6 +136,11 @@ module Spoom
         def to_s
           "#{file}:#{line}: #{message} (#{code})"
         end
+      end
+
+      sig { params(errors: T::Array[Error]).returns(T::Array[Error]) }
+      def self.sort_errors_by_code(errors)
+        errors.sort_by { |e| [e.code, e.file, e.line, e.message] }
       end
     end
   end

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -163,6 +163,14 @@ module Spoom
         refute(status)
       end
 
+      def test_display_errors_with_format_and_uniq
+        _, err, status = @project.bundle_exec("spoom tc --no-color -s code -f '%F' --no-count -u")
+        assert_equal(<<~MSG, err)
+          errors/errors.rb
+        MSG
+        refute(status)
+      end
+
       def test_display_errors_with_code
         _, err, status = @project.bundle_exec("spoom tc --no-color -c 7004")
         assert_equal(<<~MSG, err)

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -110,6 +110,20 @@ module Spoom
         refute(status)
       end
 
+      def test_display_errors_with_sort_code_but_no_count
+        _, err, status = @project.bundle_exec("spoom tc --no-color -s code --no-count")
+        assert_equal(<<~MSG, err)
+          5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+          5002 - errors/errors.rb:5: Unable to resolve constant `C`
+          7003 - errors/errors.rb:5: Method `params` does not exist on `T.class_of(Foo)`
+          7003 - errors/errors.rb:5: Method `sig` does not exist on `T.class_of(Foo)`
+          7003 - errors/errors.rb:11: Method `c` does not exist on `T.class_of(<root>)`
+          7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
+          7004 - errors/errors.rb:11: Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2`
+        MSG
+        refute(status)
+      end
+
       def test_display_errors_with_limit
         _, err, status = @project.bundle_exec("spoom tc --no-color -s code -l 1")
         assert_equal(<<~MSG, err)
@@ -164,6 +178,14 @@ module Spoom
         assert_equal(<<~MSG, err)
           7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
           Errors: 1 shown, 7 total
+        MSG
+        refute(status)
+      end
+
+      def test_display_errors_with_limit_and_code_but_no_count
+        _, err, status = @project.bundle_exec("spoom tc --no-color -c 7004 -l 1 --no-count")
+        assert_equal(<<~MSG, err)
+          7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
         MSG
         refute(status)
       end

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -57,8 +57,31 @@ module Spoom
         assert(status)
       end
 
+      def test_display_errors_with_bad_sort
+        _, err, status = @project.bundle_exec("spoom tc --no-color -s bad")
+        assert_equal(<<~MSG, err)
+          Expected '--sort' to be one of code, loc; got bad
+        MSG
+        refute(status)
+      end
+
       def test_display_errors_with_sort_default
         _, err, status = @project.bundle_exec("spoom tc --no-color -s")
+        assert_equal(<<~MSG, err)
+          5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+          5002 - errors/errors.rb:5: Unable to resolve constant `C`
+          7003 - errors/errors.rb:5: Method `params` does not exist on `T.class_of(Foo)`
+          7003 - errors/errors.rb:5: Method `sig` does not exist on `T.class_of(Foo)`
+          7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
+          7003 - errors/errors.rb:11: Method `c` does not exist on `T.class_of(<root>)`
+          7004 - errors/errors.rb:11: Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2`
+          Errors: 7
+        MSG
+        refute(status)
+      end
+
+      def test_display_errors_with_sort_loc
+        _, err, status = @project.bundle_exec("spoom tc --no-color -s loc")
         assert_equal(<<~MSG, err)
           5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
           5002 - errors/errors.rb:5: Unable to resolve constant `C`
@@ -88,7 +111,7 @@ module Spoom
       end
 
       def test_display_errors_with_limit
-        _, err, status = @project.bundle_exec("spoom tc --no-color -l 1")
+        _, err, status = @project.bundle_exec("spoom tc --no-color -s code -l 1")
         assert_equal(<<~MSG, err)
           5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
           Errors: 1 shown, 7 total
@@ -110,15 +133,6 @@ module Spoom
         _, err, status = @project.bundle_exec("spoom tc --no-color -c 7004 -l 1")
         assert_equal(<<~MSG, err)
           7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
-          Errors: 1 shown, 7 total
-        MSG
-        refute(status)
-      end
-
-      def test_display_errors_with_sort_and_limit
-        _, err, status = @project.bundle_exec("spoom tc --no-color -s code -l 1")
-        assert_equal(<<~MSG, err)
-          5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
           Errors: 1 shown, 7 total
         MSG
         refute(status)

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -119,6 +119,36 @@ module Spoom
         refute(status)
       end
 
+      def test_display_errors_with_format
+        _, err, status = @project.bundle_exec("spoom tc --no-color -s code -f '%F:%L %M %C'")
+        assert_equal(<<~MSG, err)
+          errors/errors.rb:5 Unable to resolve constant `Bar` 5002
+          errors/errors.rb:5 Unable to resolve constant `C` 5002
+          errors/errors.rb:5 Method `params` does not exist on `T.class_of(Foo)` 7003
+          errors/errors.rb:5 Method `sig` does not exist on `T.class_of(Foo)` 7003
+          errors/errors.rb:11 Method `c` does not exist on `T.class_of(<root>)` 7003
+          errors/errors.rb:10 Wrong number of arguments for constructor. Expected: `0`, got: `1` 7004
+          errors/errors.rb:11 Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2` 7004
+          Errors: 7
+        MSG
+        refute(status)
+      end
+
+      def test_display_errors_with_format_partial
+        _, err, status = @project.bundle_exec("spoom tc --no-color -s code -f '%F'")
+        assert_equal(<<~MSG, err)
+          errors/errors.rb
+          errors/errors.rb
+          errors/errors.rb
+          errors/errors.rb
+          errors/errors.rb
+          errors/errors.rb
+          errors/errors.rb
+          Errors: 7
+        MSG
+        refute(status)
+      end
+
       def test_display_errors_with_code
         _, err, status = @project.bundle_exec("spoom tc --no-color -c 7004")
         assert_equal(<<~MSG, err)

--- a/test/spoom/sorbet/errors_test.rb
+++ b/test/spoom/sorbet/errors_test.rb
@@ -271,9 +271,15 @@ module Spoom
           a.rb:105: Method foo does not exist on String https://srb.help/7003
                105 |        printer.print "foo".light_black
                                           ^^^^^^^^^^^^^^^^^
+
+          a.rb:105: Method foo does not exist on String https://srb.help/1001
+          a.rb:105: Method foo does not exist on String https://srb.help/1000
         ERR
-        assert_equal(4, errors.size)
-        assert_equal([7003, 7004, 4010, 2001], errors.sort.map(&:code))
+        assert_equal(6, errors.size)
+        assert_equal([1000, 1001, 7003, 7004, 4010, 2001], errors.sort.map(&:code))
+
+        errors = Spoom::Sorbet::Errors.sort_errors_by_code(errors)
+        assert_equal([1000, 1001, 2001, 4010, 7003, 7004], errors.map(&:code))
       end
 
       def test_complex_error_line_matching


### PR DESCRIPTION
Some improvements to `spoom tc`.

To remove duplicated error lines:

```
$ spoom tc -u
```

To format each error line:

```
$ spoom tc -f '%C - %F:%L: %M'
```

Where:

* `%C` is the error code
* `%F` is the file the error is from
* `%L` is the line the error is from
* `%M` is the error message

To hide the `Errors: X` at the end of the list:

```
$ spoom tc --no-count
```

It makes it easier to use spoom with other tools.

For example, to open all the files that contain an error:

```
vim -p `spoom tc -f '%F' -u`
```