### PR TITLE
Pass more options to Sorbet when computing coverage metrics

### DIFF
--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -21,6 +21,9 @@ module Spoom
 
       metrics = Spoom::Sorbet.srb_metrics(
         "--no-config",
+        "--no-error-sections",
+        "--no-error-count",
+        "--isolate-error-code=0",
         new_config.options_string,
         path: path,
         capture_err: true,


### PR DESCRIPTION
Speed up the computing a bit in case the project contains a lot of errors.

No functional changes.