### PR TITLE
Remove useless include of `Thor::Shell` in `Spoom::Cli::Helper`

### DIFF
--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -10,7 +10,6 @@ module Spoom
     module Helper
       extend T::Sig
       extend T::Helpers
-      include Thor::Shell
 
       requires_ancestor { Thor }
 


### PR DESCRIPTION
I think this predated the ancestor requirement to `Thor` but it's definitely useless now.