### PR TITLE
Override user error-url-base when running Sorbet with `spoom tc`

### DIFF
--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -47,8 +47,10 @@ module Spoom
           exit(result.status)
         end
 
+        error_url_base = Spoom::Sorbet::Errors::DEFAULT_ERROR_URL_BASE
         result = T.unsafe(Spoom::Sorbet).srb_tc(
           *arg,
+          "--error-url-base=#{error_url_base}",
           path: path,
           capture_err: true,
           sorbet_bin: sorbet
@@ -61,7 +63,7 @@ module Spoom
           exit(0)
         end
 
-        errors = Spoom::Sorbet::Errors::Parser.parse_string(result.err)
+        errors = Spoom::Sorbet::Errors::Parser.parse_string(result.err, error_url_base: error_url_base)
         errors_count = errors.size
 
         errors = case sort

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -79,6 +79,25 @@ module Spoom
         refute(result.status)
       end
 
+      def test_display_errors_with_sort_default_with_custom_url
+        @project.sorbet_config(<<~CONFIG)
+          .
+          --error-url-base=https://custom#
+        CONFIG
+        result = @project.bundle_exec("spoom tc --no-color -s")
+        assert_equal(<<~MSG, result.err)
+          5002 - errors/errors.rb:5: Unable to resolve constant `Bar`
+          5002 - errors/errors.rb:5: Unable to resolve constant `C`
+          7003 - errors/errors.rb:5: Method `params` does not exist on `T.class_of(Foo)`
+          7003 - errors/errors.rb:5: Method `sig` does not exist on `T.class_of(Foo)`
+          7004 - errors/errors.rb:10: Wrong number of arguments for constructor. Expected: `0`, got: `1`
+          7003 - errors/errors.rb:11: Method `c` does not exist on `T.class_of(<root>)`
+          7004 - errors/errors.rb:11: Too many arguments provided for method `Foo#foo`. Expected: `1`, got: `2`
+          Errors: 7
+        MSG
+        refute(result.status)
+      end
+
       def test_display_errors_with_sort_loc
         result = @project.bundle_exec("spoom tc --no-color -s loc")
         assert_equal(<<~MSG, result.err)


### PR DESCRIPTION
Fix issues where `spoom tc` is reporting no error while `srb tc` does report errors when using `--error-url-base`.

We always override the option with a known string when running `spoom tc` so the error parser knows what to look for in the error strings.