### PR TITLE
Update ruby.yml to skip bin/setup

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,8 +25,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: ruby -v
-    - name: Install dependencies
-      run: bin/setup
     - name: Run typechecking
       run: bin/typecheck
     - name: Check sigils


### PR DESCRIPTION
This should not be necessary since the `bundler-cache: true` setting should handle the setup.