### PR TITLE
Fix flaky `test_run_srb_from_bundler_not_found` test

### DIFF
--- a/test/spoom/sorbet/run_test.rb
+++ b/test/spoom/sorbet/run_test.rb
@@ -43,7 +43,7 @@ module Spoom
 
           _, status, exit_code = Spoom::Sorbet.srb(path: @project.path, capture_err: true)
           refute(status)
-          assert_equal(1, exit_code)
+          refute_equal(0, exit_code)
         end
       end
 


### PR DESCRIPTION
Closes #117.

This was actually order dependent.

If this test is executed first and the gem `sorbet` is not installed
on the system Bundler won't know about it and simply exit with a 127
error code.

Whereas if this test is executed _after_ one installing `sorbet`, Bundler
will see the `srb` executable in the GEM_PATH and raise a different error
(explaining that the executable is not in the bundle) and return 1 instead.