### PR TITLE
Fix Ruby version requirements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_gem:
 
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
   Exclude:
   - 'vendor/**/*'

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("syntax_tree", ">= 6.1.1")
   spec.add_dependency("thor", ">= 0.19.2")
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 end


### PR DESCRIPTION
1. Use the lowest version in the Rubocop target as suggested by @vinistock 
2. Update the requirement in the Gemspec as suggested by @andyw8