### PR TITLE
Collect metrics on non rbi files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     sorbet (0.5.10511)
       sorbet-static (= 0.5.10511)
     sorbet-runtime (0.5.10511)
+    sorbet-static (0.5.10511-universal-darwin-21)
     sorbet-static (0.5.10511-universal-darwin-22)
     sorbet-static (0.5.10511-x86_64-linux)
     syntax_tree (4.0.0)
@@ -93,6 +94,7 @@ GEM
       yard (>= 0.9)
 
 PLATFORMS
+  arm64-darwin-21
   universal-darwin-22
   x86_64-linux
 

--- a/lib/spoom/coverage/snapshot.rb
+++ b/lib/spoom/coverage/snapshot.rb
@@ -22,6 +22,9 @@ module Spoom
       prop :calls_untyped, Integer, default: 0
       prop :calls_typed, Integer, default: 0
       prop :sigils, T::Hash[String, Integer], default: Hash.new(0)
+      prop :methods_with_sig_excluding_rbis, Integer, default: 0
+      prop :methods_without_sig_excluding_rbis, Integer, default: 0
+      prop :sigils_excluding_rbis, T::Hash[String, Integer], default: Hash.new(0)
 
       # The strictness name as found in the Sorbet metrics file
       STRICTNESSES = T.let(["ignore", "false", "true", "strict", "strong", "stdlib"].freeze, T::Array[String])

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -57,6 +57,10 @@ module Spoom
         assert_equal(13, snapshot.methods_without_sig)
         assert_equal(6, snapshot.calls_typed)
         assert_equal(1, snapshot.calls_untyped)
+        assert_equal(1, snapshot.methods_with_sig_excluding_rbis)
+        assert_equal(8, snapshot.methods_without_sig_excluding_rbis)
+        assert_equal({ "false" => 1, "true" => 3 }, snapshot.sigils)
+        assert_equal({ "false" => 1, "true" => 2 }, snapshot.sigils_excluding_rbis)
         project.destroy!
       end
 
@@ -72,6 +76,10 @@ module Spoom
         assert_equal(8, snapshot.methods_without_sig)
         assert_equal(6, snapshot.calls_typed)
         assert_equal(1, snapshot.calls_untyped)
+        assert_equal(1, snapshot.methods_with_sig_excluding_rbis)
+        assert_equal(8, snapshot.methods_without_sig_excluding_rbis)
+        assert_equal({ "false" => 1, "true" => 2 }, snapshot.sigils)
+        assert_equal({ "false" => 1, "true" => 2 }, snapshot.sigils_excluding_rbis)
         project.destroy!
       end
 
@@ -108,7 +116,7 @@ module Spoom
           A3.new.foo
           B1.foo
         RB
-        project.write!("lib/d.rbi", <<~RB)
+        project.write!("sorbet/rbi/d.rbi", <<~RB)
           # typed: true
 
           module D1; end


### PR DESCRIPTION
Allows for more finer grained processing and a better indication of typing work done on a project.