### PR TITLE
Fix main branch name when initializing a new test repo

### DIFF
--- a/lib/spoom/test_helpers/project.rb
+++ b/lib/spoom/test_helpers/project.rb
@@ -62,9 +62,9 @@ module Spoom
       # Actions
 
       # Run `git init` in this project
-      sig { void }
-      def git_init
-        Spoom::Git.exec("git init -q", path: path)
+      sig { params(branch: String).void }
+      def git_init(branch: "main")
+        Spoom::Git.exec("git init -q -b #{branch}", path: path)
         Spoom::Git.exec("git config user.name 'spoom-tests'", path: path)
         Spoom::Git.exec("git config user.email 'spoom@shopify.com'", path: path)
       end

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -421,7 +421,7 @@ module Spoom
 
       def test_finish_on_original_branch
         create_git_history
-        assert_equal("master", @project.current_branch)
+        assert_equal("main", @project.current_branch)
         @project.create_and_checkout_branch("fake-branch")
         assert_equal("fake-branch", @project.current_branch)
         @project.bundle_exec("spoom coverage timeline --save")

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -89,7 +89,7 @@ module Spoom
       def test_git_rev_parse
         @project.write("file")
         @project.commit
-        assert_match(/^[a-f0-9]+$/, Spoom::Git.rev_parse("master", path: @project.path).first.strip)
+        assert_match(/^[a-f0-9]+$/, Spoom::Git.rev_parse("main", path: @project.path).first.strip)
       end
 
       def test_git_show


### PR DESCRIPTION
We were previously making the assumption that the main branch on a new repo was always `master` which is no longer the case.

This pull-request fixes the tests on environments where git is configured with a different default branch name by always using `main`. 

cc. @RyanBrushett 