### PR TITLE
Ryanb ruby lsp support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 
 group :development do
   gem "pry-byebug"
+  gem "ruby-lsp"
   gem "rubocop-shopify", require: false
   gem "rubocop-sorbet", require: false
   gem "tapioca", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     diff-lcs (1.4.4)
     equalizer (0.0.11)
     ice_nine (0.11.2)
+    language_server-protocol (3.16.0.3)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.0.0)
@@ -47,6 +48,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    prettier_print (0.1.0)
     procto (0.0.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -78,6 +80,11 @@ GEM
       rubocop (~> 1.30)
     rubocop-sorbet (0.4.0)
       rubocop
+    ruby-lsp (0.1.0)
+      language_server-protocol
+      rubocop (>= 1.0)
+      sorbet-runtime
+      syntax_tree (>= 2.4)
     ruby-progressbar (1.11.0)
     sorbet (0.5.10097)
       sorbet-static (= 0.5.10097)
@@ -91,6 +98,8 @@ GEM
     sorbet-static (0.5.10097-universal-darwin-20)
     sorbet-static (0.5.10097-universal-darwin-21)
     sorbet-static (0.5.10097-x86_64-linux)
+    syntax_tree (2.7.1)
+      prettier_print
     tapioca (0.5.4)
       bundler (>= 1.17.3)
       pry (>= 0.12.2)
@@ -129,6 +138,7 @@ DEPENDENCIES
   rake (~> 13.0.1)
   rubocop-shopify
   rubocop-sorbet
+  ruby-lsp
   spoom!
   tapioca
 

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: spoom
 type: ruby
 
 up:
-  - ruby: 2.7.2
+  - ruby: 2.7.6
   - bundler
 
 commands:


### PR DESCRIPTION
[Ruby LSP](https://github.com/Shopify/ruby-lsp) is great but it wasn't compatible with `spoom` yet because we're pretty far behind on gem bumps (which are a WIP, I have other branches for others).

Wanted to bump the development ruby version to 2.7.6 and get Ruby LSP latest running in the repo.
Big thanks to @Morriar for https://github.com/Shopify/spoom/pull/145 which is a massive step in the right direction ❤️ 
