### PR TITLE
Bump Sorbet to v0.5.10097

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,18 +79,18 @@ GEM
     rubocop-sorbet (0.4.0)
       rubocop
     ruby-progressbar (1.11.0)
-    sorbet (0.5.9271)
-      sorbet-static (= 0.5.9271)
-    sorbet-runtime (0.5.9271)
-    sorbet-static (0.5.9271-universal-darwin-14)
-    sorbet-static (0.5.9271-universal-darwin-15)
-    sorbet-static (0.5.9271-universal-darwin-16)
-    sorbet-static (0.5.9271-universal-darwin-17)
-    sorbet-static (0.5.9271-universal-darwin-18)
-    sorbet-static (0.5.9271-universal-darwin-19)
-    sorbet-static (0.5.9271-universal-darwin-20)
-    sorbet-static (0.5.9271-universal-darwin-21)
-    sorbet-static (0.5.9271-x86_64-linux)
+    sorbet (0.5.10097)
+      sorbet-static (= 0.5.10097)
+    sorbet-runtime (0.5.10097)
+    sorbet-static (0.5.10097-universal-darwin-14)
+    sorbet-static (0.5.10097-universal-darwin-15)
+    sorbet-static (0.5.10097-universal-darwin-16)
+    sorbet-static (0.5.10097-universal-darwin-17)
+    sorbet-static (0.5.10097-universal-darwin-18)
+    sorbet-static (0.5.10097-universal-darwin-19)
+    sorbet-static (0.5.10097-universal-darwin-20)
+    sorbet-static (0.5.10097-universal-darwin-21)
+    sorbet-static (0.5.10097-x86_64-linux)
     tapioca (0.5.4)
       bundler (>= 1.17.3)
       pry (>= 0.12.2)
@@ -133,4 +133,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.3.10
+   2.3.11

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -85,8 +85,8 @@ module Spoom
             without signature: 12 (86%)
 
           Calls:
-            typed: 8 (89%)
-            untyped: 1 (11%)
+            typed: 6 (86%)
+            untyped: 1 (14%)
         MSG
         assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
       end
@@ -124,8 +124,8 @@ module Spoom
             without signature: 13 (87%)
 
           Calls:
-            typed: 8 (67%)
-            untyped: 4 (33%)
+            typed: 6 (60%)
+            untyped: 4 (40%)
         MSG
         assert_equal(0, Dir.glob("#{@project.path}/spoom_data/*.json").size)
       end
@@ -151,8 +151,8 @@ module Spoom
             without signature: 8 (89%)
 
           Calls:
-            typed: 8 (89%)
-            untyped: 1 (11%)
+            typed: 6 (86%)
+            untyped: 1 (14%)
         MSG
       end
 
@@ -190,8 +190,8 @@ module Spoom
             without signature: 12 (86%)
 
           Calls:
-            typed: 8 (89%)
-            untyped: 1 (11%)
+            typed: 6 (86%)
+            untyped: 1 (14%)
         MSG
         project.destroy
         assert_equal(0, Dir.glob("#{project.path}/spoom_data/*.json").size)
@@ -230,8 +230,8 @@ module Spoom
               without signature: 12 (86%)
 
             Calls:
-              typed: 8 (89%)
-              untyped: 1 (11%)
+              typed: 6 (86%)
+              untyped: 1 (14%)
 
         OUT
         assert_equal("", result.err)
@@ -262,7 +262,7 @@ module Spoom
               without signature: 5 (83%)
 
             Calls:
-              typed: 6 (100%)
+              typed: 4 (100%)
 
           Analyzing COMMIT (2 / 3)
             Sorbet static: 0.5.1000
@@ -283,7 +283,7 @@ module Spoom
               without signature: 8 (89%)
 
             Calls:
-              typed: 7 (100%)
+              typed: 5 (100%)
 
           Analyzing COMMIT (3 / 3)
             Sorbet static: 0.5.2000
@@ -306,7 +306,7 @@ module Spoom
               without signature: 9 (90%)
 
             Calls:
-              typed: 7 (100%)
+              typed: 5 (100%)
 
         OUT
         assert_equal("", result.err)
@@ -337,7 +337,7 @@ module Spoom
               without signature: 5 (83%)
 
             Calls:
-              typed: 6 (100%)
+              typed: 4 (100%)
 
           Analyzing COMMIT (2 / 2)
             Sorbet static: 0.5.1000
@@ -358,7 +358,7 @@ module Spoom
               without signature: 8 (89%)
 
             Calls:
-              typed: 7 (100%)
+              typed: 5 (100%)
 
         OUT
         assert_equal("", result.err)

--- a/test/spoom/cli/lsp_test.rb
+++ b/test/spoom/cli/lsp_test.rb
@@ -74,7 +74,8 @@ module Spoom
         result = @project.bundle_exec("spoom lsp --no-color hover lib/hover.rb 0 0")
         assert_equal(<<~MSG, result.out)
           Hovering `lib/hover.rb:0:0`:
-          <no data>
+          This file is `# typed: false`.
+          Hover, Go To Definition, and other features are disabled in this file.
         MSG
       end
 

--- a/test/spoom/cli/lsp_test.rb
+++ b/test/spoom/cli/lsp_test.rb
@@ -42,10 +42,10 @@ module Spoom
         result = @project.bundle_exec("spoom lsp --no-color find Foo")
         assert_equal(<<~MSG, result.err)
           Error: Sorbet returned typechecking errors for `/errors.rb`
-            8:0-8:11: Not enough arguments provided for method `Foo#foo`. Expected: `1`, got: `0` (7004)
+            8:11-8:11: Not enough arguments provided for method `Foo#foo`. Expected: `1`, got: `0` (7004)
             5:2-5:5: Expected `String` but found `NilClass` for method result type (7005)
-            3:2-3:43: Method `sig` does not exist on `T.class_of(Foo)` (7003)
-            3:8-3:25: Method `params` does not exist on `T.class_of(Foo)` (7003)
+            3:2-3:5: Method `sig` does not exist on `T.class_of(Foo)` (fix available) (7003)
+            3:8-3:14: Method `params` does not exist on `T.class_of(Foo)` (7003)
             9:0-9:3: Unable to resolve constant `Bar` (fix available) (5002)
         MSG
       end

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -54,7 +54,7 @@ module Spoom
         assert_equal(9, snapshot.classes)
         assert_equal(1, snapshot.methods_with_sig)
         assert_equal(13, snapshot.methods_without_sig)
-        assert_equal(8, snapshot.calls_typed)
+        assert_equal(6, snapshot.calls_typed)
         assert_equal(1, snapshot.calls_untyped)
         project.destroy
       end
@@ -69,7 +69,7 @@ module Spoom
         assert_equal(5, snapshot.classes)
         assert_equal(1, snapshot.methods_with_sig)
         assert_equal(8, snapshot.methods_without_sig)
-        assert_equal(8, snapshot.calls_typed)
+        assert_equal(6, snapshot.calls_typed)
         assert_equal(1, snapshot.calls_untyped)
         project.destroy
       end

--- a/test/spoom/sorbet/run_test.rb
+++ b/test/spoom/sorbet/run_test.rb
@@ -60,10 +60,10 @@ module Spoom
             Usage:
               sorbet [OPTION...] <path 1> <path 2> ...
 
-              -e, string     Parse an inline ruby string (default: "")
+              -e string      Parse an inline ruby string (default: "")
               -q, --quiet    Silence all non-critical errors
               -v, --verbose  Verbosity level [0-3]
-              -h,            Show short help
+              -h             Show short help
                   --help     Show long help
                   --version  Show version
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ module Spoom
     # Replace all sorbet-like version "0.5.5888" in `test` by "X.X.XXXX"
     sig { params(text: String).returns(String) }
     def censor_sorbet_version(text)
-      text.gsub(/\d\.\d\.\d{4}/, "X.X.XXXX")
+      text.gsub(/\d\.\d\.\d{4,5}/, "X.X.XXXX")
     end
   end
 end


### PR DESCRIPTION
We didn't bump it in a long time so a few tests were broken following changes upstream.

I fixed them and explained why in each commit description.