### PR TITLE
Do not crash when requesting sigil from a directory instead of a file

### DIFF
--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -55,7 +55,7 @@ module Spoom
       # * returns nil if no sigil
       sig { params(path: T.any(String, Pathname)).returns(T.nilable(String)) }
       def self.file_strictness(path)
-        return nil unless File.exist?(path)
+        return nil unless File.file?(path)
         content = File.read(path, encoding: Encoding::ASCII_8BIT)
         strictness_in_content(content)
       end

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -159,6 +159,11 @@ module Spoom
         assert_nil(strictness)
       end
 
+      def test_file_strictness_returns_nil_if_file_is_dir
+        strictness = Sigils.file_strictness("/")
+        assert_nil(strictness)
+      end
+
       def test_file_strictness_with_valid_sigil
         project = spoom_project("test_sigils")
         project.write("file.rb", "# typed: true")


### PR DESCRIPTION
Requesting the sigil from a path that points to a directory was ending up in a crash:

```
Sigils.file_strictness("/")
```

```
Errno::EISDIR: Is a directory @ io_fread - /
    lib/spoom/sorbet/sigils.rb:59:in `read'
    lib/spoom/sorbet/sigils.rb:59:in `file_strictness'
```

With this PR we return `nil` instead.