### PR TITLE
support bumping files without typed sigil

### DIFF
--- a/test/spoom/context_test.rb
+++ b/test/spoom/context_test.rb
@@ -309,7 +309,7 @@ module Spoom
         assert_nil(context.read_file_strictness("a.rb"))
 
         context.write!("a.rb", "")
-        assert_nil(context.read_file_strictness("a.rb"))
+        assert_equal("false", context.read_file_strictness("a.rb"))
 
         context.write!("a.rb", "# typed: true\n")
         assert_equal("true", context.read_file_strictness("a.rb"))

--- a/test/spoom/file_tree_test.rb
+++ b/test/spoom/file_tree_test.rb
@@ -76,7 +76,7 @@ module Spoom
         out = StringIO.new
         tree.print(out: out, colors: false)
         assert_equal(<<~EXP, out.string)
-          Gemfile
+          Gemfile (false)
           a/
             b/
               c/
@@ -84,9 +84,9 @@ module Spoom
                   e1.rb (true)
                   e2.rb (false)
               c.rb (strict)
-            b.rb
+            b.rb (false)
           sorbet/
-            config
+            config (false)
         EXP
       end
     end

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -87,6 +87,29 @@ module Spoom
         assert_equal("false", strictness)
       end
 
+      def test_update_content_from_default_strictness
+        content = <<~STR
+          class A; end
+        STR
+
+        new_content = Sigils.update_content(content, nil, "true")
+
+        strictness = Sigils.strictness_in_content(new_content)
+
+        assert_equal("true", strictness)
+      end
+
+      def test_remove_sigil
+        content = <<~STR
+          # typed: false
+          class A; end
+        STR
+
+        new_content = Sigils.remove_sigil(content)
+        assert_nil(Sigils.strictness_in_content(new_content))
+        assert_equal("class A; end\n", new_content)
+      end
+
       def test_update_sigil_to_use_invalid_strictness
         content = <<~STR
           # typed: ignore
@@ -249,8 +272,8 @@ module Spoom
         project.write!("file2.rb", "# typed: ignore")
         files = ["#{project.absolute_path}/file1.rb", "#{project.absolute_path}/file2.rb"]
 
-        changed_files = Sigils.change_sigil_in_files(files, "true")
-        assert_equal(files, changed_files)
+        changed_files = Sigils.change_sigil_in_files(Hash[files.zip(Array.new(2, "true"))])
+        assert_equal(files, changed_files.keys)
         assert_equal("true", Sigils.file_strictness("#{project.absolute_path}/file1.rb"))
         assert_equal("true", Sigils.file_strictness("#{project.absolute_path}/file2.rb"))
 
@@ -271,8 +294,8 @@ module Spoom
         project.write!("file2.rb", string_iso)
         files = ["#{project.absolute_path}/file1.rb", "#{project.absolute_path}/file2.rb"]
 
-        changed_files = Sigils.change_sigil_in_files(files, "true")
-        assert_equal(files, changed_files)
+        changed_files = Sigils.change_sigil_in_files(Hash[files.zip(Array.new(2, "true"))])
+        assert_equal(files, changed_files.keys)
         assert_equal("true", Sigils.file_strictness("#{project.absolute_path}/file1.rb"))
         assert_equal("true", Sigils.file_strictness("#{project.absolute_path}/file2.rb"))
         project.destroy!


### PR DESCRIPTION
This is a proposed fix for https://github.com/Shopify/spoom/issues/200

When Sorbet encounters a file without a `typed` sigil, it treats the file the same as `typed: false`. This is also [documented](https://sorbet.org/docs/static#file-level-granularity-strictness-levels) on their website. This pull request changes Spoom to treat files with a missing sigil as `typed: false`. This was done to allow us to leverage `spoom bump` on our default typed codebase.

To accomplish this goal, I modified `Spoom::Sorbet::Sigils.file_strictness` to return the `DEFAULT_STRICTNESS` instead of `nil` when no sigil can be found in the file. I thought this might be more accurate. I also updated `Spoom::Sorbet::Sigils.change_sigil_in_files` to return a hash of paths to their previous strictnesses so that `undo` has enough information to be able to revert changes as needed. It now also takes a hash of paths to desired strictness to be consistent.

This change is pretty fundamental and will likely also affect graph output, so I'd be pretty careful here. Also, I personally have about a hot 5 minutes of experience with Spoom, so beware of rookie mistakes!

---

If reviewers think there is too much going on in this PR, it can easily be broken down into a PR that just changes the signature for `Spoom::Sorbet::Sigils.change_sigil_in_files` first and then the support for default strictness afterwards. Up to the readers, I'm happy to accommodate 🙇 