### PR TITLE
Make `spoom list` easier to use from other scripts

### DIFF
--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -39,12 +39,17 @@ module Spoom
 
       desc "files", "List all the files typechecked by Sorbet"
       option :tree, type: :boolean, default: true, desc: "Display list as an indented tree"
+      option :rbi, type: :boolean, default: true, desc: "Show RBI files"
       def files
         in_sorbet_project!
 
         path = exec_path
         config = Spoom::Sorbet::Config.parse_file(sorbet_config)
         files = Spoom::Sorbet.srb_files(config, path: path)
+
+        unless options[:rbi]
+          files = files.reject { |file| file.end_with?(".rbi") }
+        end
 
         if files.empty?
           say_error("No file matching `#{sorbet_config}`")

--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -50,9 +50,8 @@ module Spoom
           exit(1)
         end
 
-        say("Files matching `#{sorbet_config}`:")
         tree = FileTree.new(files, strip_prefix: path)
-        tree.print(colors: options[:color], indent_level: 2)
+        tree.print(colors: options[:color], indent_level: 0)
       end
 
       desc "--version", "Show version"

--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -45,13 +45,14 @@ module Spoom
         config = Spoom::Sorbet::Config.parse_file(sorbet_config)
         files = Spoom::Sorbet.srb_files(config, path: path)
 
-        say("Files matching `#{sorbet_config}`:")
         if files.empty?
-          say(" NONE")
-        else
-          tree = FileTree.new(files, strip_prefix: path)
-          tree.print(colors: options[:color], indent_level: 2)
+          say_error("No file matching `#{sorbet_config}`")
+          exit(1)
         end
+
+        say("Files matching `#{sorbet_config}`:")
+        tree = FileTree.new(files, strip_prefix: path)
+        tree.print(colors: options[:color], indent_level: 2)
       end
 
       desc "--version", "Show version"

--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -38,6 +38,7 @@ module Spoom
       subcommand "tc", Spoom::Cli::Run
 
       desc "files", "List all the files typechecked by Sorbet"
+      option :tree, type: :boolean, default: true, desc: "Display list as an indented tree"
       def files
         in_sorbet_project!
 
@@ -50,8 +51,12 @@ module Spoom
           exit(1)
         end
 
-        tree = FileTree.new(files, strip_prefix: path)
-        tree.print(colors: options[:color], indent_level: 0)
+        if options[:tree]
+          tree = FileTree.new(files, strip_prefix: path)
+          tree.print(colors: options[:color], indent_level: 0)
+        else
+          puts files
+        end
       end
 
       desc "--version", "Show version"

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -70,15 +70,14 @@ module Spoom
         @project.sorbet_config(".")
         out, _ = @project.bundle_exec("spoom files --no-color")
         assert_equal(<<~MSG, out)
-          Files matching `sorbet/config`:
-            lib/
-              c.rb (true)
-              d.rb (strict)
-              e.rb (strong)
-              f.rb (__STDLIB_INTERNAL)
-            test/
-              a.rb (ignore)
-              b.rb (false)
+          lib/
+            c.rb (true)
+            d.rb (strict)
+            e.rb (strong)
+            f.rb (__STDLIB_INTERNAL)
+          test/
+            a.rb (ignore)
+            b.rb (false)
         MSG
       end
 
@@ -95,12 +94,11 @@ module Spoom
         CFG
         out, _ = @project.bundle_exec("spoom files --no-color")
         assert_equal(<<~MSG, out)
-          Files matching `sorbet/config`:
-            lib/
-              c.rb (true)
-              d.rb (strict)
-              e.rb (strong)
-              f.rb (__STDLIB_INTERNAL)
+          lib/
+            c.rb (true)
+            d.rb (strict)
+            e.rb (strong)
+            f.rb (__STDLIB_INTERNAL)
         MSG
       end
 
@@ -119,13 +117,12 @@ module Spoom
         CFG
         out, _ = @project.bundle_exec("spoom files --no-color")
         assert_equal(<<~MSG, out)
-          Files matching `sorbet/config`:
-            lib/
-              d.ru (strict)
-              e.rb (strong)
-              f.rb (__STDLIB_INTERNAL)
-            test/
-              a.rake (ignore)
+          lib/
+            d.ru (strict)
+            e.rb (strong)
+            f.rb (__STDLIB_INTERNAL)
+          test/
+            a.rake (ignore)
         MSG
       end
 
@@ -137,10 +134,9 @@ module Spoom
 
         out, _ = @project.bundle_exec("spoom files --no-color --path #{project.path}")
         assert_equal(<<~MSG, out)
-          Files matching `/tmp/spoom/tests/test_files/sorbet/config`:
-            lib/
-              file1.rb (true)
-              file2.rb (true)
+          lib/
+            file1.rb (true)
+            file2.rb (true)
         MSG
       end
     end

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -50,6 +50,16 @@ module Spoom
         OUT
       end
 
+      def test_display_files_returns_1_if_no_file
+        @project.sorbet_config(".")
+        out, err, status = @project.bundle_exec("spoom files --no-color")
+        assert_equal(<<~MSG, err)
+          Error: No file matching `sorbet/config`
+        MSG
+        assert_empty(out)
+        refute(status)
+      end
+
       def test_display_files_from_config
         @project.write("test/a.rb", "# typed: ignore")
         @project.write("test/b.rb", "# typed: false")

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -158,6 +158,27 @@ module Spoom
           test/b.rb
         MSG
       end
+
+      def test_display_files_no_rbi
+        @project.write("test/a.rbi", "# typed: ignore")
+        @project.write("test/b.rbi", "# typed: false")
+        @project.write("lib/c.rb", "# typed: true")
+        @project.write("lib/d.rb", "# typed: strict")
+        @project.write("lib/e.rbi", "# typed: strong")
+        @project.write("lib/f.rbi", "# typed: __STDLIB_INTERNAL")
+        @project.sorbet_config(".")
+        out, _ = @project.bundle_exec("spoom files --no-color --no-rbi")
+        assert_equal(<<~MSG, out)
+          lib/
+            c.rb (true)
+            d.rb (strict)
+        MSG
+        out, _ = @project.bundle_exec("spoom files --no-color --no-tree --no-rbi")
+        assert_equal(<<~MSG, out)
+          lib/c.rb
+          lib/d.rb
+        MSG
+      end
     end
   end
 end

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -139,6 +139,25 @@ module Spoom
             file2.rb (true)
         MSG
       end
+
+      def test_display_files_no_tree
+        @project.write("test/a.rb", "# typed: ignore")
+        @project.write("test/b.rb", "# typed: false")
+        @project.write("lib/c.rb", "# typed: true")
+        @project.write("lib/d.rb", "# typed: strict")
+        @project.write("lib/e.rb", "# typed: strong")
+        @project.write("lib/f.rb", "# typed: __STDLIB_INTERNAL")
+        @project.sorbet_config(".")
+        out, _ = @project.bundle_exec("spoom files --no-color --no-tree")
+        assert_equal(<<~MSG, out)
+          lib/c.rb
+          lib/d.rb
+          lib/e.rb
+          lib/f.rb
+          test/a.rb
+          test/b.rb
+        MSG
+      end
     end
   end
 end


### PR DESCRIPTION
This pull-requests tweaks a bit the output of `spoom list` so it's easier to use by scripts or to pipe the result to another command etc.

It also adds two options:
* `--no-tree` to display a bare list of files
* `--no-rbi` to filter out the RBI files from the list/tree