### PR TITLE
Make `Context.git_init` return a ExecResult so the user can check if the command ran properly

### DIFF
--- a/lib/spoom/context.rb
+++ b/lib/spoom/context.rb
@@ -180,9 +180,16 @@ module Spoom
     end
 
     # Run `git init` in this context directory
-    sig { params(branch: String).returns(ExecResult) }
-    def git_init!(branch: "main")
-      git("init -b #{branch}")
+    #
+    # Warning: passing a branch will run `git init -b <branch>` which is only available in git 2.28+.
+    # In older versions, use `git_init!` followed by `git("checkout -b <branch>")`.
+    sig { params(branch: T.nilable(String)).returns(ExecResult) }
+    def git_init!(branch: nil)
+      if branch
+        git("init -b #{branch}")
+      else
+        git("init")
+      end
     end
 
     # Run `git checkout` in this context directory

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -493,7 +493,7 @@ module Spoom
 
       def create_git_history!
         @project.remove!("lib")
-        @project.git_init!
+        @project.git_init!(branch: "main")
         @project.exec("git config user.name 'spoom-tests'")
         @project.exec("git config user.email 'spoom@shopify.com'")
         @project.write!("a.rb", <<~RB)

--- a/test/spoom/context_test.rb
+++ b/test/spoom/context_test.rb
@@ -198,7 +198,7 @@ module Spoom
         assert_equal("fatal: not a git repository (or any of the parent directories): .git\n", res.err)
         refute(res.status)
 
-        res = context.git_init!
+        res = context.git_init!(branch: "main")
         path = File.realdirpath(context.absolute_path)
         assert_equal("Initialized empty Git repository in #{path}/.git/", res.out.strip)
         assert_empty(res.err)
@@ -244,8 +244,10 @@ module Spoom
         context = Context.mktmp!
         assert_nil(context.git_current_branch)
 
-        context.git_init!
+        context.git_init!(branch: "main")
         assert_equal("main", context.git_current_branch)
+        context.git("checkout -b other")
+        assert_equal("other", context.git_current_branch)
 
         context.destroy!
       end


### PR DESCRIPTION
It's frustrating to run `my_context.git_init` only for it to fail without being able to know why.

I also removed the default `-b main` from the command as older git version (< 2.28) do not support the `-b` option.