### PR TITLE
Add RBIs count to snapshot

### DIFF
--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -15,7 +15,7 @@ module Spoom
 
       desc "snapshot", "Run srb tc and display metrics"
       option :save, type: :string, lazy_default: DATA_DIR, desc: "Save snapshot data as json"
-      option :rbi, type: :boolean, default: true, desc: "Exclude RBI files from metrics"
+      option :rbi, type: :boolean, default: true, desc: "Include RBI files in metrics"
       option :sorbet, type: :string, desc: "Path to custom Sorbet bin"
       def snapshot
         in_sorbet_project!

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -54,6 +54,9 @@ module Spoom
       snapshot.version_static = Spoom::Sorbet.version_from_gemfile_lock(gem: "sorbet-static", path: path)
       snapshot.version_runtime = Spoom::Sorbet.version_from_gemfile_lock(gem: "sorbet-runtime", path: path)
 
+      files = Spoom::Sorbet.srb_files(new_config, path: path)
+      snapshot.rbi_files = files.count { |file| file.end_with?(".rbi") }
+
       snapshot
     end
 

--- a/lib/spoom/coverage/d3/timeline.rb
+++ b/lib/spoom/coverage/d3/timeline.rb
@@ -36,8 +36,26 @@ module Spoom
               pointer-events: none;
             }
 
+            .area {
+              fill-opacity: 0.5;
+            }
+
+            .line {
+              stroke-width: 2;
+              fill: transparent;
+            }
+
+            .dot {
+              r: 2;
+              fill: #888;
+            }
+
             .inverted .grid line {
               stroke: #777;
+            }
+
+            .inverted .area {
+              fill-opacity: 0.9;
             }
 
             .inverted .axis text {
@@ -46,6 +64,10 @@ module Spoom
 
             .inverted .axis line {
               stroke: #fff;
+            }
+
+            .inverted .dot {
+              fill: #fff;
             }
           CSS
         end
@@ -170,7 +192,6 @@ module Spoom
                 .y1((d) => yScale_#{id}(#{y}))
                 .curve(d3.#{curve}))
               .attr("fill", "#{color}")
-              .attr("fill-opacity", 0.5)
           HTML
         end
 
@@ -185,8 +206,6 @@ module Spoom
                  .y((d) => yScale_#{id}(#{y}))
                  .curve(d3.#{curve}))
                .attr("stroke", "#{color}")
-               .attr("stroke-width", 3)
-               .attr("fill", "transparent")
           HTML
         end
 
@@ -198,10 +217,8 @@ module Spoom
               .enter()
                 .append("circle")
                 .attr("class", "dot")
-                .attr("r", 3)
                 .attr("cx", (d) => xScale_#{id}(parseDate(d.timestamp)))
                 .attr("cy", (d, i) => yScale_#{id}(#{y}))
-                .attr("fill", "#aaa")
                 .on("mouseover", (d) => tooltip.style("opacity", 1))
                 .on("mousemove", tooltip_#{id})
                 .on("mouseleave", (d) => tooltip.style("opacity", 0));
@@ -381,18 +398,15 @@ module Spoom
               layer.append("path")
                 .attr("class", "area")
                 .attr("d", area_#{id})
-                .attr("fill", (d) => strictnessColor(d.key))
-                .attr("fill-opacity", 0.9)
+                .attr("fill", (d) => #{color})
 
               svg_#{id}.selectAll("circle")
                 .data(points_#{id})
                 .enter()
                   .append("circle")
                   .attr("class", "dot")
-                  .attr("r", 2)
                   .attr("cx", (d) => xScale_#{id}(parseDate(#{y})))
                   .attr("cy", (d, i) => yScale_#{id}(d[1]))
-                  .attr("fill", "#fff")
                   .on("mouseover", (d) => tooltip.style("opacity", 1))
                   .on("mousemove", tooltip_#{id})
                   .on("mouseleave", (d) => tooltip.style("opacity", 0));

--- a/lib/spoom/coverage/d3/timeline.rb
+++ b/lib/spoom/coverage/d3/timeline.rb
@@ -494,6 +494,129 @@ module Spoom
             JS
           end
         end
+
+        class RBIs < Stacked
+          extend T::Sig
+
+          sig { params(id: String, snapshots: T::Array[Snapshot]).void }
+          def initialize(id, snapshots)
+            keys = ['rbis', 'files']
+            data = snapshots.map do |snapshot|
+              {
+                timestamp: snapshot.commit_timestamp,
+                commit: snapshot.commit_sha,
+                total: snapshot.files,
+                values: { files: snapshot.files - snapshot.rbi_files, rbis: snapshot.rbi_files },
+              }
+            end
+            super(id, data, keys)
+          end
+
+          sig { override.returns(String) }
+          def tooltip
+            <<~JS
+              function tooltip_#{id}(d) {
+                moveTooltip(d)
+                  .html("commit <b>" + d.data.commit + "</b><br>"
+                    + d3.timeFormat("%y/%m/%d")(parseDate(d.data.timestamp)) + "<br><br>"
+                    + "Files: <b>" + d.data.values.files + "</b><br>"
+                    + "RBIs: <b>" + d.data.values.rbis + "</b><br><br>"
+                    + "Total: <b>" + d.data.total + "</b>")
+              }
+            JS
+          end
+
+          sig { override.returns(String) }
+          def script
+            <<~JS
+              #{tooltip}
+
+              var data_#{id} = #{@data.to_json};
+              var keys_#{id} = #{T.unsafe(@keys).to_json};
+
+              var stack_#{id} = d3.stack()
+                .keys(keys_#{id})
+                .value((d, key) => d.values[key]);
+
+              var layers_#{id} = stack_#{id}(data_#{id});
+
+              var points_#{id} = []
+              layers_#{id}.forEach(function(d) {
+                d.forEach(function(p) {
+                  p.key = d.key
+                  points_#{id}.push(p);
+                });
+              })
+
+              function draw_#{id}() {
+                var width_#{id} = document.getElementById("#{id}").clientWidth;
+                var height_#{id} = 200;
+
+                d3.select("##{id}").selectAll("*").remove()
+
+                var svg_#{id} = d3.select("##{id}")
+                  .attr("width", width_#{id})
+                  .attr("height", height_#{id});
+
+                #{plot}
+              }
+
+              draw_#{id}();
+              window.addEventListener("resize", draw_#{id});
+            JS
+          end
+
+          sig { override.params(y: String, color: String, curve: String).returns(String) }
+          def line(y:, color: 'strictnessColor(d.key)', curve: 'curveCatmullRom.alpha(1)')
+            <<~JS
+              var area_#{id} = d3.area()
+                .x((d) => xScale_#{id}(parseDate(#{y})))
+                .y0((d) => yScale_#{id}(d[0]))
+                .y1((d) => yScale_#{id}(d[1]))
+                .curve(d3.#{curve});
+
+              var layer = svg_#{id}.selectAll(".layer")
+                .data(layers_#{id})
+                .enter().append("g")
+                  .attr("class", "layer")
+
+              layer.append("path")
+                .attr("class", "area")
+                .attr("d", area_#{id})
+                .attr("fill", (d) => #{color})
+
+              layer.append("path")
+                .attr("class", "line")
+                .attr("d", d3.line()
+                  .x((d) => xScale_#{id}(parseDate(#{y})))
+                  .y((d, i) => yScale_#{id}(d[1]))
+                  .curve(d3.#{curve}))
+                .attr("stroke", (d) => #{color})
+
+              svg_#{id}.selectAll("circle")
+                .data(points_#{id})
+                .enter()
+                  .append("circle")
+                  .attr("class", "dot")
+                  .attr("cx", (d) => xScale_#{id}(parseDate(#{y})))
+                  .attr("cy", (d, i) => yScale_#{id}(d[1]))
+                  .on("mouseover", (d) => tooltip.style("opacity", 1))
+                  .on("mousemove", tooltip_#{id})
+                  .on("mouseleave", (d) => tooltip.style("opacity", 0));
+            JS
+          end
+
+          sig { override.returns(String) }
+          def plot
+            <<~JS
+              #{x_scale}
+              #{y_scale(min: '0', max: "d3.max(data_#{id}, (d) => d.total + 10)", ticks: 'tickValues([0, 25, 50, 75, 100])')}
+              #{line(y: 'd.data.timestamp', color: "d.key == 'rbis' ? '#8673ff' : '#007bff'")}
+              #{x_ticks}
+              #{y_ticks(ticks: 'tickValues([25, 50, 75])', format: 'd', padding: 20)}
+            JS
+          end
+        end
       end
     end
   end

--- a/lib/spoom/coverage/report.rb
+++ b/lib/spoom/coverage/report.rb
@@ -194,6 +194,15 @@ module Spoom
           end
         end
 
+        class RBIs < Timeline
+          extend T::Sig
+
+          sig { params(snapshots: T::Array[Coverage::Snapshot], title: String).void }
+          def initialize(snapshots:, title: "RBIs Timeline")
+            super(title: title, timeline: D3::Timeline::RBIs.new("timeline_rbis", snapshots))
+          end
+        end
+
         class Versions < Timeline
           extend T::Sig
 
@@ -298,6 +307,7 @@ module Spoom
         cards << Cards::Timeline::Sigils.new(snapshots: snapshots)
         cards << Cards::Timeline::Calls.new(snapshots: snapshots)
         cards << Cards::Timeline::Sigs.new(snapshots: snapshots)
+        cards << Cards::Timeline::RBIs.new(snapshots: snapshots)
         cards << Cards::Timeline::Versions.new(snapshots: snapshots)
         cards << Cards::Timeline::Runtimes.new(snapshots: snapshots)
         cards << Cards::SorbetIntro.new(sorbet_intro_commit: sorbet_intro_commit, sorbet_intro_date: sorbet_intro_date)

--- a/lib/spoom/coverage/snapshot.rb
+++ b/lib/spoom/coverage/snapshot.rb
@@ -13,6 +13,7 @@ module Spoom
       prop :commit_sha, T.nilable(String), default: nil
       prop :commit_timestamp, T.nilable(Integer), default: nil
       prop :files, Integer, default: 0
+      prop :rbi_files, Integer, default: 0
       prop :modules, Integer, default: 0
       prop :classes, Integer, default: 0
       prop :singleton_classes, Integer, default: 0
@@ -46,6 +47,7 @@ module Spoom
         snapshot.commit_sha = obj.fetch("commit_sha", nil)
         snapshot.commit_timestamp = obj.fetch("commit_timestamp", nil)
         snapshot.files = obj.fetch("files", 0)
+        snapshot.rbi_files = obj.fetch("rbi_files", 0)
         snapshot.modules = obj.fetch("modules", 0)
         snapshot.classes = obj.fetch("classes", 0)
         snapshot.singleton_classes = obj.fetch("singleton_classes", 0)
@@ -86,7 +88,7 @@ module Spoom
         end
         printl("Content:")
         indent
-        printl("files: #{snapshot.files}")
+        printl("files: #{snapshot.files} (including #{snapshot.rbi_files} RBIs)")
         printl("modules: #{snapshot.modules}")
         printl("classes: #{snapshot.classes - snapshot.singleton_classes}")
         printl("methods: #{methods}")

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -49,6 +49,16 @@ module Spoom
           A3.new.foo
           B1.foo
         RB
+        @project.write("lib/d.rbi", <<~RB)
+          # typed: true
+          module D1; end
+          module D2; end
+
+          class D3
+            sig { void }
+            def foo; end
+          end
+        RB
       end
 
       def teardown
@@ -62,18 +72,18 @@ module Spoom
           Sorbet static: X.X.XXXX
 
           Content:
-            files: 3
-            modules: 3
-            classes: 1
-            methods: 9
+            files: 4
+            modules: 5
+            classes: 2
+            methods: 14
 
           Sigils:
-            false: 1 (33%)
-            true: 2 (67%)
+            false: 1 (25%)
+            true: 3 (75%)
 
           Methods:
-            with signature: 1 (11%)
-            without signature: 8 (89%)
+            with signature: 2 (14%)
+            without signature: 12 (86%)
 
           Calls:
             typed: 8 (89%)
@@ -101,18 +111,18 @@ module Spoom
           Sorbet static: X.X.XXXX
 
           Content:
-            files: 4
-            modules: 3
-            classes: 1
-            methods: 10
+            files: 5
+            modules: 5
+            classes: 2
+            methods: 15
 
           Sigils:
-            false: 1 (25%)
-            true: 3 (75%)
+            false: 1 (20%)
+            true: 4 (80%)
 
           Methods:
-            with signature: 1 (10%)
-            without signature: 9 (90%)
+            with signature: 2 (13%)
+            without signature: 13 (87%)
 
           Calls:
             typed: 8 (67%)
@@ -122,39 +132,6 @@ module Spoom
       end
 
       def test_display_metrics_can_exclude_rbi_metrics
-        @project.write("lib/d.rbi", <<~RB)
-          # typed: true
-          module D1; end
-          module D2; end
-
-          class D3
-            sig { void }
-            def foo; end
-          end
-        RB
-        out, _ = @project.bundle_exec("spoom coverage snapshot")
-        out = censor_sorbet_version(out) if out
-        assert_equal(<<~MSG, out)
-          Sorbet static: X.X.XXXX
-
-          Content:
-            files: 4
-            modules: 5
-            classes: 2
-            methods: 14
-
-          Sigils:
-            false: 1 (25%)
-            true: 3 (75%)
-
-          Methods:
-            with signature: 2 (14%)
-            without signature: 12 (86%)
-
-          Calls:
-            typed: 8 (89%)
-            untyped: 1 (11%)
-        MSG
         out, _ = @project.bundle_exec("spoom coverage snapshot --no-rbi")
         out = censor_sorbet_version(out) if out
         assert_equal(<<~MSG, out)
@@ -200,18 +177,18 @@ module Spoom
           Sorbet static: X.X.XXXX
 
           Content:
-            files: 3
-            modules: 3
-            classes: 1
-            methods: 9
+            files: 4
+            modules: 5
+            classes: 2
+            methods: 14
 
           Sigils:
-            false: 1 (33%)
-            true: 2 (67%)
+            false: 1 (25%)
+            true: 3 (75%)
 
           Methods:
-            with signature: 1 (11%)
-            without signature: 8 (89%)
+            with signature: 2 (14%)
+            without signature: 12 (86%)
 
           Calls:
             typed: 8 (89%)
@@ -240,18 +217,18 @@ module Spoom
             Sorbet static: 0.5.0000
 
             Content:
-              files: 3
-              modules: 3
-              classes: 1
-              methods: 9
+              files: 4
+              modules: 5
+              classes: 2
+              methods: 14
 
             Sigils:
-              false: 1 (33%)
-              true: 2 (67%)
+              false: 1 (25%)
+              true: 3 (75%)
 
             Methods:
-              with signature: 1 (11%)
-              without signature: 8 (89%)
+              with signature: 2 (14%)
+              without signature: 12 (86%)
 
             Calls:
               typed: 8 (89%)

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -72,7 +72,7 @@ module Spoom
           Sorbet static: X.X.XXXX
 
           Content:
-            files: 4
+            files: 4 (including 1 RBIs)
             modules: 5
             classes: 2
             methods: 14
@@ -111,7 +111,7 @@ module Spoom
           Sorbet static: X.X.XXXX
 
           Content:
-            files: 5
+            files: 5 (including 1 RBIs)
             modules: 5
             classes: 2
             methods: 15
@@ -138,7 +138,7 @@ module Spoom
           Sorbet static: X.X.XXXX
 
           Content:
-            files: 3
+            files: 3 (including 0 RBIs)
             modules: 3
             classes: 1
             methods: 9
@@ -177,7 +177,7 @@ module Spoom
           Sorbet static: X.X.XXXX
 
           Content:
-            files: 4
+            files: 4 (including 1 RBIs)
             modules: 5
             classes: 2
             methods: 14
@@ -217,7 +217,7 @@ module Spoom
             Sorbet static: 0.5.0000
 
             Content:
-              files: 4
+              files: 4 (including 1 RBIs)
               modules: 5
               classes: 2
               methods: 14
@@ -249,7 +249,7 @@ module Spoom
             Sorbet static: 0.5.0000
 
             Content:
-              files: 2
+              files: 2 (including 0 RBIs)
               modules: 1
               classes: 1
               methods: 6
@@ -269,7 +269,7 @@ module Spoom
             Sorbet static: 0.5.1000
 
             Content:
-              files: 4
+              files: 4 (including 0 RBIs)
               modules: 1
               classes: 2
               methods: 9
@@ -291,7 +291,7 @@ module Spoom
             Sorbet runtime: 0.5.3000
 
             Content:
-              files: 6
+              files: 6 (including 0 RBIs)
               modules: 1
               classes: 2
               methods: 10
@@ -324,7 +324,7 @@ module Spoom
             Sorbet static: 0.5.0000
 
             Content:
-              files: 2
+              files: 2 (including 0 RBIs)
               modules: 1
               classes: 1
               methods: 6
@@ -344,7 +344,7 @@ module Spoom
             Sorbet static: 0.5.1000
 
             Content:
-              files: 4
+              files: 4 (including 0 RBIs)
               modules: 1
               classes: 2
               methods: 9

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -24,6 +24,7 @@ module Spoom
         snapshot1.commit_sha = "commit_sha"
         snapshot1.commit_timestamp = 1
         snapshot1.files = 2
+        snapshot1.rbi_files = 1
         snapshot1.modules = 3
         snapshot1.classes = 4
         snapshot1.methods_with_sig = 5
@@ -39,6 +40,7 @@ module Spoom
         assert_equal(json1, json2)
         assert_equal("sorbet_version", snapshot2.version_static)
         assert_equal(2, snapshot2.files)
+        assert_equal(1, snapshot2.rbi_files)
         assert_equal(10, snapshot2.sigils["true"])
       end
 
@@ -46,6 +48,7 @@ module Spoom
         project = self.project
         snapshot = Spoom::Coverage.snapshot(path: project.path)
         assert_equal(4, snapshot.files)
+        assert_equal(1, snapshot.rbi_files)
         assert_equal({ "false" => 1, "true" => 3 }, snapshot.sigils)
         assert_equal(5, snapshot.modules)
         assert_equal(9, snapshot.classes)
@@ -60,6 +63,7 @@ module Spoom
         project = self.project
         snapshot = Spoom::Coverage.snapshot(path: project.path, rbi: false)
         assert_equal(3, snapshot.files)
+        assert_equal(0, snapshot.rbi_files)
         assert_equal({ "false" => 1, "true" => 2 }, snapshot.sigils)
         assert_equal(3, snapshot.modules)
         assert_equal(5, snapshot.classes)


### PR DESCRIPTION
Count & store RBI count in snapshot so we can keep an eye on the amount of files vs. RBI files we have in a project:

![image](https://user-images.githubusercontent.com/583144/106826518-11b10800-6655-11eb-8aa2-c396afd0a615.png)

