### PR TITLE
Do not go through all directory files when bumping

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -58,10 +58,10 @@ module Spoom
         say("Checking files...")
 
         directory = File.expand_path(directory)
-        files_to_bump = Sorbet::Sigils.files_with_sigil_strictness(directory, from)
 
-        files_from_config = config_files(path: exec_path)
-        files_to_bump.select! { |file| files_from_config.include?(file) }
+        files_to_bump = config_files(path: exec_path)
+        files_to_bump.select! { |file|  file.start_with?(directory) && !file.end_with?(".rbi") }
+        files_to_bump.select! { |file|  Sorbet::Sigils.file_has_strictness?(file, from) }
 
         if only
           list = File.read(only).lines.map { |file| File.expand_path(file.strip) }

--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -60,6 +60,12 @@ module Spoom
         strictness_in_content(content)
       end
 
+      # does the file at `path` have the sigil `strictness`?
+      sig { params(path: T.any(String, Pathname), strictness: String).returns(T::Boolean) }
+      def self.file_has_strictness?(path, strictness)
+        file_strictness(path) == strictness
+      end
+
       # changes the sigil in the file at the passed path to the specified new strictness
       sig { params(path: T.any(String, Pathname), new_strictness: String).returns(T::Boolean) }
       def self.change_sigil_in_file(path, new_strictness)


### PR DESCRIPTION
Closes #127.

Before this patch, we were listing, reading and checking _all_ the files (direct and in subdirs) we could find from the bump `directory`. This may be highly inefficient, especially when the directory contains a lot of files that will end up ignored from the Sorbet config.

After this patch, while we still list them all, we at least do not read and check them if they get ignored by the config.