### PR TITLE
Condenses default `spoom tc` output and makes the sort option default

### DIFF
--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -17,7 +17,7 @@ module Spoom
       desc "tc", "Run `srb tc`"
       option :limit, type: :numeric, aliases: :l, desc: "Limit displayed errors"
       option :code, type: :numeric, aliases: :c, desc: "Filter displayed errors by code"
-      option :sort, type: :string, aliases: :s, desc: "Sort errors", enum: SORT_ENUM, lazy_default: SORT_LOC
+      option :sort, type: :string, aliases: :s, desc: "Sort errors", enum: SORT_ENUM, default: SORT_LOC
       option :format, type: :string, aliases: :f, desc: "Format line output"
       option :uniq, type: :boolean, aliases: :u, desc: "Remove duplicated lines"
       option :count, type: :boolean, default: true, desc: "Show errors count"


### PR DESCRIPTION
This PR makes the default output of the `spoom tc` command to be the condensed form of error messages displayed sorted.

Current errors presentation running `spoom tc`:

<img width="595" alt="image" src="https://user-images.githubusercontent.com/25065270/110546615-b911d680-80fc-11eb-9224-8bf79c617591.png">

Proposed error presentation running `spoom tc`:

<img width="442" alt="image" src="https://user-images.githubusercontent.com/25065270/110546457-7e0fa300-80fc-11eb-83eb-7c09f9ccc647.png">
