### PR TITLE
Avoid changing the sigils of files not bumped

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -102,6 +102,7 @@ module Spoom
           path = File.expand_path(err.file)
           next unless path.start_with?(directory)
           next unless File.file?(path)
+          next unless files_to_bump.include?(path)
           path
         end.compact.uniq
 


### PR DESCRIPTION
Let's consider this RBI file:

```rbi
# file1.rbi
# typed: true
class A
  def foo(a, b, c); end
end
```

We can create a conflict of signature when turning this file to `true`:

```rbi
# file2.rb
# typed: false
class A
  def foo(a, b); end
end
```

When this happens an error will be reported for both `file1.rbi` and `file2.rb` which prompted `spoom bump` to revert the file to `typed: false` even if it was not bumped in the first place.

This PR fixes this behaviour by reverting only the sigil for files that were bumped.

Fixes #85.