### PR TITLE
Fix bump command when called with a custom `--error-url-base`

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -83,8 +83,10 @@ module Spoom
           exit(files_to_bump.empty?)
         end
 
+        error_url_base = Spoom::Sorbet::Errors::DEFAULT_ERROR_URL_BASE
         output, status, exit_code = Sorbet.srb_tc(
           "--no-error-sections",
+          "--error-url-base=#{error_url_base}",
           path: exec_path,
           capture_err: true,
           sorbet_bin: options[:sorbet]
@@ -104,7 +106,7 @@ module Spoom
           exit(files_to_bump.empty?)
         end
 
-        errors = Sorbet::Errors::Parser.parse_string(output)
+        errors = Sorbet::Errors::Parser.parse_string(output, error_url_base: error_url_base)
 
         files_with_errors = errors.map do |err|
           path = File.expand_path(err.file)

--- a/test/spoom/sorbet/errors_test.rb
+++ b/test/spoom/sorbet/errors_test.rb
@@ -248,6 +248,30 @@ module Spoom
         assert_equal([7003, 7001, 7002], errors.map(&:code))
       end
 
+      def test_parses_errors_with_custom_error_url_base
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR, error_url_base: "https://custom-url#")
+          a.rb:80: unexpected token "end" https://custom-url#2001
+              80 |end
+                  ^^^
+
+          b.rb:28: Not enough arguments provided for method Foo#bar. Expected: 1..2, got: 1 https://custom-url#7004
+              28 |              bar "hello"
+                                ^^^^^^^^^^^
+
+          c.rb:100: Method Foo#initialize redefined without matching argument count. Expected: 0, got: 2 https://custom-url#4010
+               100 |    class Foo < T::Struct
+               101 |    end
+
+          d.rb:105: Method foo does not exist on String https://custom-url#7003
+               105 |        printer.print "foo".light_black
+                                          ^^^^^^^^^^^^^^^^^
+        ERR
+        assert_equal(4, errors.size)
+        assert_equal(["a.rb", "b.rb", "c.rb", "d.rb"], errors.map(&:file))
+        assert_equal([80, 28, 100, 105], errors.map(&:line))
+        assert_equal([2001, 7004, 4010, 7003], errors.map(&:code))
+      end
+
       def test_sort_errors
         errors = Spoom::Sorbet::Errors::Parser.parse_string(<<~ERR)
           z.rb:80: unexpected token "end" https://srb.help/2001


### PR DESCRIPTION
The regexp used to parse the error lines produced by Sorbet contained a hard-coded `https://srb.help/` for the error url base.

This meant that when the `spoom bump` command was called on a project containing a custom `--error-url-base` option in its `sorbet/config` file, the parsing went awry and Spoom didn't detect any error in the bumped files resulting in all files being bumped even if it produced thousands or errors.

This PR makes the error-url-base configurable when calling the `Errors::Parser` and override the `--error-url-base` option with a predefined one when calling `spoom bump`.

cc. @RyanBrushett 