### PR TITLE
Updates sorbet version requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     spoom (1.1.3)
       colorize
-      sorbet (>= 0.5.6347)
+      sorbet (>= 0.5.9204)
       sorbet-runtime
       thor (>= 0.19.2)
 
@@ -45,17 +45,18 @@ GEM
     rubocop-sorbet (0.4.0)
       rubocop
     ruby-progressbar (1.10.1)
-    sorbet (0.5.6530)
-      sorbet-static (= 0.5.6530)
-    sorbet-runtime (0.5.6530)
-    sorbet-static (0.5.6530-universal-darwin-14)
-    sorbet-static (0.5.6530-universal-darwin-15)
-    sorbet-static (0.5.6530-universal-darwin-16)
-    sorbet-static (0.5.6530-universal-darwin-17)
-    sorbet-static (0.5.6530-universal-darwin-18)
-    sorbet-static (0.5.6530-universal-darwin-19)
-    sorbet-static (0.5.6530-universal-darwin-20)
-    sorbet-static (0.5.6530-x86_64-linux)
+    sorbet (0.5.9204)
+      sorbet-static (= 0.5.9204)
+    sorbet-runtime (0.5.9204)
+    sorbet-static (0.5.9204-universal-darwin-14)
+    sorbet-static (0.5.9204-universal-darwin-15)
+    sorbet-static (0.5.9204-universal-darwin-16)
+    sorbet-static (0.5.9204-universal-darwin-17)
+    sorbet-static (0.5.9204-universal-darwin-18)
+    sorbet-static (0.5.9204-universal-darwin-19)
+    sorbet-static (0.5.9204-universal-darwin-20)
+    sorbet-static (0.5.9204-universal-darwin-21)
+    sorbet-static (0.5.9204-x86_64-linux)
     thor (1.1.0)
     unicode-display_width (1.7.0)
 
@@ -72,4 +73,4 @@ DEPENDENCIES
   spoom!
 
 BUNDLED WITH
-   2.2.24
+   2.2.28

--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -12,7 +12,7 @@ module Spoom
       extend T::Helpers
       include Thor::Shell
 
-      requires_ancestor Thor
+      requires_ancestor { Thor }
 
       # Print `message` on `$stdout`
       sig { params(message: String).void }

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.0")
 
   spec.add_dependency("sorbet-runtime")
-  spec.add_dependency("sorbet", ">= 0.5.6347")
+  spec.add_dependency("sorbet", ">= 0.5.9204")
   spec.add_dependency("thor", ">= 0.19.2")
   spec.add_dependency("colorize")
 


### PR DESCRIPTION
Sorbet's recent update broke the signature of the `require_ancestors`
function. This call is used in the CLI helper which gets called from
tapioca.

The version requirement is bumped because this change is not backwards
compatible.