### PR TITLE
Introduce indexing for dead code detection

### DIFF
--- a/lib/spoom.rb
+++ b/lib/spoom.rb
@@ -15,6 +15,7 @@ end
 require "spoom/file_collector"
 require "spoom/context"
 require "spoom/colors"
+require "spoom/deadcode"
 require "spoom/sorbet"
 require "spoom/cli"
 require "spoom/version"

--- a/lib/spoom/context/file_system.rb
+++ b/lib/spoom/context/file_system.rb
@@ -43,6 +43,23 @@ module Spoom
         glob("*")
       end
 
+      sig do
+        params(
+          allow_extensions: T::Array[String],
+          allow_mime_types: T::Array[String],
+          exclude_patterns: T::Array[String],
+        ).returns(T::Array[String])
+      end
+      def collect_files(allow_extensions: [], allow_mime_types: [], exclude_patterns: [])
+        collector = FileCollector.new(
+          allow_extensions: allow_extensions,
+          allow_mime_types: allow_mime_types,
+          exclude_patterns: exclude_patterns,
+        )
+        collector.visit_path(absolute_path)
+        collector.files.map { |file| file.delete_prefix("#{absolute_path}/") }
+      end
+
       # Does `relative_path` point to an existing file in this context directory?
       sig { params(relative_path: String).returns(T::Boolean) }
       def file?(relative_path)

--- a/lib/spoom/deadcode.rb
+++ b/lib/spoom/deadcode.rb
@@ -1,0 +1,47 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "syntax_tree"
+
+require_relative "deadcode/index"
+require_relative "deadcode/indexer"
+
+require_relative "deadcode/location"
+require_relative "deadcode/definition"
+require_relative "deadcode/reference"
+require_relative "deadcode/send"
+
+module Spoom
+  module Deadcode
+    class Error < Spoom::Error
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
+      sig { params(message: String, parent: Exception).void }
+      def initialize(message, parent:)
+        super(message)
+        set_backtrace(parent.backtrace)
+      end
+    end
+
+    class ParserError < Error; end
+    class IndexerError < Error; end
+
+    class << self
+      extend T::Sig
+
+      sig { params(index: Index, ruby: String, file: String).void }
+      def index_ruby(index, ruby, file:)
+        node = SyntaxTree.parse(ruby)
+        visitor = Spoom::Deadcode::Indexer.new(file, ruby, index)
+        visitor.visit(node)
+      rescue SyntaxTree::Parser::ParseError => e
+        raise ParserError.new("Error while parsing #{file} (#{e.message} at #{e.lineno}:#{e.column})", parent: e)
+      rescue => e
+        raise IndexerError.new("Error while indexing #{file} (#{e.message})", parent: e)
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/definition.rb
+++ b/lib/spoom/deadcode/definition.rb
@@ -1,0 +1,98 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    # A definition is a class, module, method, constant, etc. being defined in the code
+    class Definition < T::Struct
+      extend T::Sig
+
+      class Kind < T::Enum
+        enums do
+          AttrReader = new("attr_reader")
+          AttrWriter = new("attr_writer")
+          Class = new("class")
+          Constant = new("constant")
+          Method = new("method")
+          Module = new("module")
+        end
+      end
+
+      class Status < T::Enum
+        enums do
+          # A definition is marked as `ALIVE` if it has at least one reference with the same name
+          ALIVE = new
+          # A definition is marked as `DEAD` if it has no reference with the same name
+          DEAD = new
+          # A definition can be marked as `IGNORED` if it is not relevant for the analysis
+          IGNORED = new
+        end
+      end
+
+      const :kind, Kind
+      const :name, String
+      const :full_name, String
+      const :location, Location
+      const :status, Status, default: Status::DEAD
+
+      # Kind
+
+      sig { returns(T::Boolean) }
+      def attr_reader?
+        kind == Kind::AttrReader
+      end
+
+      sig { returns(T::Boolean) }
+      def attr_writer?
+        kind == Kind::AttrWriter
+      end
+
+      sig { returns(T::Boolean) }
+      def class?
+        kind == Kind::Class
+      end
+
+      sig { returns(T::Boolean) }
+      def constant?
+        kind == Kind::Constant
+      end
+
+      sig { returns(T::Boolean) }
+      def method?
+        kind == Kind::Method
+      end
+
+      sig { returns(T::Boolean) }
+      def module?
+        kind == Kind::Module
+      end
+
+      # Status
+
+      sig { returns(T::Boolean) }
+      def alive?
+        status == Status::ALIVE
+      end
+
+      sig { void }
+      def alive!
+        @status = Status::ALIVE
+      end
+
+      sig { returns(T::Boolean) }
+      def dead?
+        status == Status::DEAD
+      end
+
+      sig { returns(T::Boolean) }
+      def ignored?
+        status == Status::IGNORED
+      end
+
+      sig { void }
+      def ignored!
+        @status = Status::IGNORED
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -1,0 +1,61 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    class Index
+      extend T::Sig
+
+      sig { returns(T::Hash[String, T::Array[Definition]]) }
+      attr_reader :definitions
+
+      sig { returns(T::Hash[String, T::Array[Reference]]) }
+      attr_reader :references
+
+      sig { void }
+      def initialize
+        @definitions = T.let({}, T::Hash[String, T::Array[Definition]])
+        @references = T.let({}, T::Hash[String, T::Array[Reference]])
+      end
+
+      # Indexing
+
+      sig { params(definition: Definition).void }
+      def define(definition)
+        (@definitions[definition.name] ||= []) << definition
+      end
+
+      sig { params(reference: Reference).void }
+      def reference(reference)
+        (@references[reference.name] ||= []) << reference
+      end
+
+      # Mark all definitions having a reference of the same name as `alive`
+      #
+      # To be called once all the files have been indexed and all the definitions and references discovered.
+      sig { void }
+      def finalize!
+        @references.keys.each do |name|
+          definitions_for_name(name).each(&:alive!)
+        end
+      end
+
+      # Utils
+
+      sig { params(name: String).returns(T::Array[Definition]) }
+      def definitions_for_name(name)
+        @definitions[name] || []
+      end
+
+      sig { returns(T::Array[Definition]) }
+      def all_definitions
+        @definitions.values.flatten
+      end
+
+      sig { returns(T::Array[Reference]) }
+      def all_references
+        @references.values.flatten
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -106,8 +106,11 @@ module Spoom
         const_name = node_string(node.constant)
         @names_nesting << const_name
         define_class(T.must(const_name.split("::").last), @names_nesting.join("::"), node)
+
+        # We do not call `super` here because we don't want to visit the `constant` again
         visit(node.superclass) if node.superclass
         visit(node.bodystmt)
+
         @names_nesting.pop
       end
 
@@ -143,7 +146,9 @@ module Spoom
 
       sig { override.params(node: SyntaxTree::ConstPathField).void }
       def visit_const_path_field(node)
+        # We do not call `super` here because we don't want to visit the `constant` again
         visit(node.parent)
+
         name = node.constant.value
         full_name = [*@names_nesting, node_string(node.parent), name].join("::")
         define_constant(name, full_name, node)
@@ -178,7 +183,10 @@ module Spoom
         const_name = node_string(node.constant)
         @names_nesting << const_name
         define_module(T.must(const_name.split("::").last), @names_nesting.join("::"), node)
+
+        # We do not call `super` here because we don't want to visit the `constant` again
         visit(node.bodystmt)
+
         @names_nesting.pop
       end
 

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -69,7 +69,7 @@ module Spoom
           reference_method(symbol_string(value), node)
         when SyntaxTree::VCall
           # If the block call is something like `x.select { ... }`, we need to visit the block
-          visit(value)
+          super
         end
       end
 

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -1,0 +1,386 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    class Indexer < SyntaxTree::Visitor
+      extend T::Sig
+
+      sig { returns(String) }
+      attr_reader :path, :file_name
+
+      sig { returns(Index) }
+      attr_reader :index
+
+      sig { params(path: String, source: String, index: Index).void }
+      def initialize(path, source, index)
+        super()
+
+        @path = path
+        @file_name = T.let(File.basename(path), String)
+        @source = source
+        @index = index
+        @previous_node = T.let(nil, T.nilable(SyntaxTree::Node))
+        @names_nesting = T.let([], T::Array[String])
+        @nodes_nesting = T.let([], T::Array[SyntaxTree::Node])
+        @in_const_field = T.let(false, T::Boolean)
+        @in_opassign = T.let(false, T::Boolean)
+        @in_symbol_literal = T.let(false, T::Boolean)
+      end
+
+      # Visit
+
+      sig { override.params(node: T.nilable(SyntaxTree::Node)).void }
+      def visit(node)
+        return unless node
+
+        @nodes_nesting << node
+        super
+        @nodes_nesting.pop
+        @previous_node = node
+      end
+
+      sig { override.params(node: SyntaxTree::AliasNode).void }
+      def visit_alias(node)
+        reference_method(node_string(node.right), node)
+      end
+
+      sig { override.params(node: SyntaxTree::ARef).void }
+      def visit_aref(node)
+        super
+
+        reference_method("[]", node)
+      end
+
+      sig { override.params(node: SyntaxTree::ARefField).void }
+      def visit_aref_field(node)
+        super
+
+        reference_method("[]=", node)
+      end
+
+      sig { override.params(node: SyntaxTree::ArgBlock).void }
+      def visit_arg_block(node)
+        value = node.value
+
+        case value
+        when SyntaxTree::SymbolLiteral
+          # If the block call is something like `x.select(&:foo)`, we need to reference the `foo` method
+          reference_method(symbol_string(value), node)
+        when SyntaxTree::VCall
+          # If the block call is something like `x.select { ... }`, we need to visit the block
+          visit(value)
+        end
+      end
+
+      sig { override.params(node: SyntaxTree::Binary).void }
+      def visit_binary(node)
+        super
+
+        op = node.operator
+
+        # Reference the operator itself
+        reference_method(op.to_s, node)
+
+        case op
+        when :<, :>, :<=, :>=
+          # For comparison operators, we also reference the `<=>` method
+          reference_method("<=>", node)
+        end
+      end
+
+      sig { override.params(node: SyntaxTree::CallNode).void }
+      def visit_call(node)
+        visit_send(
+          Send.new(
+            node: node,
+            name: node_string(node.message),
+            recv: node.receiver,
+            args: call_args(node.arguments),
+          ),
+        )
+      end
+
+      sig { override.params(node: SyntaxTree::ClassDeclaration).void }
+      def visit_class(node)
+        const_name = node_string(node.constant)
+        @names_nesting << const_name
+        define_class(T.must(const_name.split("::").last), @names_nesting.join("::"), node)
+        visit(node.superclass) if node.superclass
+        visit(node.bodystmt)
+        @names_nesting.pop
+      end
+
+      sig { override.params(node: SyntaxTree::Command).void }
+      def visit_command(node)
+        visit_send(
+          Send.new(
+            node: node,
+            name: node_string(node.message),
+            args: call_args(node.arguments),
+            block: node.block,
+          ),
+        )
+      end
+
+      sig { override.params(node: SyntaxTree::CommandCall).void }
+      def visit_command_call(node)
+        visit_send(
+          Send.new(
+            node: node,
+            name: node_string(node.message),
+            recv: node.receiver,
+            args: call_args(node.arguments),
+            block: node.block,
+          ),
+        )
+      end
+
+      sig { override.params(node: SyntaxTree::Const).void }
+      def visit_const(node)
+        reference_constant(node.value, node) unless @in_symbol_literal
+      end
+
+      sig { override.params(node: SyntaxTree::ConstPathField).void }
+      def visit_const_path_field(node)
+        visit(node.parent)
+        name = node.constant.value
+        full_name = [*@names_nesting, node_string(node.parent), name].join("::")
+        define_constant(name, full_name, node)
+      end
+
+      sig { override.params(node: SyntaxTree::DefNode).void }
+      def visit_def(node)
+        super
+
+        name = node_string(node.name)
+        define_method(name, [*@names_nesting, name].join("::"), node)
+      end
+
+      sig { override.params(node: SyntaxTree::Field).void }
+      def visit_field(node)
+        visit(node.parent)
+
+        name = node.name
+        case name
+        when SyntaxTree::Const
+          name = name.value
+          full_name = [*@names_nesting, node_string(node.parent), name].join("::")
+          define_constant(name, full_name, node)
+        when SyntaxTree::Ident
+          reference_method(name.value, node) if @in_opassign
+          reference_method("#{name.value}=", node)
+        end
+      end
+
+      sig { override.params(node: SyntaxTree::ModuleDeclaration).void }
+      def visit_module(node)
+        const_name = node_string(node.constant)
+        @names_nesting << const_name
+        define_module(T.must(const_name.split("::").last), @names_nesting.join("::"), node)
+        visit(node.bodystmt)
+        @names_nesting.pop
+      end
+
+      sig { override.params(node: SyntaxTree::OpAssign).void }
+      def visit_opassign(node)
+        # Both `FOO = x` and `FOO += x` yield a VarField node, but the former is a constant definition and the latter is
+        # a constant reference. We need to distinguish between the two cases.
+        @in_opassign = true
+        super
+        @in_opassign = false
+      end
+
+      sig { params(send: Send).void }
+      def visit_send(send)
+        visit(send.recv)
+
+        case send.name
+        when "attr_reader"
+          send.args.each do |arg|
+            next unless arg.is_a?(SyntaxTree::SymbolLiteral)
+
+            name = symbol_string(arg)
+            define_attr_reader(name, [*@names_nesting, name].join("::"), arg)
+          end
+        when "attr_writer"
+          send.args.each do |arg|
+            next unless arg.is_a?(SyntaxTree::SymbolLiteral)
+
+            name = symbol_string(arg)
+            define_attr_writer("#{name}=", "#{[*@names_nesting, name].join("::")}=", arg)
+          end
+        when "attr_accessor"
+          send.args.each do |arg|
+            next unless arg.is_a?(SyntaxTree::SymbolLiteral)
+
+            name = symbol_string(arg)
+            full_name = [*@names_nesting, name].join("::")
+            define_attr_reader(name, full_name, arg)
+            define_attr_writer("#{name}=", "#{full_name}=", arg)
+          end
+        else
+          reference_method(send.name, send.node)
+          visit_all(send.args)
+          visit(send.block)
+        end
+      end
+
+      sig { override.params(node: SyntaxTree::SymbolLiteral).void }
+      def visit_symbol_literal(node)
+        # Something like `:FOO` will yield a Const node but we do not want to treat it as a constant reference.
+        # So we need to distinguish between the two cases.
+        @in_symbol_literal = true
+        super
+        @in_symbol_literal = false
+      end
+
+      sig { override.params(node: SyntaxTree::TopConstField).void }
+      def visit_top_const_field(node)
+        define_constant(node.constant.value, node.constant.value, node)
+      end
+
+      sig { override.params(node: SyntaxTree::VarField).void }
+      def visit_var_field(node)
+        value = node.value
+        case value
+        when SyntaxTree::Const
+          if @in_opassign
+            reference_constant(value.value, node)
+          else
+            name = value.value
+            define_constant(name, [*@names_nesting, name].join("::"), node)
+          end
+        when SyntaxTree::Ident
+          reference_method(value.value, node) if @in_opassign
+          reference_method("#{value.value}=", node)
+        end
+      end
+
+      sig { override.params(node: SyntaxTree::VCall).void }
+      def visit_vcall(node)
+        visit_send(Send.new(node: node, name: node_string(node.value)))
+      end
+
+      private
+
+      # Definition indexing
+
+      sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
+      def define_attr_reader(name, full_name, node)
+        definition = Definition.new(
+          kind: Definition::Kind::AttrReader,
+          name: name,
+          full_name: full_name,
+          location: node_location(node),
+        )
+        @index.define(definition)
+      end
+
+      sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
+      def define_attr_writer(name, full_name, node)
+        definition = Definition.new(
+          kind: Definition::Kind::AttrWriter,
+          name: name,
+          full_name: full_name,
+          location: node_location(node),
+        )
+        @index.define(definition)
+      end
+
+      sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
+      def define_class(name, full_name, node)
+        definition = Definition.new(
+          kind: Definition::Kind::Class,
+          name: name,
+          full_name: full_name,
+          location: node_location(node),
+        )
+        @index.define(definition)
+      end
+
+      sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
+      def define_constant(name, full_name, node)
+        definition = Definition.new(
+          kind: Definition::Kind::Constant,
+          name: name,
+          full_name: full_name,
+          location: node_location(node),
+        )
+        @index.define(definition)
+      end
+
+      sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
+      def define_method(name, full_name, node)
+        definition = Definition.new(
+          kind: Definition::Kind::Method,
+          name: name,
+          full_name: full_name,
+          location: node_location(node),
+        )
+        @index.define(definition)
+      end
+
+      sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
+      def define_module(name, full_name, node)
+        definition = Definition.new(
+          kind: Definition::Kind::Module,
+          name: name,
+          full_name: full_name,
+          location: node_location(node),
+        )
+        @index.define(definition)
+      end
+
+      # Reference indexing
+
+      sig { params(name: String, node: SyntaxTree::Node).void }
+      def reference_constant(name, node)
+        @index.reference(Reference.new(name: name, kind: Reference::Kind::Constant, location: node_location(node)))
+      end
+
+      sig { params(name: String, node: SyntaxTree::Node).void }
+      def reference_method(name, node)
+        @index.reference(Reference.new(name: name, kind: Reference::Kind::Method, location: node_location(node)))
+      end
+
+      # Node utils
+
+      sig { params(node: T.any(Symbol, SyntaxTree::Node)).returns(String) }
+      def node_string(node)
+        case node
+        when Symbol
+          node.to_s
+        else
+          T.must(@source[node.location.start_char...node.location.end_char])
+        end
+      end
+
+      sig { params(node: SyntaxTree::Node).returns(Location) }
+      def node_location(node)
+        Location.from_syntax_tree(@path, node.location)
+      end
+
+      sig { params(node: SyntaxTree::Node).returns(String) }
+      def symbol_string(node)
+        node_string(node).delete_prefix(":")
+      end
+
+      sig do
+        params(
+          node: T.any(SyntaxTree::Args, SyntaxTree::ArgParen, SyntaxTree::ArgsForward, NilClass),
+        ).returns(T::Array[SyntaxTree::Node])
+      end
+      def call_args(node)
+        case node
+        when SyntaxTree::ArgParen
+          call_args(node.arguments)
+        when SyntaxTree::Args
+          node.parts
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/location.rb
+++ b/lib/spoom/deadcode/location.rb
@@ -1,0 +1,58 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    class Location
+      extend T::Sig
+
+      include Comparable
+
+      class LocationError < Spoom::Error; end
+
+      class << self
+        extend T::Sig
+
+        sig { params(file: String, location: SyntaxTree::Location).returns(Location) }
+        def from_syntax_tree(file, location)
+          new(file, location.start_line, location.start_column, location.end_line, location.end_column)
+        end
+      end
+
+      sig { returns(String) }
+      attr_reader :file
+
+      sig { returns(Integer) }
+      attr_reader :start_line, :start_column, :end_line, :end_column
+
+      sig do
+        params(
+          file: String,
+          start_line: Integer,
+          start_column: Integer,
+          end_line: Integer,
+          end_column: Integer,
+        ).void
+      end
+      def initialize(file, start_line, start_column, end_line, end_column)
+        @file = file
+        @start_line = start_line
+        @start_column = start_column
+        @end_line = end_line
+        @end_column = end_column
+      end
+
+      sig { override.params(other: BasicObject).returns(T.nilable(Integer)) }
+      def <=>(other)
+        return nil unless Location === other
+
+        to_s <=> other.to_s
+      end
+
+      sig { returns(String) }
+      def to_s
+        "#{@file}:#{@start_line}:#{@start_column}-#{@end_line}:#{@end_column}"
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/reference.rb
+++ b/lib/spoom/deadcode/reference.rb
@@ -1,0 +1,34 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    # A reference is a call to a method or a constant
+    class Reference < T::Struct
+      extend T::Sig
+
+      class Kind < T::Enum
+        enums do
+          Constant = new
+          Method = new
+        end
+      end
+
+      const :kind, Kind
+      const :name, String
+      const :location, Location
+
+      # Kind
+
+      sig { returns(T::Boolean) }
+      def constant?
+        kind == Kind::Constant
+      end
+
+      sig { returns(T::Boolean) }
+      def method?
+        kind == Kind::Method
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/send.rb
+++ b/lib/spoom/deadcode/send.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    # An abstraction to simplify handling of SyntaxTree::CallNode, SyntaxTree::Command, SyntaxTree::CommandCall and
+    # SyntaxTree::VCall nodes.
+    class Send < T::Struct
+      extend T::Sig
+
+      const :node, SyntaxTree::Node
+      const :name, String
+      const :recv, T.nilable(SyntaxTree::Node), default: nil
+      const :args, T::Array[SyntaxTree::Node], default: []
+      const :block, T.nilable(SyntaxTree::Node), default: nil
+    end
+  end
+end

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -1,0 +1,72 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "test_with_project"
+
+module Spoom
+  module Test
+    module Helpers
+      module DeadcodeHelper
+        extend T::Sig
+        extend T::Helpers
+
+        requires_ancestor { TestWithProject }
+
+        # Indexing
+
+        sig { returns(Deadcode::Index) }
+        def deadcode_index
+          files = project.collect_files(
+            allow_extensions: [".rb", ".erb", ".rake", ".rakefile", ".gemspec"],
+            allow_mime_types: ["text/x-ruby", "text/x-ruby-script"],
+          )
+
+          index = Deadcode::Index.new
+
+          files.each do |file|
+            content = project.read(file)
+            Spoom::Deadcode.index_ruby(index, content, file: file)
+          end
+
+          index.finalize!
+          index
+        end
+
+        # Assertions
+
+        sig { params(index: Deadcode::Index, name: String).void }
+        def assert_alive(index, name)
+          defs = definitions_for_name(index, name)
+          assert(defs.all?(&:alive?))
+        end
+
+        sig { params(index: Deadcode::Index, name: String).void }
+        def assert_dead(index, name)
+          defs = definitions_for_name(index, name)
+          assert(defs.all?(&:dead?))
+        end
+
+        sig { params(index: Deadcode::Index, name: String).void }
+        def assert_ignored(index, name)
+          defs = definitions_for_name(index, name)
+          assert(defs.all?(&:ignored?))
+        end
+
+        sig { params(index: Deadcode::Index, name: String).void }
+        def refute_ignored(index, name)
+          defs = definitions_for_name(index, name)
+          assert(defs.none?(&:ignored?))
+        end
+
+        private
+
+        sig { params(index: Deadcode::Index, name: String).returns(T::Array[Deadcode::Definition]) }
+        def definitions_for_name(index, name)
+          defs = index.definitions_for_name(name)
+          refute_empty(defs)
+          defs
+        end
+      end
+    end
+  end
+end

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -37,25 +37,25 @@ module Spoom
         sig { params(index: Deadcode::Index, name: String).void }
         def assert_alive(index, name)
           defs = definitions_for_name(index, name)
-          assert(defs.all?(&:alive?))
+          assert(defs.all?(&:alive?), "Expected all definitions for `#{name}` to be alive")
         end
 
         sig { params(index: Deadcode::Index, name: String).void }
         def assert_dead(index, name)
           defs = definitions_for_name(index, name)
-          assert(defs.all?(&:dead?))
+          assert(defs.all?(&:dead?), "Expected all definitions for `#{name}` to be dead")
         end
 
         sig { params(index: Deadcode::Index, name: String).void }
         def assert_ignored(index, name)
           defs = definitions_for_name(index, name)
-          assert(defs.all?(&:ignored?))
+          assert(defs.all?(&:ignored?), "Expected all definitions for `#{name}` to be ignored")
         end
 
         sig { params(index: Deadcode::Index, name: String).void }
         def refute_ignored(index, name)
           defs = definitions_for_name(index, name)
-          assert(defs.none?(&:ignored?))
+          assert(defs.none?(&:ignored?), "Expected all definitions for `#{name}` to not be ignored")
         end
 
         private
@@ -63,7 +63,7 @@ module Spoom
         sig { params(index: Deadcode::Index, name: String).returns(T::Array[Deadcode::Definition]) }
         def definitions_for_name(index, name)
           defs = index.definitions_for_name(name)
-          refute_empty(defs)
+          refute_empty(defs, "No indexed definition found for `#{name}`")
           defs
         end
       end

--- a/test/spoom/deadcode/index_definitions_test.rb
+++ b/test/spoom/deadcode/index_definitions_test.rb
@@ -1,0 +1,247 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    class IndexDefinitionsTest < Spoom::TestWithProject
+      include Test::Helpers::DeadcodeHelper
+
+      def test_index_rescue_parser_error
+        @project.write!("foo.rb", <<~RB)
+          def foo(
+        RB
+
+        exception = assert_raises(ParserError) do
+          deadcode_index
+        end
+
+        assert_equal(
+          "Error while parsing foo.rb (syntax error, unexpected end-of-input, expecting ')' at 1:9)",
+          exception.message,
+        )
+      end
+
+      def test_index_constant_definitions
+        @project.write!("foo.rb", <<~RB)
+          C1 = 42
+          ::C2 = 42
+          NOT_INDEXED::C3 = 42
+          not_indexed::C4 = 42
+          not_indexed.C5 = 42
+          C6, C7 = 42
+
+          NOT_INDEXED.foo = 42
+
+          @NOT_INDEXED = 42
+          not_indexed[:NOT_INDEXED][:NOT_INDEXED] = 42
+          NOT_INDEXED += 42
+          NOT_INDEXED << 42
+        RB
+
+        assert_equal(
+          ["C1", "C2", "C3", "C4", "C5", "C6", "C7"],
+          deadcode_index.all_definitions.select(&:constant?).map(&:name),
+        )
+      end
+
+      def test_index_class_definitions
+        @project.write!("foo.rb", <<~RB)
+          class C1; end
+          class ::C2; end
+          class NOT_INDEXED::C3; end
+          class not_indexed::C4; end
+
+          class C5 < NOT_INDEXED
+            class C6; end
+          end
+        RB
+
+        assert_equal(
+          ["C1", "C2", "C3", "C4", "C5", "C6"],
+          deadcode_index.all_definitions.select(&:class?).map(&:name),
+        )
+      end
+
+      def test_index_module_definitions
+        @project.write!("foo.rb", <<~RB)
+          module M1; end
+          module ::M2; end
+          module NOT_INDEXED::M3; end
+          module not_indexed::M4; end
+
+          module M5
+            module M6; end
+          end
+        RB
+
+        assert_equal(
+          ["M1", "M2", "M3", "M4", "M5", "M6"],
+          deadcode_index.all_definitions.select(&:module?).map(&:name),
+        )
+      end
+
+      def test_index_method_definitions
+        @project.write!("foo.rb", <<~RB)
+          def m1; end
+          def self.m2; end
+          def NOT_INDEXED::m3; end
+          def not_indexed::m4; end
+          def not_indexed.m5; end
+
+          def m6(); end
+          def m7(x, y, z); end
+
+          def m8 = 42
+
+          def m9=(x); end
+
+          def `; end
+          def !; end
+          def <=>; end
+          def CONST; end
+        RB
+
+        assert_equal(
+          ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9=", "`", "!", "<=>", "CONST"],
+          deadcode_index.all_definitions.select(&:method?).map(&:name),
+        )
+      end
+
+      def test_index_attribute_definitions
+        @project.write!("foo.rb", <<~RB)
+          attr_reader :r1
+          attr_reader :r2, :r3
+          attr_reader(:r4, :r5)
+          self.attr_reader :r6
+          self.attr_reader(:r7)
+
+          attr_writer :w1
+          attr_writer :w2, :w3
+          attr_writer(:w4, :w5)
+          self.attr_writer :w6
+          self.attr_writer(:w7)
+
+          attr_accessor :a1
+          attr_accessor :a2, :a3
+          attr_accessor(:a4, :a5)
+          self.attr_accessor :a6
+          self.attr_accessor(:a7)
+        RB
+
+        index = deadcode_index
+
+        assert_equal(
+          ["a1", "a2", "a3", "a4", "a5", "a6", "a7", "r1", "r2", "r3", "r4", "r5", "r6", "r7"],
+          index.all_definitions.select(&:attr_reader?).map(&:name).sort,
+        )
+
+        assert_equal(
+          ["a1=", "a2=", "a3=", "a4=", "a5=", "a6=", "a7=", "w1=", "w2=", "w3=", "w4=", "w5=", "w6=", "w7="],
+          index.all_definitions.select(&:attr_writer?).map(&:name).sort,
+        )
+      end
+
+      def test_index_attribute_definitions_but_ignore_when_not_a_symbol
+        @project.write!("foo.rb", <<~RB)
+          attr_reader :r1
+          attr_reader "foo"
+          attr_reader *names
+        RB
+
+        assert_equal(
+          ["r1"],
+          deadcode_index.all_definitions.select(&:attr_reader?).map(&:name),
+        )
+      end
+
+      def test_index_method_splats
+        @project.write!("foo.rb", <<~RB)
+          def foo(*args, **kwargs, &block)
+            bar(*args, **kwargs, &block)
+          end
+        RB
+
+        assert_equal(
+          ["foo"],
+          deadcode_index.all_definitions.select(&:method?).map(&:name).sort,
+        )
+      end
+
+      def test_index_method_forward_definitions
+        @project.write!("foo.rb", <<~RB)
+          def foo(...)
+            bar(...)
+          end
+        RB
+
+        assert_equal(
+          ["foo"],
+          deadcode_index.all_definitions.select(&:method?).map(&:name).sort,
+        )
+      end
+
+      def test_index_method_star_forward_definitions
+        skip if RUBY_VERSION < "3.2"
+
+        @project.write!("foo.rb", <<~RB)
+          def foo(*, **, &)
+            bar(*, **, &)
+          end
+        RB
+
+        assert_equal(
+          ["foo"],
+          deadcode_index.all_definitions.select(&:method?).map(&:name).sort,
+        )
+      end
+
+      def test_index_namespaces
+        @project.write!("foo.rb", <<~RB)
+          class A
+            module B
+              class C::D; end
+
+              E = 42
+              ::F = 42
+              G::H::I = 42
+              E.J = 42
+
+              attr_accessor :foo
+
+              def bar; end
+              def self.baz; end
+
+              class << self
+                def bla; end
+              end
+            end
+          end
+
+          def baz; end
+        RB
+
+        assert_equal(
+          [
+            "A",
+            "A::B",
+            "A::B::C::D",
+            "A::B::E",
+            "A::B::E::J",
+            "A::B::G::H::I",
+            "A::B::bar",
+            "A::B::baz",
+            "A::B::bla",
+            "A::B::foo",
+            "A::B::foo=",
+            "F",
+            "baz",
+          ],
+          deadcode_index.all_definitions.map(&:full_name).sort,
+        )
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/index_finalize_test.rb
+++ b/test/spoom/deadcode/index_finalize_test.rb
@@ -1,0 +1,156 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    class IndexFinalizeTest < Spoom::TestWithProject
+      include Test::Helpers::DeadcodeHelper
+
+      def test_index_deadcode_constants
+        @project.write!("foo.rb", <<~RB)
+          class Foo
+            DEAD1 = 42
+
+            def foo
+              puts ALIVE1
+            end
+          end
+
+          ALIVE1 = 42
+          ALIVE2 = 42
+          DEAD2 = 42
+
+          puts ALIVE2
+          Foo.foo
+        RB
+
+        index = deadcode_index
+        assert_alive(index, "ALIVE1")
+        assert_alive(index, "ALIVE2")
+        assert_dead(index, "DEAD1")
+        assert_dead(index, "DEAD2")
+      end
+
+      def test_index_deadcode_classes
+        @project.write!("foo.rb", <<~RB)
+          class ALIVE1
+            def initialize
+              @x = ALIVE2.new
+            end
+
+            class DEAD1; end
+          end
+
+          class ALIVE2; end
+          class DEAD2; end
+
+          ALIVE1.new
+        RB
+
+        index = deadcode_index
+        assert_alive(index, "ALIVE1")
+        assert_alive(index, "ALIVE2")
+        assert_dead(index, "DEAD1")
+        assert_dead(index, "DEAD2")
+      end
+
+      def test_index_deadcode_modules
+        @project.write!("foo.rb", <<~RB)
+          module ALIVE1
+            include ALIVE2
+
+            module DEAD1; end
+          end
+
+          module ALIVE2; end
+          module DEAD2; end
+
+          puts ALIVE1.ancestors
+        RB
+
+        index = deadcode_index
+        assert_alive(index, "ALIVE1")
+        assert_alive(index, "ALIVE2")
+        assert_dead(index, "DEAD1")
+        assert_dead(index, "DEAD2")
+      end
+
+      def test_index_deadcode_methods
+        @project.write!("foo.rb", <<~RB)
+          def dead1; end
+
+          def alive1
+            alive2
+          end
+
+          def alive2; end
+          def dead2; end
+
+          alive1
+        RB
+
+        index = deadcode_index
+        assert_alive(index, "alive1")
+        assert_alive(index, "alive2")
+        assert_dead(index, "dead1")
+        assert_dead(index, "dead2")
+      end
+
+      def test_index_deadcode_aref
+        @project.write!("foo.rb", <<~RB)
+          def []; end
+          def []=; end
+        RB
+
+        index = deadcode_index
+        assert_dead(index, "[]")
+        assert_dead(index, "[]=")
+
+        @project.write!("foo.rb", <<~RB)
+          def []; end
+          def []=; end
+
+          self[:foo]
+          self[:foo] = 42
+        RB
+
+        index = deadcode_index
+        assert_alive(index, "[]")
+        assert_alive(index, "[]=")
+      end
+
+      def test_index_deadcode_operators
+        @project.write!("foo.rb", <<~RB)
+          def <=>(x); end
+          def -(x); end
+          def <<(x); end
+
+          self < 42
+          self - 42
+          self << 42
+        RB
+
+        index = deadcode_index
+        assert_alive(index, "<=>")
+        assert_alive(index, "-")
+        assert_alive(index, "<<")
+      end
+
+      def test_index_deadcode_aliases
+        @project.write!("foo.rb", <<~RB)
+          def dead; end
+          def alive; end
+
+          alias dead alive
+        RB
+
+        index = deadcode_index
+        assert_alive(index, "alive")
+        assert_dead(index, "dead")
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/index_references_test.rb
+++ b/test/spoom/deadcode/index_references_test.rb
@@ -1,0 +1,155 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    class IndexReferencesTest < Spoom::TestWithProject
+      include Test::Helpers::DeadcodeHelper
+
+      def test_index_constant_references
+        @project.write!("foo.rb", <<~RB)
+          puts C1
+          puts C2::C3::C4
+          puts foo::C5
+          puts C6.foo
+          foo = C7
+          C8 << 42
+          C9 += 42
+          C10 ||= 42
+          C11[C12]
+          C13::NOT_INDEXED = 42 # The last one is not indexed, it's an assignment
+          puts "\#{C14}"
+
+          ::NOT_INDEXED = 42 # Not indexed, it's an assignment
+          puts "NOT_INDEXED_STRING"
+          puts :NOT_INDEXED_SYMBOL
+        RB
+
+        assert_equal(
+          ["C1", "C10", "C11", "C12", "C13", "C14", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9"],
+          deadcode_index.all_references.select(&:constant?).map(&:name).sort,
+        )
+      end
+
+      def test_index_class_references
+        @project.write!("foo.rb", <<~RB)
+          C1.new
+
+          class X < ::C2; end
+          class X < C3; end
+          class X < C4::C5; end
+        RB
+
+        assert_equal(
+          ["C1", "C2", "C3", "C4", "C5"],
+          deadcode_index.all_references.select(&:constant?).map(&:name).sort,
+        )
+      end
+
+      def test_index_module_references
+        @project.write!("foo.rb", <<~RB)
+          module X
+            include M1
+            extend M2
+            prepend M3
+          end
+
+          M4.include M5
+          M6.extend M7
+          M8.prepend M9
+        RB
+
+        assert_equal(
+          ["M1", "M2", "M3", "M4", "M5", "M6", "M7", "M8", "M9"],
+          deadcode_index.all_references.select(&:constant?).map(&:name).sort,
+        )
+      end
+
+      def test_index_method_references
+        @project.write!("foo.rb", <<~RB)
+          m1
+          m2(m3)
+          m4 m5
+          self.m6
+          self.m7(m8)
+          self.m9 m10
+          C.m11
+          C.m12(m13)
+          C.m14 m15
+          m16.m17
+          m18.m19(m20)
+          m21.m22 m23
+
+          m24.m25.m26
+
+          !m27
+          m28&.m29
+          m30(&:m31)
+          m32 { m33 }
+          m34 do m35 end
+          m36[m37] # The [] is indexed and will count as one more reference
+
+          m38(&m39)
+
+          def foo(&block)
+            m40(&block)
+          end
+        RB
+
+        references = deadcode_index.all_references.select(&:method?)
+        assert_equal(41, references.size)
+
+        references.each do |ref|
+          next if ref.name == "[]"
+
+          assert(ref.name =~ /^m(\d+)(=)?$/)
+        end
+      end
+
+      def test_index_method_assign_references
+        @project.write!("foo.rb", <<~RB)
+          m1= 42
+          m2=(42)
+          m3 = m4.m5
+          m6.m7.m8 = m9.m10
+          @c.m11 = 42
+        RB
+
+        assert_equal(
+          ["m10", "m11=", "m1=", "m2=", "m3=", "m4", "m5", "m6", "m7", "m8=", "m9"],
+          deadcode_index.all_references.map(&:name).sort,
+        )
+      end
+
+      def test_index_method_opassign_references
+        @project.write!("foo.rb", <<~RB)
+          m1 += 42
+          m2 |= 42
+          m3 ||= 42
+          m4.m5 += m6
+        RB
+
+        assert_equal(
+          ["m1", "m1=", "m2", "m2=", "m3", "m3=", "m4", "m5", "m5=", "m6"],
+          deadcode_index.all_references.map(&:name).sort,
+        )
+      end
+
+      def test_index_method_forward_references
+        @project.write!("foo.rb", <<~RB)
+          def foo(...)
+            bar(...)
+          end
+        RB
+
+        assert_equal(
+          ["bar"],
+          deadcode_index.all_references.map(&:name).sort,
+        )
+      end
+    end
+  end
+end

--- a/test/test_with_project.rb
+++ b/test/test_with_project.rb
@@ -11,6 +11,9 @@ module Spoom
 
     abstract!
 
+    sig { returns(TestProject) }
+    attr_reader :project
+
     sig { params(args: T.untyped).void }
     def initialize(*args)
       super


### PR DESCRIPTION
This is the first step of dead code detection: indexing the Ruby code to find definitions and references.

The concept is somehow easy:

1. Parse the code and:
  a. Find the things it defines: constants, classes, modules, methods, etc. and mark it dead
  b. Find all the references to things: calling a constant, a class, a method, etc.
2. Once everything is parsed, finalize the index: mark alive all the definitions for which we found a reference with the same name

In the next steps we'll add, parsing ERB files, a plugin system to handle DSLs and meta-programming then the CLI.

This PR is easier to review commit by commit.