### PR TITLE
Update Ruby dependency to 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: [ "2.7", "3.0", "3.1" ]
         experimental: [false]
         include:
           - ruby: '3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,4 +133,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.2.27
+   2.3.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       spoom
       thor (>= 0.19.2)
       yard-sorbet
-    thor (1.1.0)
+    thor (1.2.1)
     thread_safe (0.3.6)
     unicode-display_width (1.7.0)
     unparser (0.5.5)

--- a/sorbet/rbi/gems/thor@1.2.1.rbi
+++ b/sorbet/rbi/gems/thor@1.2.1.rbi
@@ -388,6 +388,7 @@ class Thor::CoreExt::HashWithIndifferentAccess < ::Hash
   def [](key); end
   def []=(key, value); end
   def delete(key); end
+  def except(*keys); end
   def fetch(key, *args); end
   def key?(key); end
   def merge(other); end
@@ -600,6 +601,8 @@ class Thor::Options < ::Thor::Arguments
   def parse(args); end
   def peek; end
   def remaining; end
+  def shift; end
+  def unshift(arg, is_value: T.unsafe(nil)); end
 
   protected
 
@@ -652,6 +655,7 @@ module Thor::Shell
   def print_table(*args, &block); end
   def print_wrapped(*args, &block); end
   def say(*args, &block); end
+  def say_error(*args, &block); end
   def say_status(*args, &block); end
   def set_color(*args, &block); end
   def shell; end
@@ -683,6 +687,7 @@ class Thor::Shell::Basic
   def print_table(array, options = T.unsafe(nil)); end
   def print_wrapped(message, options = T.unsafe(nil)); end
   def say(message = T.unsafe(nil), color = T.unsafe(nil), force_new_line = T.unsafe(nil)); end
+  def say_error(message = T.unsafe(nil), color = T.unsafe(nil), force_new_line = T.unsafe(nil)); end
   def say_status(status, message, log_status = T.unsafe(nil)); end
   def set_color(string, *_arg1); end
   def terminal_width; end

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("sorbet", ">= 0.5.9204")
   spec.add_dependency("thor", ">= 0.19.2")
 
-  spec.required_ruby_version = ">= 2.3.7"
+  spec.required_ruby_version = ">= 2.7.0"
 end


### PR DESCRIPTION
Ruby 2.6 is [EOL since 2022-03-31](https://www.ruby-lang.org/en/downloads/branches/#:~:text=EOL%20date%3A%202022%2D03%2D31).