### PR TITLE
Do not use install path from global bundle config

### DIFF
--- a/test/spoom/context/sorbet_test.rb
+++ b/test/spoom/context/sorbet_test.rb
@@ -36,6 +36,7 @@ module Spoom
 
           gem "sorbet"
         GEMFILE
+        context.bundle("config set --local path $GEM_HOME")
         context.bundle_install!
 
         res = context.srb("tc")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ module Spoom
       project = TestProject.mktmp!(name || self.name)
       project.write_gemfile!(spoom_gemfile)
       project.write_sorbet_config!(".")
+      project.bundle("config set --local path $GEM_HOME")
       project
     end
 


### PR DESCRIPTION
Rely on the environment variable `$GEM_HOME`. This has the side effect of making tests faster for people with a global `bundle config set path 'vendor/bundle'` since bundle won't have to download and install the same gems over and over again.

Fixes https://github.com/Shopify/spoom/issues/239.