### PR TITLE
Parse --no-stdlib from config

### DIFF
--- a/lib/spoom/sorbet/config.rb
+++ b/lib/spoom/sorbet/config.rb
@@ -29,11 +29,15 @@ module Spoom
       sig { returns(T::Array[String]) }
       attr_reader :paths, :ignore, :allowed_extensions
 
+      sig { returns(T::Boolean) }
+      attr_accessor :no_stdlib
+
       sig { void }
       def initialize
         @paths = T.let([], T::Array[String])
         @ignore = T.let([], T::Array[String])
         @allowed_extensions = T.let([], T::Array[String])
+        @no_stdlib = T.let(false, T::Boolean)
       end
 
       sig { returns(Config) }
@@ -42,6 +46,7 @@ module Spoom
         new_config.paths.concat(@paths)
         new_config.ignore.concat(@ignore)
         new_config.allowed_extensions.concat(@allowed_extensions)
+        new_config.no_stdlib = @no_stdlib
         new_config
       end
 
@@ -63,6 +68,7 @@ module Spoom
         opts.concat(paths)
         opts.concat(ignore.map { |p| "--ignore #{p}" })
         opts.concat(allowed_extensions.map { |ext| "--allowed-extension #{ext}" })
+        opts << "--no-stdlib" if @no_stdlib
         opts.join(" ")
       end
 
@@ -105,6 +111,9 @@ module Spoom
               next
             when /^--dir=/
               config.paths << parse_option(line)
+              next
+            when /^--no-stdlib$/
+              config.no_stdlib = true
               next
             when /^--.*=/
               next

--- a/test/spoom/sorbet/config_test.rb
+++ b/test/spoom/sorbet/config_test.rb
@@ -86,6 +86,17 @@ module Spoom
         assert_empty(config.allowed_extensions)
       end
 
+      def test_parses_a_config_string_with_no_stdlib
+        config = Spoom::Sorbet::Config.parse_string(<<~CONFIG)
+          a
+          b
+          --no-stdlib
+          c
+        CONFIG
+        assert_equal(['a', 'b', 'c'], config.paths)
+        assert(config.no_stdlib)
+      end
+
       def test_parses_a_config_string_with_mixed_options
         config = Spoom::Sorbet::Config.parse_string(<<~CONFIG)
           a
@@ -124,10 +135,12 @@ module Spoom
           --allowed-extension=.rbi
           --allowed-extension=.rake
           --allowed-extension=.ru
+          --no-stdlib
         CONFIG
         assert_equal(['.'], config.paths)
         assert_equal(['.git/', '.idea/', 'vendor/'], config.ignore)
         assert_equal(['.rb', '.rbi', '.rake', '.ru'], config.allowed_extensions)
+        assert(config.no_stdlib)
       end
 
       def test_parses_a_config_file_with_errors
@@ -161,8 +174,9 @@ module Spoom
           --ignore=.git/
           --ignore=vendor/
           --allowed-extension=.rb
+          --no-stdlib
         CONFIG
-        assert_equal(". --ignore .git/ --ignore vendor/ --allowed-extension .rb", config.options_string)
+        assert_equal(". --ignore .git/ --ignore vendor/ --allowed-extension .rb --no-stdlib", config.options_string)
       end
     end
   end


### PR DESCRIPTION
When computing typing coverage for a project which use `--no-stdlib` we should pass back this option. Without it, Sorbet will hang or return a bazillion errors.

This PR makes the `Config` parser recognize `--no-stdlib` in the config file and generate it when we ask for the options string.