### PR TITLE
Add `Git::Commit`

### DIFF
--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -84,16 +84,15 @@ module Spoom
           exit(1)
         end
 
-        ticks.each_with_index do |sha, i|
-          date = Spoom::Git.commit_time(sha, path: path)
-          say("Analyzing commit `#{sha}` - #{date&.strftime("%F")} (#{i + 1} / #{ticks.size})")
+        ticks.each_with_index do |commit, i|
+          say("Analyzing commit `#{commit.sha}` - #{commit.time.strftime("%F")} (#{i + 1} / #{ticks.size})")
 
-          Spoom::Git.checkout(sha, path: path)
+          Spoom::Git.checkout(commit.sha, path: path)
 
           snapshot = T.let(nil, T.nilable(Spoom::Coverage::Snapshot))
           if options[:bundle_install]
             Bundler.with_unbundled_env do
-              next unless bundle_install(path, sha)
+              next unless bundle_install(path, commit.sha)
 
               snapshot = Spoom::Coverage.snapshot(path: path, sorbet_bin: sorbet)
             end
@@ -107,7 +106,7 @@ module Spoom
 
           next unless save_dir
 
-          file = "#{save_dir}/#{sha}.json"
+          file = "#{save_dir}/#{commit.sha}.json"
           File.write(file, snapshot.to_json)
           say("  Snapshot data saved under `#{file}`\n\n")
         end

--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -71,9 +71,9 @@ module Spoom
         to = parse_time(options[:to], "--to")
 
         unless from
-          intro_sha = Spoom::Git.sorbet_intro_commit(path: path)
-          intro_sha = T.must(intro_sha) # we know it's in there since in_sorbet_project!
-          from = Spoom::Git.commit_time(intro_sha, path: path)
+          intro_commit = Spoom::Git.sorbet_intro_commit(path: path)
+          intro_commit = T.must(intro_commit) # we know it's in there since in_sorbet_project!
+          from = intro_commit.time
         end
 
         timeline = Spoom::Timeline.new(from, to, path: path)

--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -46,7 +46,7 @@ module Spoom
         sorbet = options[:sorbet]
 
         ref_before = Spoom::Git.current_branch
-        ref_before = Spoom::Git.last_commit(path: path) unless ref_before
+        ref_before = Spoom::Git.last_commit(path: path)&.sha unless ref_before
         unless ref_before
           say_error("Not in a git repository")
           say_error("\nSpoom needs to checkout into your previous commits to build the timeline.", status: nil)

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -45,9 +45,9 @@ module Spoom
         snapshot = Snapshot.new
         return snapshot unless metrics
 
-        sha = Spoom::Git.last_commit(path: path)
-        snapshot.commit_sha = sha
-        snapshot.commit_timestamp = Spoom::Git.commit_timestamp(sha, path: path).to_i if sha
+        last_commit = Spoom::Git.last_commit(path: path)
+        snapshot.commit_sha = last_commit&.sha
+        snapshot.commit_timestamp = last_commit&.timestamp
 
         snapshot.files = metrics.fetch("types.input.files", 0)
         snapshot.modules = metrics.fetch("types.input.modules.total", 0)

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -89,15 +89,14 @@ module Spoom
       sig { params(snapshots: T::Array[Snapshot], palette: D3::ColorPalette, path: String).returns(Report) }
       def report(snapshots, palette:, path: ".")
         intro_commit = Git.sorbet_intro_commit(path: path)
-        intro_date = intro_commit ? Git.commit_time(intro_commit, path: path) : nil
 
         Report.new(
           project_name: File.basename(File.expand_path(path)),
           palette: palette,
           snapshots: snapshots,
           sigils_tree: sigils_tree(path: path),
-          sorbet_intro_commit: intro_commit,
-          sorbet_intro_date: intro_date,
+          sorbet_intro_commit: intro_commit&.sha,
+          sorbet_intro_date: intro_commit&.time,
         )
       end
 

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -97,13 +97,16 @@ module Spoom
         epoch_to_time(timestamp.to_s)
       end
 
-      # Get the last commit sha
-      sig { params(path: String).returns(T.nilable(String)) }
+      # Get the last commit in the currently checked out branch
+      sig { params(path: String).returns(T.nilable(Commit)) }
       def last_commit(path: ".")
-        result = rev_parse("HEAD", path: path)
+        result = log("HEAD --format='%h %at' -1", path: path)
         return nil unless result.status
 
-        result.out.strip
+        out = result.out.strip
+        return nil if out.empty?
+
+        parse_commit(out)
       end
 
       # Translate a git epoch timestamp into a Time

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -118,28 +118,37 @@ module Spoom
         diff("HEAD", path: path).out.empty?
       end
 
-      # Get the hash of the commit introducing the `sorbet/config` file
-      sig { params(path: String).returns(T.nilable(String)) }
+      # Get the commit introducing the `sorbet/config` file
+      sig { params(path: String).returns(T.nilable(Commit)) }
       def sorbet_intro_commit(path: ".")
-        result = Spoom::Git.log("--diff-filter=A --format='%h' -1 -- sorbet/config", path: path)
+        result = log("--diff-filter=A --format='%h %at' -1 -- sorbet/config", path: path)
         return nil unless result.status
 
         out = result.out.strip
         return nil if out.empty?
 
-        out
+        parse_commit(out)
       end
 
-      # Get the hash of the commit removing the `sorbet/config` file
-      sig { params(path: String).returns(T.nilable(String)) }
+      # Get the commit removing the `sorbet/config` file
+      sig { params(path: String).returns(T.nilable(Commit)) }
       def sorbet_removal_commit(path: ".")
-        result = Spoom::Git.log("--diff-filter=D --format='%h' -1 -- sorbet/config", path: path)
+        result = log("--diff-filter=D --format='%h %at' -1 -- sorbet/config", path: path)
         return nil unless result.status
 
         out = result.out.strip
         return nil if out.empty?
 
-        out
+        parse_commit(out)
+      end
+
+      # Parse a line formated as `%h %at` into a `Commit`
+      sig { params(string: String).returns(T.nilable(Commit)) }
+      def parse_commit(string)
+        sha, epoch = string.split(" ", 2)
+        return nil unless sha && epoch
+
+        Commit.new(sha: sha, time: epoch_to_time(epoch))
       end
     end
   end

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -6,6 +6,18 @@ require "time"
 module Spoom
   # Execute git commands
   module Git
+    class Commit < T::Struct
+      extend T::Sig
+
+      const :sha, String
+      const :time, Time
+
+      sig { returns(Integer) }
+      def timestamp
+        time.to_i
+      end
+    end
+
     class << self
       extend T::Sig
 

--- a/lib/spoom/git.rb
+++ b/lib/spoom/git.rb
@@ -60,11 +60,6 @@ module Spoom
       end
 
       sig { params(arg: String, path: String).returns(ExecResult) }
-      def rev_parse(*arg, path: ".")
-        exec("git rev-parse --short #{arg.join(" ")}", path: path)
-      end
-
-      sig { params(arg: String, path: String).returns(ExecResult) }
       def show(*arg, path: ".")
         exec("git show #{arg.join(" ")}", path: path)
       end
@@ -79,24 +74,6 @@ module Spoom
 
       # Utils
 
-      # Get the commit epoch timestamp for a `sha`
-      sig { params(sha: String, path: String).returns(T.nilable(Integer)) }
-      def commit_timestamp(sha, path: ".")
-        result = show("--no-notes --no-patch --pretty=%at #{sha}", path: path)
-        return nil unless result.status
-
-        result.out.strip.to_i
-      end
-
-      # Get the commit Time for a `sha`
-      sig { params(sha: String, path: String).returns(T.nilable(Time)) }
-      def commit_time(sha, path: ".")
-        timestamp = commit_timestamp(sha, path: path)
-        return nil unless timestamp
-
-        epoch_to_time(timestamp.to_s)
-      end
-
       # Get the last commit in the currently checked out branch
       sig { params(path: String).returns(T.nilable(Commit)) }
       def last_commit(path: ".")
@@ -107,12 +84,6 @@ module Spoom
         return nil if out.empty?
 
         parse_commit(out)
-      end
-
-      # Translate a git epoch timestamp into a Time
-      sig { params(timestamp: String).returns(Time) }
-      def epoch_to_time(timestamp)
-        Time.strptime(timestamp, "%s")
       end
 
       # Is there uncommited changes in `path`?
@@ -151,7 +122,8 @@ module Spoom
         sha, epoch = string.split(" ", 2)
         return nil unless sha && epoch
 
-        Commit.new(sha: sha, time: epoch_to_time(epoch))
+        time = Time.strptime(epoch, "%s")
+        Commit.new(sha: sha, time: time)
       end
     end
   end

--- a/lib/spoom/timeline.rb
+++ b/lib/spoom/timeline.rb
@@ -15,7 +15,7 @@ module Spoom
     end
 
     # Return one commit for each month between `from` and `to`
-    sig { returns(T::Array[String]) }
+    sig { returns(T::Array[Git::Commit]) }
     def ticks
       commits_for_dates(months)
     end
@@ -34,21 +34,21 @@ module Spoom
     end
 
     # Return one commit for each date in `dates`
-    sig { params(dates: T::Array[Time]).returns(T::Array[String]) }
+    sig { params(dates: T::Array[Time]).returns(T::Array[Git::Commit]) }
     def commits_for_dates(dates)
       dates.map do |t|
         result = Spoom::Git.log(
           "--since='#{t}'",
           "--until='#{t.to_date.next_month}'",
-          "--format='format:%h'",
+          "--format='format:%h %at'",
           "--author-date-order",
           "-1",
           path: @path,
         )
         next if result.out.empty?
 
-        result.out
-      end.compact.uniq
+        Git.parse_commit(result.out.strip)
+      end.compact.uniq(&:sha)
     end
   end
 end

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -513,7 +513,7 @@ module Spoom
             def self.bar; end
           end
         RB
-        @project.commit!(date: Time.parse("2010-01-02 03:04:05"))
+        @project.commit!(time: Time.parse("2010-01-02 03:04:05"))
         @project.write!("c.rb", <<~RB)
           # typed: false
           class Baz; end
@@ -522,10 +522,10 @@ module Spoom
           # typed: true
           Baz.new
         RB
-        @project.commit!(date: Time.parse("2010-02-02 03:04:05"))
+        @project.commit!(time: Time.parse("2010-02-02 03:04:05"))
         @project.write!("e.rb", "# typed: ignore")
         @project.write!("f.rb", "# typed: __INTERNAL_STDLIB")
-        @project.commit!(date: Time.parse("2010-03-02 03:04:05"))
+        @project.commit!(time: Time.parse("2010-03-02 03:04:05"))
       end
     end
   end

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -47,19 +47,19 @@ module Spoom
       end
 
       def test_commit_timestamp
-        date = Time.parse("1987-02-05 09:00:00")
+        time = Time.parse("1987-02-05 09:00:00")
         @project.write!("file")
-        @project.commit!(date: date)
+        @project.commit!(time: time)
         sha = Spoom::Git.last_commit(path: @project.absolute_path)
-        assert_equal(date.strftime("%s").to_i, Spoom::Git.commit_timestamp(T.must(sha), path: @project.absolute_path))
+        assert_equal(time.strftime("%s").to_i, Spoom::Git.commit_timestamp(T.must(sha), path: @project.absolute_path))
       end
 
       def test_commit_time
-        date = Time.parse("1987-02-05 09:00:00")
+        time = Time.parse("1987-02-05 09:00:00")
         @project.write!("file")
-        @project.commit!(date: date)
+        @project.commit!(time: time)
         sha = Spoom::Git.last_commit(path: @project.absolute_path)
-        assert_equal(date, Spoom::Git.commit_time(T.must(sha), path: @project.absolute_path))
+        assert_equal(time, Spoom::Git.commit_time(T.must(sha), path: @project.absolute_path))
       end
 
       def test_git_diff
@@ -76,7 +76,7 @@ module Spoom
 
       def test_git_log
         @project.write!("file")
-        @project.commit!(date: Time.parse("1987-02-05 09:00:00 +0000"))
+        @project.commit!(time: Time.parse("1987-02-05 09:00:00 +0000"))
         log = Spoom::Git.log("--format='format:%ad'", path: @project.absolute_path).out
         assert_equal("Thu Feb 5 09:00:00 1987 +0000", log)
       end
@@ -89,7 +89,7 @@ module Spoom
 
       def test_git_show
         @project.write!("file")
-        @project.commit!(date: Time.parse("1987-02-05 09:00:00"))
+        @project.commit!(time: Time.parse("1987-02-05 09:00:00"))
         assert_match(/Thu Feb 5 09:00:00 1987/, Spoom::Git.show(path: @project.absolute_path).out)
       end
 

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -94,15 +94,17 @@ module Spoom
       end
 
       def test_sorbet_intro_not_found
-        sha = Spoom::Git.sorbet_intro_commit(path: @project.absolute_path)
-        assert_nil(sha)
+        commit = Spoom::Git.sorbet_intro_commit(path: @project.absolute_path)
+        assert_nil(commit)
       end
 
       def test_sorbet_intro_found
+        intro_time = Time.parse("1987-02-05 09:00:00 +0000")
         @project.write!("sorbet/config")
-        @project.commit!
-        sha = Spoom::Git.sorbet_intro_commit(path: @project.absolute_path)
-        assert_match(/\A[a-z0-9]+\z/, sha)
+        @project.commit!(time: intro_time)
+        commit = Spoom::Git.sorbet_intro_commit(path: @project.absolute_path)
+        assert_match(/\A[a-z0-9]+\z/, commit&.sha)
+        assert_equal(intro_time, commit&.time)
       end
 
       def test_sorbet_removal_not_found
@@ -111,12 +113,15 @@ module Spoom
       end
 
       def test_sorbet_removal_found
+        intro_time = Time.parse("1987-02-05 09:00:00 +0000")
+        removal_time = Time.parse("1987-02-05 21:00:00 +0000")
         @project.write!("sorbet/config")
-        @project.commit!
+        @project.commit!(time: intro_time)
         @project.remove!("sorbet/config")
-        @project.commit!
-        sha = Spoom::Git.sorbet_removal_commit(path: @project.absolute_path)
-        assert_match(/\A[a-z0-9]+\z/, sha)
+        @project.commit!(time: removal_time)
+        commit = Spoom::Git.sorbet_removal_commit(path: @project.absolute_path)
+        assert_match(/\A[a-z0-9]+\z/, commit&.sha)
+        assert_equal(removal_time, commit&.time)
       end
     end
   end

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -81,12 +81,6 @@ module Spoom
         assert_equal("Thu Feb 5 09:00:00 1987 +0000", log)
       end
 
-      def test_git_rev_parse
-        @project.write!("file")
-        @project.commit!
-        assert_match(/^[a-f0-9]+$/, Spoom::Git.rev_parse("main", path: @project.absolute_path).out.strip)
-      end
-
       def test_git_show
         @project.write!("file")
         @project.commit!(time: Time.parse("1987-02-05 09:00:00"))

--- a/test/spoom/git_test.rb
+++ b/test/spoom/git_test.rb
@@ -50,16 +50,16 @@ module Spoom
         time = Time.parse("1987-02-05 09:00:00")
         @project.write!("file")
         @project.commit!(time: time)
-        sha = Spoom::Git.last_commit(path: @project.absolute_path)
-        assert_equal(time.strftime("%s").to_i, Spoom::Git.commit_timestamp(T.must(sha), path: @project.absolute_path))
+        last_commit = Spoom::Git.last_commit(path: @project.absolute_path)
+        assert_equal(time.to_i, last_commit&.timestamp)
       end
 
       def test_commit_time
         time = Time.parse("1987-02-05 09:00:00")
         @project.write!("file")
         @project.commit!(time: time)
-        sha = Spoom::Git.last_commit(path: @project.absolute_path)
-        assert_equal(time, Spoom::Git.commit_time(T.must(sha), path: @project.absolute_path))
+        last_commit = Spoom::Git.last_commit(path: @project.absolute_path)
+        assert_equal(time, last_commit&.time)
       end
 
       def test_git_diff

--- a/test/spoom/timeline_test.rb
+++ b/test/spoom/timeline_test.rb
@@ -10,13 +10,13 @@ module Spoom
         @project.git_init!
         @project.exec("git config user.name 'spoom-tests'")
         @project.exec("git config user.email 'spoom@shopify.com'")
-        @project.commit!("commit 1", date: Time.parse("2010-01-02 03:04:05"))
+        @project.commit!("commit 1", time: Time.parse("2010-01-02 03:04:05"))
         @project.write!("file2", "")
-        @project.commit!("commit 2", date: Time.parse("2010-04-01 03:04:05"))
+        @project.commit!("commit 2", time: Time.parse("2010-04-01 03:04:05"))
         @project.write!("file3", "")
-        @project.commit!("commit 3", date: Time.parse("2010-06-30 03:04:05"))
+        @project.commit!("commit 3", time: Time.parse("2010-06-30 03:04:05"))
         @project.write!("file4", "")
-        @project.commit!("commit 4", date: Time.parse("2011-01-02 03:04:05"))
+        @project.commit!("commit 4", time: Time.parse("2011-01-02 03:04:05"))
       end
 
       def test_timeline_months

--- a/test/test_project.rb
+++ b/test/test_project.rb
@@ -13,10 +13,10 @@ module Spoom
 
     # Git
 
-    sig { params(message: String, date: Time).void }
-    def commit!(message = "message", date: Time.now.utc)
+    sig { params(message: String, time: Time).void }
+    def commit!(message = "message", time: Time.now.utc)
       exec("git add --all")
-      exec("GIT_COMMITTER_DATE=\"#{date}\" git commit -m '#{message}' --date '#{date}'")
+      exec("GIT_COMMITTER_DATE=\"#{time}\" git commit -m '#{message}' --date '#{time}'")
     end
 
     sig { params(name: String).void }


### PR DESCRIPTION
This abstraction avoids having to call a `git` command twice to get the first the sha and then the timestamp of every single commit.

Beside a slight speedup when computing timelines, this also allows us to remove some unneeded methods.