### PR TITLE
Speed up version reading by passing `--no-config` to Sorbet

### DIFF
--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -68,6 +68,7 @@ module Spoom
       end
       def srb_version(*arg, path: '.', capture_err: false, sorbet_bin: nil)
         out, res = T.unsafe(self).srb_tc(
+          "--no-config",
           "--version",
           *arg,
           path: path,


### PR DESCRIPTION
It turns up that when we run `sorbet --version`, Sorbet will still read the config file and list all the paths to be analyzed.

On big codebases, this can cost up to 1 second:

```bash
$ time bundle exec srb tc --version
Sorbet typechecker 0.5.6274 git 88e72f6da215d2952b761b0f4398d4296bfc16e3 debug_symbols=true clean=1

real	0m5.551s

$ time bundle exec srb tc --version --no-config
Sorbet typechecker 0.5.6274 git 88e72f6da215d2952b761b0f4398d4296bfc16e3 debug_symbols=true clean=1

real	0m4.545s
```

This pull-request also pass `--no-config` when we ask for Sorbet version to make it faster on larger codebases.