### PR TITLE
Fix `sorbet-static-and-runtime` version in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,7 @@ module Spoom
         source("https://rubygems.org")
 
         gemspec name: "spoom", path: "#{SPOOM_PATH}"
+        gem "sorbet-static-and-runtime", "#{Gem::Specification.find_by_name("sorbet-static-and-runtime").version}"
       GEMFILE
     end
 


### PR DESCRIPTION
Fixes #404 

## Description

Spoom tests install gems on an instance of `TestProject`, including the most recent version of Sorbet. When Sorbet implements a change that breaks existing Spoom tests, that change will likely be surfaced on CI in an unrelated Spoom PR, which creates a lot of confusion amongst developers as they try to track down the reason for the change.

This PR adds a line that fixes the Sorbet version in Spoom tests to the version in Spoom's Gemfile.lock. This is adapted from the [approach we take in Tapioca](https://github.com/Shopify/tapioca/blob/2cd43f312d6cfd051f7bbaad0202340232e9958c/spec/spec_with_project.rb#L51-L53). Now, tests will only break when Sorbet is bumped in Gemfile.lock, which will make it easier to identify the cause of these breaking tests and reduce confusion.

## Questions

It looks like all the tests are passing with this change -- are there any tests that should be opted out of this approach?

## Testing

To test this, I reverted two recent PRs that [bumped Sorbet](https://github.com/Shopify/spoom/pull/401) and [fixed a test failure related to the new version of Sorbet](https://github.com/Shopify/spoom/pull/401); when I ran the test without my change, it failed, and then once my change was implemented, it passed.