### PR TITLE
Fallback to older srb if necessary

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     spoom (1.0.9)
       colorize
-      sorbet (>= 0.5.6347)
+      sorbet (~> 0.5.5)
       sorbet-runtime
       thor (>= 0.19.2)
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ Bump files using a custom instance of Sorbet:
 $ spoom bump --from false --to true --sorbet /path/to/sorbet/bin
 ```
 
+Count the number of errors if all files were bumped to true:
+
+```
+$ spoom bump --count-errors --dry
+```
+
 #### Interact with Sorbet LSP mode
 
 **Experimental**

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -83,12 +83,9 @@ module Spoom
           exit(files_to_bump.empty?)
         end
 
-        output, no_errors = Sorbet.srb_tc(
-          "--no-error-sections",
-          path: exec_path,
-          capture_err: true,
-          sorbet_bin: options[:sorbet]
-        )
+        tc_args = []
+        tc_args << "--no-error-sections" if Sorbet.srb_version.to_s >= "0.5.6347"
+        output, no_errors = Sorbet.srb_tc(*tc_args, path: exec_path, capture_err: true, sorbet_bin: options[:sorbet])
 
         if no_errors
           print_changes(files_to_bump, command: cmd, from: from, to: to, dry: dry, path: exec_path)

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.0")
 
   spec.add_dependency("sorbet-runtime")
-  spec.add_dependency("sorbet", ">= 0.5.6347")
+  spec.add_dependency("sorbet", "~> 0.5.5")
   spec.add_dependency("thor", ">= 0.19.2")
   spec.add_dependency("colorize")
 


### PR DESCRIPTION
Instead of making our Sorbet version requirement more strict, we should determine whether to use the new `--no-error-sections` option based on the executable version.

This PR checks the version and decides whether to use the argument or not. On the second commit, I also mentioned the new `--count-errors` option in the README, which we missed in #76.