### PR TITLE
Do not always call `bundle_install!` in TestWithProject

### DIFF
--- a/test/spoom/cli/bump_test.rb
+++ b/test/spoom/cli/bump_test.rb
@@ -6,6 +6,10 @@ require "test_with_project"
 module Spoom
   module Cli
     class BumpTest < TestWithProject
+      def setup
+        @project.bundle_install!
+      end
+
       def test_bump_outside_sorbet_dir
         @project.remove!("sorbet/config")
         result = @project.spoom("bump --no-color")

--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -6,6 +6,10 @@ require "test_with_project"
 module Spoom
   module Cli
     class CliTest < TestWithProject
+      def setup
+        @project.bundle_install!
+      end
+
       def test_display_current_version_short_option
         result = @project.spoom("-v")
         assert_equal("Spoom v#{Spoom::VERSION}", result.out.strip)

--- a/test/spoom/cli/config_test.rb
+++ b/test/spoom/cli/config_test.rb
@@ -6,6 +6,10 @@ require "test_with_project"
 module Spoom
   module Cli
     class ConfigTest < TestWithProject
+      def setup
+        @project.bundle_install!
+      end
+
       def test_return_error_if_no_sorbet_config
         @project.remove!("sorbet/config")
         result = @project.spoom("config --no-color")

--- a/test/spoom/cli/coverage_test.rb
+++ b/test/spoom/cli/coverage_test.rb
@@ -48,10 +48,6 @@ module Spoom
         @project.bundle_install!
       end
 
-      def teardown
-        @project.destroy!
-      end
-
       def test_display_metrics
         result = @project.spoom("coverage snapshot")
         out = censor_sorbet_version(result.out)
@@ -179,6 +175,7 @@ module Spoom
 
       def test_display_metrics_with_path_option
         project = new_project("test_display_metrics_with_path_option_2")
+        project.bundle_install!
         result = project.spoom("coverage snapshot -p #{@project.absolute_path}")
         out = censor_sorbet_version(result.out)
         assert_equal(<<~MSG, out)
@@ -439,6 +436,7 @@ module Spoom
       def test_timeline_with_path_option
         create_git_history!
         project = new_project("test_timeline_with_path_option_2")
+        project.bundle_install!
         result = project.spoom("coverage timeline --save -p #{@project.absolute_path}")
         assert(result.status)
         assert_equal("", result.err)

--- a/test/spoom/cli/lsp_test.rb
+++ b/test/spoom/cli/lsp_test.rb
@@ -6,6 +6,10 @@ require "test_with_project"
 module Spoom
   module Cli
     class LSPTest < TestWithProject
+      def setup
+        @project.bundle_install!
+      end
+
       # Errors
 
       def test_cant_open_without_config
@@ -280,6 +284,7 @@ module Spoom
           class Test; end
         RB
         project = new_project("test_lsp_with_path_option_2")
+        project.bundle_install!
         result = project.spoom("lsp -p #{@project.absolute_path} --no-color find Test")
         assert_equal(<<~MSG, result.out)
           Symbols matching `Test`:

--- a/test/spoom/cli/run_test.rb
+++ b/test/spoom/cli/run_test.rb
@@ -7,6 +7,7 @@ module Spoom
   module Cli
     class RunTest < TestWithProject
       def setup
+        @project.bundle_install!
         @project.write!("file.rb", "# typed: true")
         @project.write!("errors/errors.rb", <<~RB)
           # typed: true

--- a/test/test_with_project.rb
+++ b/test/test_with_project.rb
@@ -15,7 +15,6 @@ module Spoom
     def initialize(*args)
       super
       @project = T.let(new_project, TestProject)
-      @project.bundle_install!
     end
 
     sig { void }


### PR DESCRIPTION
So one can use a TestWithProject without always running `bundle install` if not needed.