### PR TITLE
Add Sorbet killed handling

### DIFF
--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -119,6 +119,15 @@ module Spoom
           ERR
           undo_changes(files_to_bump, from)
           exit(error.result.exit_code)
+        rescue Spoom::Sorbet::Error::Killed => error
+          say_error(<<~ERR, status: nil)
+            !!! Sorbet exited with code #{Spoom::Sorbet::KILLED_CODE} - KILLED !!!
+
+            It means Sorbet was killed while executing. Changes to files have not been applied.
+            Re-run `spoom bump` to try again.
+          ERR
+          undo_changes(files_to_bump, from)
+          exit(error.result.exit_code)
         end
 
         if result.status

--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -114,6 +114,12 @@ module Spoom
         ERR
 
         exit(error.result.exit_code)
+      rescue Spoom::Sorbet::Error::Killed => error
+        say_error(<<~ERR, status: nil)
+          #{red("!!! Sorbet exited with code #{error.result.exit_code} - KILLED !!!")}
+        ERR
+
+        exit(error.result.exit_code)
       end
 
       no_commands do

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -301,6 +301,28 @@ module Spoom
         refute(result.status)
       end
 
+      def test_display_sorbet_killed
+        # Create a fake Sorbet that will segfault
+        @project.write!("mock_sorbet", <<~RB)
+          #!/usr/bin/env ruby
+          $stderr.puts "segfault"
+          exit(#{Spoom::Sorbet::KILLED_CODE})
+        RB
+        @project.exec("chmod +x mock_sorbet")
+
+        # Any file will segfault with this
+        @project.write!("will_segfault.rb", <<~RB)
+          # typed: true
+          foo
+        RB
+
+        result = @project.bundle_exec("spoom tc --no-color --sorbet #{@project.absolute_path}/mock_sorbet")
+        assert_equal(<<~OUT, result.err)
+          !!! Sorbet exited with code 137 - KILLED !!!
+        OUT
+        refute(result.status)
+      end
+
       def test_display_sorbet_error
         result = @project.bundle_exec("spoom tc --no-color --sorbet-options=\"--not-found\"")
         assert_equal(<<~MSG, result.err)

--- a/test/spoom/sorbet/run_test.rb
+++ b/test/spoom/sorbet/run_test.rb
@@ -93,6 +93,23 @@ module Spoom
         end
       end
 
+      def test_sorbet_raises_when_killed
+        Bundler.with_unbundled_env do
+          mock_result = ExecResult.new(
+            out: "out",
+            err: "err",
+            status: false,
+            exit_code: Spoom::Sorbet::KILLED_CODE,
+          )
+
+          Spoom.stub(:exec, mock_result) do
+            assert_raises(Spoom::Sorbet::Error::Killed, "Sorbet was killed.") do
+              Spoom::Sorbet.srb("-e foo")
+            end
+          end
+        end
+      end
+
       def test_sorbet_raises_on_sefault
         Bundler.with_unbundled_env do
           mock_result = ExecResult.new(


### PR DESCRIPTION
## Description 

This is PR 1 of 3 to address the issue outlined in this issue: https://github.com/Shopify/spoom/issues/259

1. https://github.com/Shopify/spoom/pull/278
1. https://github.com/Shopify/spoom/pull/279
1. **Add Sorbet killed handling**

In this PR I've added handling in the `Spoom::Sorbet#srb` method to check for the when Sorbet has been killed. This then propagates out in the same way that segfault does, needing explicit `resque`s and output for the error at that place. 

## Approach 

Talking with @Morriar and @KaanOzkan the approach that was landed on was to catch the issue at the Sorbet level and raise an explicit exception for Segfault (exit code: 139) and eventually Killed (exit code: 137). This means that the current handling where we check for segfault can be repalced with rescuing and then outputting the error message that currently exists. 