### PR TITLE
Rename some `Context` methods 

### DIFF
--- a/lib/spoom/context.rb
+++ b/lib/spoom/context.rb
@@ -131,13 +131,13 @@ module Spoom
 
     # Read the `contents` of the Gemfile in this context directory
     sig { returns(T.nilable(String)) }
-    def gemfile
+    def read_gemfile
       read("Gemfile")
     end
 
     # Set the `contents` of the Gemfile in this context directory
     sig { params(contents: String, append: T::Boolean).void }
-    def gemfile!(contents, append: false)
+    def write_gemfile!(contents, append: false)
       write!("Gemfile", contents, append: append)
     end
 
@@ -196,19 +196,19 @@ module Spoom
 
     # Read the contents of `sorbet/config` in this context directory
     sig { returns(String) }
-    def sorbet_config
+    def read_sorbet_config
       read(Spoom::Sorbet::CONFIG_PATH)
     end
 
     # Set the `contents` of `sorbet/config` in this context directory
     sig { params(contents: String, append: T::Boolean).void }
-    def sorbet_config!(contents, append: false)
+    def write_sorbet_config!(contents, append: false)
       write!(Spoom::Sorbet::CONFIG_PATH, contents, append: append)
     end
 
     # Read the strictness sigil from the file at `relative_path` (returns `nil` if no sigil)
     sig { params(relative_path: String).returns(T.nilable(String)) }
-    def file_strictness(relative_path)
+    def read_file_strictness(relative_path)
       Spoom::Sorbet::Sigils.file_strictness(absolute_path_to(relative_path))
     end
   end

--- a/lib/spoom/context.rb
+++ b/lib/spoom/context.rb
@@ -197,13 +197,13 @@ module Spoom
     # Read the contents of `sorbet/config` in this context directory
     sig { returns(String) }
     def sorbet_config
-      read("sorbet/config")
+      read(Spoom::Sorbet::CONFIG_PATH)
     end
 
     # Set the `contents` of `sorbet/config` in this context directory
     sig { params(contents: String, append: T::Boolean).void }
     def sorbet_config!(contents, append: false)
-      write!("sorbet/config", contents, append: append)
+      write!(Spoom::Sorbet::CONFIG_PATH, contents, append: append)
     end
 
     # Read the strictness sigil from the file at `relative_path` (returns `nil` if no sigil)

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -45,8 +45,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("true", @project.file_strictness("file1.rb"))
-        assert_equal("false", @project.file_strictness("file2.rb"))
+        assert_equal("true", @project.read_file_strictness("file1.rb"))
+        assert_equal("false", @project.read_file_strictness("file2.rb"))
       end
 
       def test_bump_doesnt_change_sigils_outside_directory
@@ -64,9 +64,9 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("false", @project.file_strictness("lib/a/file.rb"))
-        assert_equal("true", @project.file_strictness("lib/b/file.rb"))
-        assert_equal("true", @project.file_strictness("lib/c/file.rb"))
+        assert_equal("false", @project.read_file_strictness("lib/a/file.rb"))
+        assert_equal("true", @project.read_file_strictness("lib/b/file.rb"))
+        assert_equal("true", @project.read_file_strictness("lib/c/file.rb"))
 
         @project.destroy!
       end
@@ -91,8 +91,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("false", @project.file_strictness("file1.rb"))
-        assert_equal("strict", @project.file_strictness("file2.rb"))
+        assert_equal("false", @project.read_file_strictness("file1.rb"))
+        assert_equal("strict", @project.read_file_strictness("file2.rb"))
       end
 
       def test_bump_nondefault_from_to_revert
@@ -115,8 +115,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("strong", @project.file_strictness("file1.rb"))
-        assert_equal("ignore", @project.file_strictness("file2.rb"))
+        assert_equal("strong", @project.read_file_strictness("file1.rb"))
+        assert_equal("ignore", @project.read_file_strictness("file2.rb"))
       end
 
       def test_force_bump_without_typecheck
@@ -140,8 +140,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("strong", @project.file_strictness("file1.rb"))
-        assert_equal("strong", @project.file_strictness("file2.rb"))
+        assert_equal("strong", @project.read_file_strictness("file1.rb"))
+        assert_equal("strong", @project.read_file_strictness("file2.rb"))
       end
 
       def test_bump_with_multiline_error
@@ -171,11 +171,11 @@ module Spoom
         OUT
         assert(result.status)
 
-        assert_equal("true", @project.file_strictness("file.rb"))
+        assert_equal("true", @project.read_file_strictness("file.rb"))
       end
 
       def test_bump_with_custom_error_url_base
-        @project.sorbet_config!(<<~CONFIG)
+        @project.write_sorbet_config!(<<~CONFIG)
           .
           --error-url-base="https://docs.org#"
         CONFIG
@@ -206,7 +206,7 @@ module Spoom
         OUT
         assert(result.status)
 
-        assert_equal("true", @project.file_strictness("file.rb"))
+        assert_equal("true", @project.read_file_strictness("file.rb"))
       end
 
       def test_bump_preserve_file_encoding
@@ -226,7 +226,7 @@ module Spoom
         OUT
         refute(result.status)
 
-        strictness = @project.file_strictness("file.rb")
+        strictness = @project.read_file_strictness("file.rb")
         assert_equal("true", strictness)
         assert_match("ISO-8859", %x{file "#{@project.absolute_path}/file.rb"})
       end
@@ -253,8 +253,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("false", @project.file_strictness("file1.rb"))
-        assert_equal("false", @project.file_strictness("file2.rb"))
+        assert_equal("false", @project.read_file_strictness("file1.rb"))
+        assert_equal("false", @project.read_file_strictness("file2.rb"))
       end
 
       def test_bump_dry_does_nothing_even_with_force
@@ -280,8 +280,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("false", @project.file_strictness("file1.rb"))
-        assert_equal("false", @project.file_strictness("file2.rb"))
+        assert_equal("false", @project.read_file_strictness("file1.rb"))
+        assert_equal("false", @project.read_file_strictness("file2.rb"))
       end
 
       def test_bump_dry_suggest_custom_command
@@ -302,7 +302,7 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("false", @project.file_strictness("file1.rb"))
+        assert_equal("false", @project.read_file_strictness("file1.rb"))
       end
 
       def test_bump_dry_does_nothing_with_no_file
@@ -335,8 +335,8 @@ module Spoom
         OUT
         assert(result.status)
 
-        assert_equal("false", @project.file_strictness("file1.rb"))
-        assert_equal("false", @project.file_strictness("file2.rb"))
+        assert_equal("false", @project.read_file_strictness("file1.rb"))
+        assert_equal("false", @project.read_file_strictness("file2.rb"))
       end
 
       def test_bump_dry_does_not_revert_files_not_bumped
@@ -366,8 +366,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("false", @project.file_strictness("file1.rb"))
-        assert_equal("true", @project.file_strictness("file2.rbi"))
+        assert_equal("false", @project.read_file_strictness("file1.rb"))
+        assert_equal("true", @project.read_file_strictness("file2.rbi"))
       end
 
       def test_bump_only_specified_files
@@ -396,7 +396,7 @@ module Spoom
       end
 
       def test_bump_files_according_to_config
-        @project.sorbet_config!(<<~CONFIG)
+        @project.write_sorbet_config!(<<~CONFIG)
           .
           --ignore=vendor/
         CONFIG
@@ -419,8 +419,8 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("true", @project.file_strictness("file1.rb"))
-        assert_equal("false", @project.file_strictness("vendor/file2.rb"))
+        assert_equal("true", @project.read_file_strictness("file1.rb"))
+        assert_equal("false", @project.read_file_strictness("vendor/file2.rb"))
       end
 
       def test_count_errors_without_dry
@@ -462,12 +462,12 @@ module Spoom
           No file to bump from `false` to `true`
         OUT
         assert(result.status)
-        assert_equal("false", @project.file_strictness("file1.rb"))
+        assert_equal("false", @project.read_file_strictness("file1.rb"))
       end
 
       def test_bump_with_sorbet_segfault
         project = new_project
-        project.gemfile!(<<~GEMFILE)
+        project.write_gemfile!(<<~GEMFILE)
           source "https://rubygems.org"
 
           gem "sorbet-static", "= 0.5.9267"
@@ -498,9 +498,9 @@ module Spoom
         OUT
         refute(result.status)
 
-        assert_equal("false", project.file_strictness("cant_be_bump1.rb"))
-        assert_equal("false", project.file_strictness("cant_be_bump2.rb"))
-        assert_equal("false", project.file_strictness("will_segfault.rb"))
+        assert_equal("false", project.read_file_strictness("cant_be_bump1.rb"))
+        assert_equal("false", project.read_file_strictness("cant_be_bump2.rb"))
+        assert_equal("false", project.read_file_strictness("will_segfault.rb"))
 
         project.destroy!
       end

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -74,7 +74,7 @@ module Spoom
         @project.write!("lib/d.rb", "# typed: strict")
         @project.write!("lib/e.rb", "# typed: strong")
         @project.write!("lib/f.rb", "# typed: __STDLIB_INTERNAL")
-        @project.sorbet_config!(<<~CFG)
+        @project.write_sorbet_config!(<<~CFG)
           .
           --ignore=test
         CFG
@@ -95,7 +95,7 @@ module Spoom
         @project.write!("lib/d.ru", "# typed: strict")
         @project.write!("lib/e.rb", "# typed: strong")
         @project.write!("lib/f.rb", "# typed: __STDLIB_INTERNAL")
-        @project.sorbet_config!(<<~CFG)
+        @project.write_sorbet_config!(<<~CFG)
           .
           --allowed-extension=.rake
           --allowed-extension=.ru

--- a/test/spoom/cli/config_test.rb
+++ b/test/spoom/cli/config_test.rb
@@ -15,7 +15,7 @@ module Spoom
       end
 
       def test_display_empty_config
-        @project.sorbet_config!("")
+        @project.write_sorbet_config!("")
         result = @project.spoom("config --no-color")
         assert_equal(<<~MSG, result.out)
           Found Sorbet config at `sorbet/config`.
@@ -50,7 +50,7 @@ module Spoom
       end
 
       def test_display_multi_config
-        @project.sorbet_config!(<<~CFG)
+        @project.write_sorbet_config!(<<~CFG)
           lib
           --dir=test
           --dir
@@ -75,7 +75,7 @@ module Spoom
       end
 
       def test_display_config_with_ignored_files
-        @project.sorbet_config!(<<~CFG)
+        @project.write_sorbet_config!(<<~CFG)
           lib/project.rb
           --ignore=lib/main
           --ignore
@@ -99,7 +99,7 @@ module Spoom
       end
 
       def test_display_config_with_allowed_extensions
-        @project.sorbet_config!(<<~CFG)
+        @project.write_sorbet_config!(<<~CFG)
           lib/project.rb
           --ignore=lib/main
           --ignore

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -32,7 +32,7 @@ module Spoom
       end
 
       def test_display_no_errors_without_filter
-        @project.sorbet_config!("file.rb")
+        @project.write_sorbet_config!("file.rb")
         result = @project.spoom("tc")
         assert_equal(<<~MSG, result.err)
           No errors! Great job.
@@ -41,7 +41,7 @@ module Spoom
       end
 
       def test_display_no_errors_with_sort
-        @project.sorbet_config!("file.rb")
+        @project.write_sorbet_config!("file.rb")
         result = @project.spoom("tc --no-color -s")
         assert_equal(<<~MSG, result.err)
           No errors! Great job.
@@ -73,7 +73,7 @@ module Spoom
       end
 
       def test_display_errors_with_sort_default_with_custom_url
-        @project.sorbet_config!(<<~CONFIG)
+        @project.write_sorbet_config!(<<~CONFIG)
           .
           --error-url-base=https://custom#
         CONFIG
@@ -279,7 +279,7 @@ module Spoom
 
       def test_display_sorbet_segfault
         project = new_project
-        project.gemfile!(<<~GEMFILE)
+        project.write_gemfile!(<<~GEMFILE)
           source "https://rubygems.org"
 
           gem "sorbet-static", "= 0.5.9267"

--- a/test/spoom/context_test.rb
+++ b/test/spoom/context_test.rb
@@ -154,9 +154,9 @@ module Spoom
 
       def test_context_gemfile
         context = Context.mktmp!
-        context.gemfile!("CONTENTS")
+        context.write_gemfile!("CONTENTS")
         assert(context.file?("Gemfile"))
-        assert_equal("CONTENTS", context.gemfile)
+        assert_equal("CONTENTS", context.read_gemfile)
         context.destroy!
       end
 
@@ -180,7 +180,7 @@ module Spoom
         assert_equal("Could not locate Gemfile\n", res.err)
         refute(res.status)
 
-        context.gemfile!(<<~GEMFILE)
+        context.write_gemfile!(<<~GEMFILE)
           source "https://rubygems.org"
 
           gem "ansi"
@@ -248,15 +248,15 @@ module Spoom
         context.destroy!
       end
 
-      def test_context_sorbet_config!
+      def test_context_write_sorbet_config!
         context = Context.mktmp!
 
         assert_raises(Errno::ENOENT) do
-          context.sorbet_config
+          context.read_sorbet_config
         end
 
-        context.sorbet_config!(".")
-        assert_equal(".", context.sorbet_config)
+        context.write_sorbet_config!(".")
+        assert_equal(".", context.read_sorbet_config)
 
         context.destroy!
       end
@@ -273,7 +273,7 @@ module Spoom
         res = context.srb("tc")
         refute(res.status)
 
-        context.gemfile!(<<~GEMFILE)
+        context.write_gemfile!(<<~GEMFILE)
           source "https://rubygems.org"
 
           gem "sorbet"
@@ -283,7 +283,7 @@ module Spoom
         res = context.srb("tc")
         refute(res.status)
 
-        context.sorbet_config!(".")
+        context.write_sorbet_config!(".")
         res = context.srb("tc")
         assert_equal(<<~ERR, res.err)
           a.rb:3: Method `foo` does not exist on `T.class_of(<root>)` https://srb.help/7003
@@ -306,13 +306,13 @@ module Spoom
       def test_context_file_strictness
         context = Context.mktmp!
 
-        assert_nil(context.file_strictness("a.rb"))
+        assert_nil(context.read_file_strictness("a.rb"))
 
         context.write!("a.rb", "")
-        assert_nil(context.file_strictness("a.rb"))
+        assert_nil(context.read_file_strictness("a.rb"))
 
         context.write!("a.rb", "# typed: true\n")
-        assert_equal("true", context.file_strictness("a.rb"))
+        assert_equal("true", context.read_file_strictness("a.rb"))
 
         context.destroy!
       end

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -78,7 +78,7 @@ module Spoom
       sig { returns(TestProject) }
       def project
         project = new_project
-        project.sorbet_config!(<<~CONFIG)
+        project.write_sorbet_config!(<<~CONFIG)
           .
           --allowed-extension .rb
           --allowed-extension .rbi

--- a/test/spoom/sorbet/run_test.rb
+++ b/test/spoom/sorbet/run_test.rb
@@ -11,7 +11,7 @@ module Spoom
       end
 
       def test_run_srb_from_bundler
-        @project.gemfile!(<<~GEM)
+        @project.write_gemfile!(<<~GEM)
           source 'https://rubygems.org'
           gem 'sorbet'
         GEM
@@ -29,7 +29,7 @@ module Spoom
       end
 
       def test_run_srb_from_bundler_not_found
-        @project.gemfile!("source 'https://rubygems.org'")
+        @project.write_gemfile!("source 'https://rubygems.org'")
         Bundler.with_unbundled_env do
           result = @project.bundle_install!
           assert(result.status)

--- a/test/spoom/sorbet/version_test.rb
+++ b/test/spoom/sorbet/version_test.rb
@@ -7,7 +7,7 @@ module Spoom
   module Sorbet
     class VersionTest < TestWithProject
       def test_srb_version_return_nil_if_srb_not_installed
-        @project.gemfile!("")
+        @project.write_gemfile!("")
         Bundler.with_unbundled_env do
           version = Spoom::Sorbet.srb_version(path: @project.absolute_path, capture_err: true)
           assert_nil(version)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,8 +16,8 @@ module Spoom
     sig { params(name: T.nilable(String)).returns(TestProject) }
     def new_project(name = nil)
       project = TestProject.mktmp!(name || self.name)
-      project.gemfile!(spoom_gemfile)
-      project.sorbet_config!(".")
+      project.write_gemfile!(spoom_gemfile)
+      project.write_sorbet_config!(".")
       project
     end
 


### PR DESCRIPTION
As I was migrating a few clients to use the Context, I noticed a few inconsistencies in the naming that were making the resulting code a bit confusing.

File related methods should all use the `read_`/`write_` prefix if not it's easy to mistake them for actions:

```ruby
bundle_install!
tapioca_config! # would that mean running `tapioca config` or writing to `sorbet/tapioca/config.yml`?
write_sorbet_config! # is more obvious
```