### PR TITLE
Update coverage cli command to reflect --save option

### DIFF
--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -198,7 +198,7 @@ module Spoom
 
             If you already generated snapshot files under another directory use #{blue('spoom coverage report PATH')}.
 
-            To generate snapshot files run #{blue('spoom coverage timeline --save-dir spoom_data')}.
+            To generate snapshot files run #{blue('spoom coverage timeline --save')}.
           ERR
         end
       end

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -401,7 +401,7 @@ module Spoom
 
           If you already generated snapshot files under another directory use spoom coverage report PATH.
 
-          To generate snapshot files run spoom coverage timeline --save-dir spoom_data.
+          To generate snapshot files run spoom coverage timeline --save.
         ERR
       end
 


### PR DESCRIPTION
--save-dir was removed in #32 however the error message for the
coverage cli command still referenced it. This updates the command
included in the error message to reflect the current available
options.