### PR TITLE
Make `spoom bump --dry` message more obvious

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -133,7 +133,7 @@ module Spoom
           if dry && command
             say("\nRun `#{command}` to bump them")
           elsif dry
-            say("\nRun `spoom bump --from #{from} --to #{to}` to bump them")
+            say("\nRun `spoom bump --from #{from} --to #{to}` locally then `commit the changes` and `push them`")
           end
         end
 

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -225,7 +225,7 @@ module Spoom
           Can bump `1` file from `false` to `true`:
            + file1.rb
 
-          Run `spoom bump --from false --to true` to bump them
+          Run `spoom bump --from false --to true` locally then `commit the changes` and `push them`
         OUT
         refute(status)
 
@@ -252,7 +252,7 @@ module Spoom
            + file1.rb
            + file2.rb
 
-          Run `spoom bump --from false --to true` to bump them
+          Run `spoom bump --from false --to true` locally then `commit the changes` and `push them`
         OUT
         refute(status)
 


### PR DESCRIPTION
Try to make the `dry` error message and solution clearer:

![image](https://user-images.githubusercontent.com/583144/120854801-abc58600-c54b-11eb-9033-6cd609c5ef48.png)
