### PR TITLE
Use new no error sections option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     spoom (1.0.9)
       colorize
-      sorbet (~> 0.5.5)
+      sorbet (>= 0.5.6347)
       sorbet-runtime
       thor (>= 0.19.2)
 
@@ -45,11 +45,11 @@ GEM
     rubocop-sorbet (0.4.0)
       rubocop
     ruby-progressbar (1.10.1)
-    sorbet (0.5.6196)
-      sorbet-static (= 0.5.6196)
-    sorbet-runtime (0.5.6196)
-    sorbet-static (0.5.6196-universal-darwin-14)
-    thor (1.0.1)
+    sorbet (0.5.6349)
+      sorbet-static (= 0.5.6349)
+    sorbet-runtime (0.5.6349)
+    sorbet-static (0.5.6349-universal-darwin-14)
+    thor (1.1.0)
     unicode-display_width (1.7.0)
 
 PLATFORMS

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -76,7 +76,12 @@ module Spoom
           exit(files_to_bump.empty?)
         end
 
-        output, no_errors = Sorbet.srb_tc(path: exec_path, capture_err: true, sorbet_bin: options[:sorbet])
+        output, no_errors = Sorbet.srb_tc(
+          "--no-error-sections",
+          path: exec_path,
+          capture_err: true,
+          sorbet_bin: options[:sorbet]
+        )
 
         if no_errors
           print_changes(files_to_bump, command: cmd, from: from, to: to, dry: dry, path: exec_path)

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -14,11 +14,12 @@ module Spoom
       return "", "Error: `#{path}` is not a directory.", false unless File.directory?(path)
       opts = {}
       opts[:chdir] = path
-      _, o, e, s = Open3.popen3(*T.unsafe([command, *T.unsafe(arg), opts]))
+      i, o, e, s = Open3.popen3(*T.unsafe([command, *T.unsafe(arg), opts]))
       out = o.read.to_s
       o.close
       err = e.read.to_s
       e.close
+      i.close
       [out, err, T.cast(s.value, Process::Status).success?]
     end
 

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.0")
 
   spec.add_dependency("sorbet-runtime")
-  spec.add_dependency("sorbet", "~> 0.5.5")
+  spec.add_dependency("sorbet", ">= 0.5.6347")
   spec.add_dependency("thor", ">= 0.19.2")
   spec.add_dependency("colorize")
 

--- a/test/spoom/cli/lsp_test.rb
+++ b/test/spoom/cli/lsp_test.rb
@@ -44,7 +44,7 @@ module Spoom
         assert_equal(<<~MSG, err)
           Error: Sorbet returned typechecking errors for `/errors.rb`
             8:0-8:11: Not enough arguments provided for method `Foo#foo`. Expected: `1`, got: `0` (7004)
-            4:2-5:5: Returning value that does not conform to method result type (7005)
+            4:2-5:5: Expected `String` but found `NilClass` for method result type (7005)
             3:2-3:43: Method `sig` does not exist on `T.class_of(Foo)` (7003)
             3:8-3:25: Method `params` does not exist on `T.class_of(Foo)` (7003)
             9:0-9:3: Unable to resolve constant `Bar` (fix available) (5002)


### PR DESCRIPTION
Use the new option introduced in https://github.com/sorbet/sorbet/pull/4078 for Spoom bump.

I locked the version of Sorbet to be greater or equal to the one where the new option is introduced.