### PR TITLE
cli/bump: Fix "0 or 1 file(s) changed" pluralization

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -132,13 +132,14 @@ module Spoom
 
       no_commands do
         def print_changes(files, command:, from: "false", to: "true", dry: false, path: File.expand_path("."))
-          if files.empty?
+          files_count = files.size
+          if files_count.zero?
             say("No files to bump from `#{from}` to `#{to}`")
             return
           end
           message = StringIO.new
           message << (dry ? "Can bump" : "Bumped")
-          message << " `#{files.size}` file#{"s" if files.size > 1}"
+          message << " `#{files_count}` file#{"s" if files_count > 1}"
           message << " from `#{from}` to `#{to}`:"
           say(message.string)
           files.each do |file|
@@ -146,7 +147,7 @@ module Spoom
             say(" + #{file_path}")
           end
           if dry && command
-            say("\nRun `#{command}` to bump #{files.length > 1 ? "them" : "it"}")
+            say("\nRun `#{command}` to bump #{files_count > 1 ? "them" : "it"}")
           elsif dry
             say("\nRun `spoom bump --from #{from} --to #{to}` locally then `commit the changes` and `push them`")
           end

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -71,7 +71,7 @@ module Spoom
         say("\n")
 
         if files_to_bump.empty?
-          say("No file to bump from `#{from}` to `#{to}`")
+          say("No files to bump from `#{from}` to `#{to}`")
           exit(0)
         end
 
@@ -133,7 +133,7 @@ module Spoom
       no_commands do
         def print_changes(files, command:, from: "false", to: "true", dry: false, path: File.expand_path("."))
           if files.empty?
-            say("No file to bump from `#{from}` to `#{to}`")
+            say("No files to bump from `#{from}` to `#{to}`")
             return
           end
           message = StringIO.new
@@ -146,7 +146,7 @@ module Spoom
             say(" + #{file_path}")
           end
           if dry && command
-            say("\nRun `#{command}` to bump them")
+            say("\nRun `#{command}` to bump #{files.length > 1 ? "them" : "it"}")
           elsif dry
             say("\nRun `spoom bump --from #{from} --to #{to}` locally then `commit the changes` and `push them`")
           end

--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -20,7 +20,7 @@ module Spoom
         assert_equal(<<~OUT, result.out)
           Checking files...
 
-          No file to bump from `false` to `true`
+          No files to bump from `false` to `true`
         OUT
         assert(result.status)
       end
@@ -167,7 +167,7 @@ module Spoom
         assert_equal(<<~OUT, result.out)
           Checking files...
 
-          No file to bump from `true` to `strict`
+          No files to bump from `true` to `strict`
         OUT
         assert(result.status)
 
@@ -202,7 +202,7 @@ module Spoom
         assert_equal(<<~OUT, result.out)
           Checking files...
 
-          No file to bump from `true` to `strict`
+          No files to bump from `true` to `strict`
         OUT
         assert(result.status)
 
@@ -298,7 +298,7 @@ module Spoom
           Can bump `1` file from `false` to `true`:
            + file1.rb
 
-          Run `bump.sh` to bump them
+          Run `bump.sh` to bump it
         OUT
         refute(result.status)
 
@@ -311,7 +311,7 @@ module Spoom
         assert_equal(<<~OUT, result.out)
           Checking files...
 
-          No file to bump from `false` to `true`
+          No files to bump from `false` to `true`
         OUT
         assert(result.status)
       end
@@ -331,7 +331,7 @@ module Spoom
         assert_equal(<<~OUT, result.out)
           Checking files...
 
-          No file to bump from `false` to `true`
+          No files to bump from `false` to `true`
         OUT
         assert(result.status)
 
@@ -459,7 +459,7 @@ module Spoom
           Checking files...
 
           Found 1 type checking error
-          No file to bump from `false` to `true`
+          No files to bump from `false` to `true`
         OUT
         assert(result.status)
         assert_equal("false", @project.read_file_strictness("file1.rb"))
@@ -546,7 +546,7 @@ module Spoom
         assert_equal(<<~OUT, result.out)
           Checking files...
 
-          No file to bump from `ignore` to `false`
+          No files to bump from `ignore` to `false`
         OUT
         assert(result.status)
       end


### PR DESCRIPTION
- The previous wording of "No file to bump" sounded weird given that zero is usually referred to in the plural.
- Similarly, Spoom detecting a single file to bump but referring to that single file plurally was confusing as well.
