### PR TITLE
Add option to count errors if files were bumped to true

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -26,6 +26,8 @@ module Spoom
         desc: "Only change specified list (one file by line)"
       option :suggest_bump_command, type: :string,
         desc: "Command to suggest if files can be bumped"
+      option :count_errors, type: :boolean, default: false,
+        desc: "Count the number of errors if all files were bumped"
       sig { params(directory: String).void }
       def bump(directory = ".")
         in_sorbet_project!
@@ -45,6 +47,11 @@ module Spoom
 
         unless Sorbet::Sigils.valid_strictness?(to)
           say_error("Invalid strictness `#{to}` for option `--to`")
+          exit(1)
+        end
+
+        if options[:count_errors] && !dry
+          say_error("`--count-errors` can only be used with `--dry`")
           exit(1)
         end
 
@@ -94,6 +101,8 @@ module Spoom
         end.compact.uniq
 
         undo_changes(files_with_errors, from)
+
+        say("Found #{errors.length} type checking error#{'s' if errors.length > 1}") if options[:count_errors]
 
         files_changed = files_to_bump - files_with_errors
         print_changes(files_changed, command: cmd, from: from, to: to, dry: dry, path: exec_path)


### PR DESCRIPTION
Add `--count-errors` option to bump, which is similar to a dry run, but prints the number of total errors if all files were bumped to true. No changes are made to the files.

This is useful for measuring typing progress in big code bases where addressing a specific signature or error doesn't unlock the file being `typed: true`, but already reduces the remaining errors to fix.

This is how the output looks. (`bspoom` is just an alias for `bin/spoom`).
<img width="363" alt="Screen Shot 2021-03-15 at 3 36 09 PM" src="https://user-images.githubusercontent.com/18742907/111213622-53fc2c00-85a7-11eb-8449-9f45f0989d6f.png">