### PR TITLE
Fix encoding issues when writing non-ASCII content

### DIFF
--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -66,7 +66,7 @@ module Spoom
         content = File.read(path, encoding: Encoding::ASCII_8BIT)
         new_content = update_sigil(content, new_strictness)
 
-        File.write(path, new_content)
+        File.write(path, new_content, encoding: Encoding::ASCII_8BIT)
 
         strictness_in_content(new_content) == new_strictness
       end

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -220,6 +220,29 @@ module Spoom
         project.destroy
       end
 
+      def test_change_sigil_in_file_with_default_internal_encoding
+        project = spoom_project
+
+        string = <<~RB
+          # typed: true
+
+          puts "À coûté 10€"
+        RB
+
+        old_encoding = Encoding.default_internal
+        project.write("file.rb", string.encode("UTF-8"))
+
+        begin
+          Encoding.default_internal = Encoding::UTF_8
+
+          Sigils.change_sigil_in_file("#{project.path}/file.rb", "strict")
+          assert_equal("strict", Sigils.file_strictness("#{project.path}/file.rb"))
+        ensure
+          Encoding.default_internal = old_encoding
+          project.destroy
+        end
+      end
+
       def test_change_sigil_in_files_false_to_true
         project = spoom_project
         project.write("file1.rb", "# typed: false")


### PR DESCRIPTION
This fixes the bug reported here: https://github.com/Shopify/tapioca/issues/881.

I traced the problem to a combination of writing the content without specifying an `encoding` [here](https://github.com/Shopify/spoom/blob/main/lib/spoom/sorbet/sigils.rb#L69) while `Encoding.default_internal` is set to `Encoding::UTF_8` by Rails [here](https://github.com/rails/rails/blob/main/railties/lib/rails.rb#L22).

In these circumstances, writing the new RBI content will fail if it contains UTF-8 characters.