### PR TITLE
CLI commands use Context

### DIFF
--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -41,10 +41,7 @@ module Spoom
       option :tree, type: :boolean, default: true, desc: "Display list as an indented tree"
       option :rbi, type: :boolean, default: true, desc: "Show RBI files"
       def files
-        in_sorbet_project!
-
-        path = exec_path
-        context = Context.new(path)
+        context = context_requiring_sorbet!
         files = context.srb_files
 
         unless options[:rbi]
@@ -52,12 +49,12 @@ module Spoom
         end
 
         if files.empty?
-          say_error("No file matching `#{sorbet_config_file}`")
+          say_error("No file matching `#{Sorbet::CONFIG_PATH}`")
           exit(1)
         end
 
         if options[:tree]
-          tree = FileTree.new(files, strip_prefix: path)
+          tree = FileTree.new(files, strip_prefix: exec_path)
           tree.print(colors: options[:color], indent_level: 0)
         else
           puts files

--- a/lib/spoom/cli/bump.rb
+++ b/lib/spoom/cli/bump.rb
@@ -47,8 +47,7 @@ module Spoom
       option :sorbet_options, type: :string, default: "", desc: "Pass options to Sorbet"
       sig { params(directory: String).void }
       def bump(directory = ".")
-        in_sorbet_project!
-
+        context = context_requiring_sorbet!
         from = options[:from]
         to = options[:to]
         force = options[:force]
@@ -56,7 +55,6 @@ module Spoom
         only = options[:only]
         cmd = options[:suggest_bump_command]
         exec_path = File.expand_path(self.exec_path)
-        context = Context.new(exec_path)
 
         unless Sorbet::Sigils.valid_strictness?(from)
           say_error("Invalid strictness `#{from}` for option `--from`")

--- a/lib/spoom/cli/config.rb
+++ b/lib/spoom/cli/config.rb
@@ -13,10 +13,11 @@ module Spoom
 
       desc "show", "Show Sorbet config"
       def show
-        in_sorbet_project!
-        config = sorbet_config
+        context = context_requiring_sorbet!
+        config = context.sorbet_config
+        config_path = Pathname.new("#{exec_path}/#{Spoom::Sorbet::CONFIG_PATH}").cleanpath
 
-        say("Found Sorbet config at `#{sorbet_config_file}`.")
+        say("Found Sorbet config at `#{config_path}`.")
 
         say("\nPaths typechecked:")
         if config.paths.empty?

--- a/lib/spoom/cli/coverage.rb
+++ b/lib/spoom/cli/coverage.rb
@@ -18,9 +18,7 @@ module Spoom
       option :rbi, type: :boolean, default: true, desc: "Include RBI files in metrics"
       option :sorbet, type: :string, desc: "Path to custom Sorbet bin"
       def snapshot
-        in_sorbet_project!
-        path = exec_path
-        context = Context.new(path)
+        context = context_requiring_sorbet!
         sorbet = options[:sorbet]
 
         snapshot = Spoom::Coverage.snapshot(context, rbi: options[:rbi], sorbet_bin: sorbet)
@@ -42,9 +40,8 @@ module Spoom
       option :bundle_install, type: :boolean, desc: "Execute `bundle install` before collecting metrics"
       option :sorbet, type: :string, desc: "Path to custom Sorbet bin"
       def timeline
-        in_sorbet_project!
+        context = context_requiring_sorbet!
         path = exec_path
-        context = Context.new(path)
         sorbet = options[:sorbet]
 
         ref_before = context.git_current_branch
@@ -143,8 +140,7 @@ module Spoom
         default: Spoom::Coverage::D3::COLOR_STRONG,
         desc: "Color used for typed: strong"
       def report
-        in_sorbet_project!
-        context = Context.new(exec_path)
+        context = context_requiring_sorbet!
 
         data_dir = options[:data]
         files = Dir.glob("#{data_dir}/*.json")

--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -67,6 +67,27 @@ module Spoom
         end
       end
 
+      # Returns the context at `--path` (by default the current working directory)
+      sig { returns(Context) }
+      def context
+        @context ||= T.let(Context.new(exec_path), T.nilable(Context))
+      end
+
+      # Raise if `spoom` is not ran inside a context with a `sorbet/config` file
+      sig { returns(Context) }
+      def context_requiring_sorbet!
+        context = self.context
+        unless context.has_sorbet_config?
+          say_error(
+            "not in a Sorbet project (`#{Spoom::Sorbet::CONFIG_PATH}` not found)\n\n" \
+              "When running spoom from another path than the project's root, " \
+              "use `--path PATH` to specify the path to the root.",
+          )
+          Kernel.exit(1)
+        end
+        context
+      end
+
       # Return the path specified through `--path`
       sig { returns(String) }
       def exec_path

--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -46,27 +46,6 @@ module Spoom
         $stderr.flush
       end
 
-      # Is `spoom` ran inside a project with a `sorbet/config` file?
-      sig { returns(T::Boolean) }
-      def in_sorbet_project?
-        File.file?(sorbet_config_file)
-      end
-
-      # Enforce that `spoom` is ran inside a project with a `sorbet/config` file
-      #
-      # Display an error message and exit otherwise.
-      sig { void }
-      def in_sorbet_project!
-        unless in_sorbet_project?
-          say_error(
-            "not in a Sorbet project (`#{sorbet_config_file}` not found)\n\n" \
-              "When running spoom from another path than the project's root, " \
-              "use `--path PATH` to specify the path to the root.",
-          )
-          Kernel.exit(1)
-        end
-      end
-
       # Returns the context at `--path` (by default the current working directory)
       sig { returns(Context) }
       def context
@@ -92,16 +71,6 @@ module Spoom
       sig { returns(String) }
       def exec_path
         options[:path]
-      end
-
-      sig { returns(String) }
-      def sorbet_config_file
-        Pathname.new("#{exec_path}/#{Spoom::Sorbet::CONFIG_PATH}").cleanpath.to_s
-      end
-
-      sig { returns(Sorbet::Config) }
-      def sorbet_config
-        Sorbet::Config.parse_file(sorbet_config_file)
       end
 
       # Colors

--- a/lib/spoom/cli/lsp.rb
+++ b/lib/spoom/cli/lsp.rb
@@ -14,7 +14,8 @@ module Spoom
 
       desc "interactive", "Interactive LSP mode"
       def show
-        in_sorbet_project!
+        context_requiring_sorbet!
+
         lsp = lsp_client
         # TODO: run interactive mode
         puts lsp
@@ -111,7 +112,8 @@ module Spoom
 
       no_commands do
         def lsp_client
-          in_sorbet_project!
+          context_requiring_sorbet!
+
           path = exec_path
           client = Spoom::LSP::Client.new(
             Spoom::Sorbet::BIN_PATH,

--- a/lib/spoom/cli/run.rb
+++ b/lib/spoom/cli/run.rb
@@ -24,9 +24,7 @@ module Spoom
       option :sorbet, type: :string, desc: "Path to custom Sorbet bin"
       option :sorbet_options, type: :string, default: "", desc: "Pass options to Sorbet"
       def tc(*paths_to_select)
-        in_sorbet_project!
-
-        path = exec_path
+        context = context_requiring_sorbet!
         limit = options[:limit]
         sort = options[:sort]
         code = options[:code]
@@ -34,7 +32,6 @@ module Spoom
         format = options[:format]
         count = options[:count]
         sorbet = options[:sorbet]
-        context = Context.new(path)
 
         unless limit || code || sort
           result = T.unsafe(context).srb_tc(

--- a/lib/spoom/context/sorbet.rb
+++ b/lib/spoom/context/sorbet.rb
@@ -79,6 +79,12 @@ module Spoom
         res.out.split(" ")[2]
       end
 
+      # Does this context has a `sorbet/config` file?
+      sig { returns(T::Boolean) }
+      def has_sorbet_config?
+        file?(Spoom::Sorbet::CONFIG_PATH)
+      end
+
       sig { returns(Spoom::Sorbet::Config) }
       def sorbet_config
         Spoom::Sorbet::Config.parse_string(read_sorbet_config)

--- a/test/spoom/context/sorbet_test.rb
+++ b/test/spoom/context/sorbet_test.rb
@@ -178,6 +178,16 @@ module Spoom
         context.destroy!
       end
 
+      def test_context_has_sorbet_config
+        context = Context.mktmp!
+        refute(context.has_sorbet_config?)
+
+        context.write_sorbet_config!(".")
+        assert(context.has_sorbet_config?)
+
+        context.destroy!
+      end
+
       def test_context_file_strictness
         context = Context.mktmp!
 


### PR DESCRIPTION
Last follow up to https://github.com/Shopify/code-db/pull/575, make the CLI commands use Context since most of what is needed to run the commands is now available on the Context.

This PR is easier to review commit by commit.