### PR TITLE
Fix broken CLI test output

### DIFF
--- a/test/spoom/cli/cli_test.rb
+++ b/test/spoom/cli/cli_test.rb
@@ -34,10 +34,10 @@ module Spoom
             spoom tc              # Run Sorbet and parses its output
 
           Options:
-                [--color], [--no-color]  # Use colors
-                                         # Default: true
-            p, [--path=PATH]             # Run spoom in a specific path
-                                         # Default: .
+               [--color], [--no-color]  # Use colors
+                                        # Default: true
+            p, [--path=PATH]            # Run spoom in a specific path
+                                        # Default: .
 
         OUT
       end


### PR DESCRIPTION
The output for one of the CLI tests has some incorrect spacing, which is causing CI to fail.