### PR TITLE
Require `pathname`

### DIFF
--- a/lib/spoom.rb
+++ b/lib/spoom.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
-require "set"
 require "pathname"
 
 module Spoom

--- a/lib/spoom.rb
+++ b/lib/spoom.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "set"
+require "pathname"
 
 module Spoom
   extend T::Sig

--- a/lib/spoom/sorbet/lsp/structures.rb
+++ b/lib/spoom/sorbet/lsp/structures.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "../../printer"
+require "set"
 
 module Spoom
   module LSP


### PR DESCRIPTION
`pathname` is in the standard library but not core, so it needs to be required before being used.

Bundler requires it when you use `bundle exec spoom` or a `spoom` binstub:
https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/shared_helpers.rb#L3

But it may not always be the case. Also if you don't use Bundler but simply run `gem install spoom && spoom --version`, it fails because of that.