### PR TITLE
Bump uses sorbet/config to know which files to change

### DIFF
--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -44,7 +44,7 @@ module Spoom
         in_sorbet_project!
 
         path = exec_path
-        config = Spoom::Sorbet::Config.parse_file(sorbet_config)
+        config = sorbet_config
         files = Spoom::Sorbet.srb_files(config, path: path)
 
         unless options[:rbi]
@@ -52,7 +52,7 @@ module Spoom
         end
 
         if files.empty?
-          say_error("No file matching `#{sorbet_config}`")
+          say_error("No file matching `#{sorbet_config_file}`")
           exit(1)
         end
 

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -53,6 +53,9 @@ module Spoom
         directory = File.expand_path(directory)
         files_to_bump = Sorbet::Sigils.files_with_sigil_strictness(directory, from)
 
+        files_from_config = config_files(path: exec_path)
+        files_to_bump.select! { |file| files_from_config.include?(file) }
+
         if only
           list = File.read(only).lines.map { |file| File.expand_path(file.strip) }
           files_to_bump.select! { |file| list.include?(File.expand_path(file)) }
@@ -120,6 +123,12 @@ module Spoom
 
         def undo_changes(files, from_strictness)
           Sorbet::Sigils.change_sigil_in_files(files, from_strictness)
+        end
+
+        def config_files(path: ".")
+          config = sorbet_config
+          files = Sorbet.srb_files(config, path: path)
+          files.map { |file| File.expand_path(file) }
         end
       end
     end

--- a/lib/spoom/cli/config.rb
+++ b/lib/spoom/cli/config.rb
@@ -14,9 +14,9 @@ module Spoom
       desc "show", "Show Sorbet config"
       def show
         in_sorbet_project!
-        config = Spoom::Sorbet::Config.parse_file(sorbet_config)
+        config = sorbet_config
 
-        say("Found Sorbet config at `#{sorbet_config}`.")
+        say("Found Sorbet config at `#{sorbet_config_file}`.")
 
         say("\nPaths typechecked:")
         if config.paths.empty?

--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -29,7 +29,7 @@ module Spoom
       # Is `spoom` ran inside a project with a `sorbet/config` file?
       sig { returns(T::Boolean) }
       def in_sorbet_project?
-        File.file?(sorbet_config)
+        File.file?(sorbet_config_file)
       end
 
       # Enforce that `spoom` is ran inside a project with a `sorbet/config` file
@@ -39,7 +39,7 @@ module Spoom
       def in_sorbet_project!
         unless in_sorbet_project?
           say_error(
-            "not in a Sorbet project (#{colorize(sorbet_config, :yellow)} not found)\n\n" \
+            "not in a Sorbet project (#{colorize(sorbet_config_file, :yellow)} not found)\n\n" \
             "When running spoom from another path than the project's root, " \
             "use #{colorize('--path PATH', :blue)} to specify the path to the root."
           )
@@ -54,8 +54,13 @@ module Spoom
       end
 
       sig { returns(String) }
-      def sorbet_config
+      def sorbet_config_file
         Pathname.new("#{exec_path}/#{Spoom::Sorbet::CONFIG_PATH}").cleanpath.to_s
+      end
+
+      sig { returns(Sorbet::Config) }
+      def sorbet_config
+        Sorbet::Config.parse_file(sorbet_config_file)
       end
 
       # Is the `--color` option true?


### PR DESCRIPTION
Fix `spoom bump` so it doesn't try to bump files ignored in the `sorbet/config`.