### PR TITLE
Add --count-errors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ Bump files using a custom instance of Sorbet:
 $ spoom bump --from false --to true --sorbet /path/to/sorbet/bin
 ```
 
+Count the number of errors if all files were bumped to true:
+
+```
+$ spoom bump --count-errors --dry
+```
+
 #### Interact with Sorbet LSP mode
 
 **Experimental**

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Bump files using a custom instance of Sorbet:
 $ spoom bump --from false --to true --sorbet /path/to/sorbet/bin
 ```
 
-Count the number of errors if all files were bumped to true:
+Count the number of type-checking errors if all files were bumped to true:
 
 ```
 $ spoom bump --count-errors --dry


### PR DESCRIPTION
Add a note about the new `--count-errors` option in the README.