### PR TITLE
checkout the original branch instead of commit when available

### DIFF
--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -44,8 +44,9 @@ module Spoom
         path = exec_path
         sorbet = options[:sorbet]
 
-        sha_before = Spoom::Git.last_commit(path: path)
-        unless sha_before
+        ref_before = Spoom::Git.current_branch
+        ref_before = Spoom::Git.last_commit(path: path) unless ref_before
+        unless ref_before
           say_error("Not in a git repository")
           say_error("\nSpoom needs to checkout into your previous commits to build the timeline.", status: nil)
           exit(1)
@@ -107,7 +108,7 @@ module Spoom
           File.write(file, snapshot.to_json)
           say("  Snapshot data saved under `#{file}`\n\n")
         end
-        Spoom::Git.checkout(sha_before, path: path)
+        Spoom::Git.checkout(ref_before, path: path)
       end
 
       desc "report", "Produce a typing coverage report"

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -50,6 +50,13 @@ module Spoom
       exec("git show #{arg.join(' ')}", path: path)
     end
 
+    sig { params(path: String).returns(T.nilable(String)) }
+    def self.current_branch(path: ".")
+      out, _, status = exec("git branch --show-current", path: path)
+      return nil unless status
+      out.strip
+    end
+
     # Utils
 
     # Get the commit epoch timestamp for a `sha`

--- a/lib/spoom/test_helpers/project.rb
+++ b/lib/spoom/test_helpers/project.rb
@@ -100,6 +100,16 @@ module Spoom
         FileUtils.rm_rf(path)
       end
 
+      sig { params(name: String).void }
+      def create_and_checkout_branch(name)
+        Spoom::Git.exec("git checkout -b #{name}", path: path)
+      end
+
+      sig { returns(T.nilable(String)) }
+      def current_branch
+        Spoom::Git.current_branch(path: path)
+      end
+
       private
 
       # Create an absolute path from `self.path` and `rel_path`

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -420,6 +420,15 @@ module Spoom
         assert(File.exist?("#{@project.path}/spoom_report.html"))
       end
 
+      def test_finish_on_original_branch
+        create_git_history
+        assert_equal("master", @project.current_branch)
+        @project.create_and_checkout_branch("fake-branch")
+        assert_equal("fake-branch", @project.current_branch)
+        @project.bundle_exec("spoom coverage timeline --save")
+        assert_equal("fake-branch", @project.current_branch)
+      end
+
       private
 
       def create_git_history


### PR DESCRIPTION
This addresses the issue that spoom would checkout the original commit instead of the original branch when running the coverage command. 

This is a draft PR as I have not figured out how to simulate being on a branch in a test yet, so do not have a test for the behaviour yet. 