### PR TITLE
Require `tmpdir` in context.rb

### DIFF
--- a/lib/spoom/context.rb
+++ b/lib/spoom/context.rb
@@ -3,6 +3,7 @@
 
 require "fileutils"
 require "open3"
+require "tmpdir"
 
 module Spoom
   # An abstraction to a Ruby project context


### PR DESCRIPTION
Trying to use `Context.mktmp!` will error if the app does not require `tmpdir` already.