### PR TITLE
Remove Ruby LSP from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 
 group :development do
   gem "debug"
-  gem "ruby-lsp"
   gem "rubocop-shopify", require: false
   gem "rubocop-sorbet", require: false
   gem "tapioca", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,6 @@ GEM
     irb (1.6.3)
       reline (>= 0.3.0)
     json (2.6.3)
-    language_server-protocol (3.17.0.3)
     minitest (5.18.0)
     minitest-reporters (1.6.0)
       ansi
@@ -31,7 +30,6 @@ GEM
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
-    prettier_print (1.2.1)
     rainbow (3.1.1)
     rake (13.0.6)
     rbi (0.0.16)
@@ -59,10 +57,6 @@ GEM
       rubocop (~> 1.50)
     rubocop-sorbet (0.7.0)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.5.1)
-      language_server-protocol (~> 3.17.0)
-      sorbet-runtime
-      syntax_tree (>= 6.1.1, < 7)
     ruby-progressbar (1.13.0)
     sorbet (0.5.10805)
       sorbet-static (= 0.5.10805)
@@ -73,8 +67,6 @@ GEM
     sorbet-static-and-runtime (0.5.10805)
       sorbet (= 0.5.10805)
       sorbet-runtime (= 0.5.10805)
-    syntax_tree (6.1.1)
-      prettier_print (>= 1.2.0)
     tapioca (0.11.5)
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
@@ -107,7 +99,6 @@ DEPENDENCIES
   rake (~> 13.0.1)
   rubocop-shopify
   rubocop-sorbet
-  ruby-lsp
   spoom!
   tapioca
 


### PR DESCRIPTION
Was originally added in https://github.com/Shopify/spoom/pull/150 but now Ruby LSP can be used without it being in the Gemfile.

(and removing it means one less things for Dependabot to notify about).