### PR TITLE
Remove Ruby 2.7 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2"]
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_gem:
 
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   Exclude:
   - 'vendor/**/*'

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: spoom
 type: ruby
 
 up:
-  - ruby: 2.7.6
+  - ruby: 3.2.2
   - bundler
 
 commands:

--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -28,7 +28,7 @@ module Spoom
         T::Array[String],
       )
 
-      SIGIL_REGEXP = T.let(/^#[\ t]*typed[\ t]*:[ \t]*(\w*)[ \t]*/.freeze, Regexp)
+      SIGIL_REGEXP = T.let(/^#[\ t]*typed[\ t]*:[ \t]*(\w*)[ \t]*/, Regexp)
 
       class << self
         extend T::Sig


### PR DESCRIPTION
[Ruby 2.7 is now EOL](https://www.ruby-lang.org/en/downloads/branches/#:~:text=03%2D31%20(expected)-,Ruby%202.7,-status%3A%20eol%0Arelease).

This PR removes support for it.