### PR TITLE
Testing against multiple ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,25 +15,33 @@ on:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ruby: [2.6, 2.7]
+        experimental: [false]
+        include:
+          - ruby: 3.0
+            os: [ubuntu-latest]
+            experimental: true
 
-    runs-on: ubuntu-latest
-
+    continue-on-error: ${{ matrix.experimental }}
+    name: ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby }}
+    - run: ruby -v
     - name: Install dependencies
       run: bin/setup
     - name: Run typechecking
       run: bin/typecheck
     - name: Check sigils
       run: bundle exec exe/spoom bump --from true --to strict --dry
-    - name: Run tests
-      run: bin/test
+    - run: bin/test
+      continue-on-error: ${{ matrix.experimental }}
     - name: Run style
       run: bin/style

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
   - 'vendor/**/*'
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,5 @@ gemspec
 group(:development) do
   gem('rubocop-shopify', require: false)
   gem('rubocop-sorbet', require: false)
-  gem('byebug')
   gem('pry-byebug')
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     coderay (1.1.3)
     colorize (0.8.1)
     method_source (1.0.0)
-    minitest (5.14.1)
+    minitest (5.14.3)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -57,7 +57,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
-  byebug
   minitest (~> 5.0)
   pry-byebug
   rake (~> 13.0.1)

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: spoom
 type: ruby
 
 up:
-  - ruby: 2.6.3
+  - ruby: 2.7.2
   - bundler
 
 commands:


### PR DESCRIPTION
This PR aims to improve the GH action to test against multiple ruby versions.
Right now we only know that it works with Ruby 2.6

I'm also introducing tests against Ruby 3.0. It's going to be easier to keep compatibility with all of the stable ruby versions we have right now