### PR TITLE
Remove experimental CI for 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,11 +16,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby: [ "2.7", "3.0", "3.1" ]
-        experimental: [false]
-        include:
-          - ruby: '3.1'
-            os: ubuntu-latest
-            experimental: true
     continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It's no longer experimental since we have it in the matrix.