### PR TITLE
Remove useless labels from Dependabot auto-tagging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       - "Shopify/sorbet"
     labels:
       - "dependencies"
-      - "ruby"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,4 +16,3 @@ updates:
       - "Shopify/sorbet"
     labels:
       - "dependencies"
-      - "gh-actions"


### PR DESCRIPTION
Let's remove those errors: https://github.com/Shopify/spoom/pull/136#issuecomment-1155606934