### PR TITLE
Improvements to `spoom bump`

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -24,7 +24,7 @@ module Spoom
         desc: "Only display what would happen, do not actually change sigils"
       option :only, type: :string, default: nil, aliases: :o,
         desc: "Only change specified list (one file by line)"
-      option :suggest_bump_command, type: :string, default: "spoom bump",
+      option :suggest_bump_command, type: :string,
         desc: "Command to suggest if files can be bumped"
       sig { params(directory: String).void }
       def bump(directory = ".")
@@ -111,8 +111,10 @@ module Spoom
             file_path = Pathname.new(file).relative_path_from(path)
             $stderr.puts(" + #{file_path}")
           end
-          if dry
-            $stderr.puts("\nRun `#{command} --from #{from} --to #{to}` to bump them")
+          if dry && command
+            $stderr.puts("\nRun `#{command}` to bump them")
+          elsif dry
+            $stderr.puts("\nRun `spoom bump --from #{from} --to #{to}` to bump them")
           end
         end
 

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -48,6 +48,8 @@ module Spoom
           exit(1)
         end
 
+        $stderr.puts("Checking files...")
+
         directory = File.expand_path(directory)
         files_to_bump = Sorbet::Sigils.files_with_sigil_strictness(directory, from)
 
@@ -55,6 +57,8 @@ module Spoom
           list = File.read(only).lines.map { |file| File.expand_path(file.strip) }
           files_to_bump.select! { |file| list.include?(File.expand_path(file)) }
         end
+
+        $stderr.puts("\n")
 
         if files_to_bump.empty?
           $stderr.puts("No file to bump from #{from} to #{to}")

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -28,7 +28,11 @@ module Spoom
       def test_bump_no_file
         out, err, status = @project.bundle_exec("spoom bump --no-color")
         assert_empty(out)
-        assert_equal("No file to bump from false to true", err.strip)
+        assert_equal(<<~ERR, err)
+          Checking files...
+
+          No file to bump from false to true
+        ERR
         assert(status)
       end
 
@@ -45,6 +49,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Bumped 1 file from false to true:
            + file1.rb
         ERR
@@ -62,6 +68,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump lib/b")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Bumped 1 file from false to true:
            + lib/b/file.rb
         ERR
@@ -87,6 +95,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --from true --to strict")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Bumped 1 file from true to strict:
            + file2.rb
         ERR
@@ -109,6 +119,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --from ignore --to strong")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Bumped 1 file from ignore to strong:
            + file1.rb
         ERR
@@ -131,6 +143,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --force --from ignore --to strong")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Bumped 2 files from ignore to strong:
            + file1.rb
            + file2.rb
@@ -162,6 +176,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --from true --to strict")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           No file to bump from true to strict
         ERR
         assert(status)
@@ -179,6 +195,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Bumped 1 file from false to true:
            + file.rb
         ERR
@@ -202,6 +220,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --dry")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Can bump 1 file from false to true:
            + file1.rb
 
@@ -226,6 +246,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --dry -f")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Can bump 2 files from false to true:
            + file1.rb
            + file2.rb
@@ -247,6 +269,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --dry -f --suggest-bump-command 'bundle exec spoom bump'")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Can bump 1 file from false to true:
            + file1.rb
 
@@ -261,6 +285,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --dry")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           No file to bump from false to true
         ERR
         assert(status)
@@ -279,6 +305,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump --dry")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           No file to bump from false to true
         ERR
         assert(status)
@@ -302,6 +330,8 @@ module Spoom
         out, err, status = @project.bundle_exec("spoom bump -o files.lst")
         assert_empty(out)
         assert_equal(<<~ERR, err)
+          Checking files...
+
           Bumped 3 files from false to true:
            + file1.rb
            + file3.rb

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -238,6 +238,25 @@ module Spoom
         assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file2.rb"))
       end
 
+      def test_bump_dry_suggest_custom_command
+        @project.write("file1.rb", <<~RB)
+          # typed: false
+          class A; end
+        RB
+
+        out, err, status = @project.bundle_exec("spoom bump --dry -f --suggest-bump-command 'bundle exec spoom bump'")
+        assert_empty(out)
+        assert_equal(<<~ERR, err)
+          Can bump 1 file from false to true:
+           + file1.rb
+
+          Run `bundle exec spoom bump --from false --to true` to bump them
+        ERR
+        refute(status)
+
+        assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/file1.rb"))
+      end
+
       def test_bump_dry_does_nothing_with_no_file
         out, err, status = @project.bundle_exec("spoom bump --dry")
         assert_empty(out)

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -266,7 +266,7 @@ module Spoom
           class A; end
         RB
 
-        out, err, status = @project.bundle_exec("spoom bump --dry -f --suggest-bump-command 'bundle exec spoom bump'")
+        out, err, status = @project.bundle_exec("spoom bump --dry -f --suggest-bump-command 'bump.sh'")
         assert_empty(out)
         assert_equal(<<~ERR, err)
           Checking files...
@@ -274,7 +274,7 @@ module Spoom
           Can bump 1 file from false to true:
            + file1.rb
 
-          Run `bundle exec spoom bump --from false --to true` to bump them
+          Run `bump.sh` to bump them
         ERR
         refute(status)
 


### PR DESCRIPTION
This pull-request does two things:

1. It adds a `--suggest-bump-command` option to the bump command so one can specify how the bump should be ran:

   ```bash
   $ bundle exec spoom bump --dry -f --suggest-bump-command "bundle exec spoom bump"
   Can bump 1 file from false to true:
    + file1.rb

   Run `bundle exec spoom bump --from false --to true` to bump them
   ```

2. It adds a line when the command starts so the user can see something is happening:

   ```bash
   $ bundle exec spoom bump
   Checking files...
   ```