### PR TITLE
Always capture the error stream when running `Context#srb_metrics`

### DIFF
--- a/lib/spoom/context/sorbet.rb
+++ b/lib/spoom/context/sorbet.rb
@@ -42,7 +42,7 @@ module Spoom
           capture_err: T::Boolean,
         ).returns(T.nilable(T::Hash[String, Integer]))
       end
-      def srb_metrics(*arg, sorbet_bin: nil, capture_err: false)
+      def srb_metrics(*arg, sorbet_bin: nil, capture_err: true)
         metrics_file = "metrics.tmp"
 
         T.unsafe(self).srb_tc(

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -27,11 +27,11 @@ module Spoom
           new_config.options_string,
         ]
 
-        metrics = context.srb_metrics(*flags, capture_err: true, sorbet_bin: sorbet_bin)
+        metrics = context.srb_metrics(*flags, sorbet_bin: sorbet_bin)
 
         # Collect extra information using a different configuration
         flags << "--ignore sorbet/rbi/"
-        metrics_without_rbis = context.srb_metrics(*flags, capture_err: true, sorbet_bin: sorbet_bin)
+        metrics_without_rbis = context.srb_metrics(*flags, sorbet_bin: sorbet_bin)
 
         snapshot = Snapshot.new
         return snapshot unless metrics


### PR DESCRIPTION
This will avoid a `No errors, good job` to pop in the test output.