### PR TITLE
Fix flaky test for snapshots

### DIFF
--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -86,6 +86,7 @@ module Spoom
       sig { returns(TestProject) }
       def project
         project = new_project
+        project.bundle_install!
         project.write_sorbet_config!(<<~CONFIG)
           .
           --allowed-extension .rb


### PR DESCRIPTION
Fixes #321.

The snapshot tests were not calling `bundle install` within the test context which lead to a test failure if this test runs before any other test actually calling `bundle install` since Sorbet won't be available.

cc. @KaanOzkan 