### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,8 +25,6 @@ jobs:
           - ruby: '3.1'
             os: ubuntu-latest
             experimental: true
-            env:
-              RUBYOPT: "--disable-error_highlight"
     continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix and shifts Ruby 3.0 out of experimental.

It also addresses some syntax issues in the CI config:

1. 3.0 is now wrapped in quotes so that it is not truncated to 3.  If unquoted, a 3.0 causes the latest Ruby 3 (at this point Ruby 3.1.0) to be loaded.  To ensure a Ruby 3.0.x is loaded this must be quoted
2. Removed the array in the os entry in the include.  This should be a single element, not an array.

I'm seeing flaky failures on one individual spec, shifting between Ruby versions with different runs.
