### PR TITLE
Quality of life improvements to spoom bump

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,6 +31,8 @@ jobs:
       run: bin/setup
     - name: Run typechecking
       run: bin/typecheck
+    - name: Check sigils
+      run: bundle exec exe/spoom bump --from true --to strict --dry
     - name: Run tests
       run: bin/test
     - name: Run style

--- a/README.md
+++ b/README.md
@@ -208,6 +208,24 @@ Bump the strictness from all files currently at `typed: false` to `typed: true` 
 $ spoom bump --from false --to true -f
 ```
 
+Bump the strictness from a list of files (one file by line):
+
+```
+$ spoom bump --from false --to true -o list.txt
+```
+
+Check if files can be bumped without applying any change:
+
+```
+$ spoom bump --from false --to true --dry
+```
+
+Bump files using a custom instance of Sorbet:
+
+```
+$ spoom bump --from false --to true --sorbet /path/to/sorbet/bin
+```
+
 #### Interact with Sorbet LSP mode
 
 **Experimental**

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -96,7 +96,7 @@ module Spoom
             $stderr.puts(" + #{file_path}")
           end
           if dry
-            $stderr.puts("\nRun `spoom bump --from #{from} --to #{true}` to bump them")
+            $stderr.puts("\nRun `spoom bump --from #{from} --to #{to}` to bump them")
           end
         end
 

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -63,7 +63,7 @@ module Spoom
         if force
           print_changes(files_to_bump, from: from, to: to, dry: dry, path: exec_path)
           undo_changes(files_to_bump, from) if dry
-          exit(0)
+          exit(files_to_bump.empty?)
         end
 
         output, no_errors = Sorbet.srb_tc(path: exec_path, capture_err: true, sorbet_bin: options[:sorbet])
@@ -71,7 +71,7 @@ module Spoom
         if no_errors
           print_changes(files_to_bump, from: from, to: to, dry: dry, path: exec_path)
           undo_changes(files_to_bump, from) if dry
-          exit(0)
+          exit(files_to_bump.empty?)
         end
 
         errors = Sorbet::Errors::Parser.parse_string(output)
@@ -88,6 +88,7 @@ module Spoom
         files_changed = files_to_bump - files_with_errors
         print_changes(files_changed, from: from, to: to, dry: dry, path: exec_path)
         undo_changes(files_to_bump, from) if dry
+        exit(files_changed.empty?)
       end
 
       no_commands do

--- a/lib/spoom/version.rb
+++ b/lib/spoom/version.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Spoom

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -267,6 +267,29 @@ module Spoom
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
       end
+
+      def test_bump_only_specified_files
+        @project.write("file1.rb", "# typed: false")
+        @project.write("file2.rb", "# typed: false")
+        @project.write("file3.rb", "# typed: false")
+        @project.write("file4.rb", "# typed: false")
+        @project.write("file5.rb", "# typed: false")
+        @project.write("files.lst", <<~FILES)
+          file1.rb
+          file3.rb
+          file5.rb
+        FILES
+
+        out, err, status = @project.bundle_exec("spoom bump -o files.lst")
+        assert_empty(out)
+        assert_equal(<<~ERR, err)
+          Bumped 3 files from false to true:
+           + file1.rb
+           + file3.rb
+           + file5.rb
+        ERR
+        assert(status)
+      end
     end
   end
 end

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -48,7 +48,7 @@ module Spoom
           Bumped 1 file from false to true:
            + file1.rb
         ERR
-        assert(status)
+        refute(status)
 
         assert_equal("true", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
@@ -65,7 +65,7 @@ module Spoom
           Bumped 1 file from false to true:
            + lib/b/file.rb
         ERR
-        assert(status)
+        refute(status)
 
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/lib/a/file.rb"))
         assert_equal("true", Sorbet::Sigils.file_strictness("#{@project.path}/lib/b/file.rb"))
@@ -90,7 +90,7 @@ module Spoom
           Bumped 1 file from true to strict:
            + file2.rb
         ERR
-        assert(status)
+        refute(status)
 
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
         assert_equal("strict", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
@@ -112,7 +112,7 @@ module Spoom
           Bumped 1 file from ignore to strong:
            + file1.rb
         ERR
-        assert(status)
+        refute(status)
 
         assert_equal("strong", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
         assert_equal("ignore", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
@@ -135,7 +135,7 @@ module Spoom
            + file1.rb
            + file2.rb
         ERR
-        assert(status)
+        refute(status)
 
         assert_equal("strong", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
         assert_equal("strong", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
@@ -182,7 +182,7 @@ module Spoom
           Bumped 1 file from false to true:
            + file.rb
         ERR
-        assert(status)
+        refute(status)
 
         strictness = Sorbet::Sigils.file_strictness("#{@project.path}/file.rb")
         assert_equal("true", strictness)
@@ -207,7 +207,7 @@ module Spoom
 
           Run `spoom bump --from false --to true` to bump them
         ERR
-        assert(status)
+        refute(status)
 
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
@@ -232,7 +232,7 @@ module Spoom
 
           Run `spoom bump --from false --to true` to bump them
         ERR
-        assert(status)
+        refute(status)
 
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
@@ -288,7 +288,7 @@ module Spoom
            + file3.rb
            + file5.rb
         ERR
-        assert(status)
+        refute(status)
       end
     end
   end


### PR DESCRIPTION
This pull-request adds a few options to `spoom bump` as to make it easier to use in more complex bumps.

1. Add some printing so we see what the command is doing
2. Add `spoom bump --dry to not do anything, just see the changes that might happen
3. Add `spoom bump --only file.rb` to change only the files listed
4. Adjust exit values so `spoom bump` can more easily used in a script

We can also use all of this to check if files could be bumped to `typed: strict` in our own CI.

See the pull-request #65 for example:

![image](https://user-images.githubusercontent.com/583144/104509906-60203900-55b8-11eb-9257-d28911bf2fac.png)

As a matter of fact, this PR is also enabling `spoom bump--from true --to strict --dry` on this repository.

Closes #65.