### PR TITLE
Run CI on all branches

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,11 +7,7 @@
 
 name: Ruby
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Makes it easier to see errors _before_ opening the PR.