### PR TITLE
Allow filtering errors by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Hide the `Errors: X` at the end of the list:
 $ spoom tc --no-count
 ```
 
+List only the errors comming from specific directories or files:
+
+```
+$ spoom tc file1.rb path1/ path2/
+```
+
 #### Typing coverage
 
 Show metrics about the project contents and the typing coverage:

--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -23,7 +23,7 @@ module Spoom
       option :count, type: :boolean, default: true, desc: "Show errors count"
       option :sorbet, type: :string, desc: "Path to custom Sorbet bin"
       option :sorbet_options, type: :string, default: "", desc: "Pass options to Sorbet"
-      def tc
+      def tc(*paths_to_select)
         in_sorbet_project!
 
         path = exec_path
@@ -68,6 +68,12 @@ module Spoom
         errors_count = errors.size
 
         errors = errors.select { |e| e.code == code } if code
+
+        unless paths_to_select.empty?
+          errors.select! do |error|
+            paths_to_select.any? { |path_to_select| error.file&.start_with?(path_to_select) }
+          end
+        end
 
         errors = case sort
         when SORT_CODE


### PR DESCRIPTION
Some people have [asked for it](https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1653686693560809?thread_ts=1653682744.622629&cid=CHN2L03NH) on the Sorbet Slack.

With this feature we could offer [a better answer](https://sorbet.org/docs/faq#how-do-i-see-errors-from-a-single-file-not-the-whole-project:~:text=There%20are%20also%20third%2Dparty%20tools%20that%20offer%20the%20ability%20to%20sort%20and%20filter%20Sorbet%E2%80%99s%20errors%2C%20like%20spoom.) in the official docs.