### PR TITLE
Preserve empty lines when using `spoom bump`

### DIFF
--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -25,7 +25,7 @@ module Spoom
         STRICTNESS_INTERNAL,
       ].freeze, T::Array[String])
 
-      SIGIL_REGEXP = T.let(/^#\s*typed\s*:\s*(\w*)$/.freeze, Regexp)
+      SIGIL_REGEXP = T.let(/^#[\ t]*typed[\ t]*:[ \t]*(\w*)[ \t]*/.freeze, Regexp)
 
       # returns the full sigil comment string for the passed strictness
       sig { params(strictness: String).returns(String) }

--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -25,7 +25,7 @@ module Spoom
         STRICTNESS_INTERNAL,
       ].freeze, T::Array[String])
 
-      SIGIL_REGEXP = T.let(/^#\s*typed\s*:\s*(\w*)\s*$/.freeze, Regexp)
+      SIGIL_REGEXP = T.let(/^#\s*typed\s*:\s*(\w*)$/.freeze, Regexp)
 
       # returns the full sigil comment string for the passed strictness
       sig { params(strictness: String).returns(String) }

--- a/lib/spoom/test_helpers/project.rb
+++ b/lib/spoom/test_helpers/project.rb
@@ -59,6 +59,11 @@ module Spoom
         Dir.glob("#{@path}/**/*").sort
       end
 
+      sig { params(rel_path: String).returns(String) }
+      def read(rel_path)
+        File.read(absolute_path(rel_path))
+      end
+
       # Actions
 
       # Run `git init` in this project

--- a/lib/spoom/test_helpers/project.rb
+++ b/lib/spoom/test_helpers/project.rb
@@ -59,6 +59,7 @@ module Spoom
         Dir.glob("#{@path}/**/*").sort
       end
 
+      # Return the content of the file at `rel_path`
       sig { params(rel_path: String).returns(String) }
       def read(rel_path)
         File.read(absolute_path(rel_path))

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -512,6 +512,30 @@ module Spoom
           assert_equal("false", Sorbet::Sigils.file_strictness("#{@project.path}/will_segfault.rb"))
         end
       end
+
+      def test_bump_preserve_empty_line
+        @project.write("file1.rb", <<~RB)
+          # typed: false
+
+          class A; end
+        RB
+
+        result = @project.bundle_exec("spoom bump --no-color")
+        assert_empty(result.err)
+        assert_equal(<<~OUT, result.out)
+          Checking files...
+
+          Bumped `1` file from `false` to `true`:
+           + file1.rb
+        OUT
+        refute(result.status)
+
+        assert_equal(<<~RB, @project.read("file1.rb"))
+          # typed: true
+
+          class A; end
+        RB
+      end
     end
   end
 end


### PR DESCRIPTION
Fix for #118

Right now, Spoom will remove empty lines after bumping files. My guess is most codebases wouldn't be affected because of enforced magic comments such as `# frozen_string_literal: true`.

Before:
```ruby
# typed: false

class Foo; end
```

After:
```ruby
# typed: true
class Foo; end
```

Adjusting the type sigil regex to only match on horizontal whitespace (tabs and spaces) seems to fix the issue, although there could be additional edge cases to consider.