### PR TITLE
Find `sorbet/config` removal

### DIFF
--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -97,5 +97,15 @@ module Spoom
       return nil if res.empty?
       res
     end
+
+    # Get the hash of the commit removing the `sorbet/config` file
+    sig { params(path: String).returns(T.nilable(String)) }
+    def self.sorbet_removal_commit(path: ".")
+      res, _, status = Spoom::Git.log("--diff-filter=D --format='%h' -1 -- sorbet/config", path: path)
+      return nil unless status
+      res.strip!
+      return nil if res.empty?
+      res
+    end
   end
 end

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -93,7 +93,9 @@ module Spoom
     def self.sorbet_intro_commit(path: ".")
       res, _, status = Spoom::Git.log("--diff-filter=A --format='%h' -1 -- sorbet/config", path: path)
       return nil unless status
-      res.strip
+      res.strip!
+      return nil if res.empty?
+      res
     end
   end
 end

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -109,6 +109,20 @@ module Spoom
         sha = Spoom::Git.sorbet_intro_commit(path: @project.path)
         assert_match(/\A[a-z0-9]+\z/, sha)
       end
+
+      def test_sorbet_removal_not_found
+        sha = Spoom::Git.sorbet_removal_commit(path: @project.path)
+        assert_nil(sha)
+      end
+
+      def test_sorbet_removal_found
+        @project.write("sorbet/config")
+        @project.commit
+        @project.remove("sorbet/config")
+        @project.commit
+        sha = Spoom::Git.sorbet_removal_commit(path: @project.path)
+        assert_match(/\A[a-z0-9]+\z/, sha)
+      end
     end
   end
 end


### PR DESCRIPTION
Main change: Add `sorbet_removal_commit` method so one can find when the  `sorbet/config` was removed.

Side change: Return `nil` if no `sorbet_intro_commit` was found. The git log command can return the exit code 0 while nothing matches the search. We add a check to ensure we return `nil` is the output is empty.