### PR TITLE
Introduce dead code plugin base

### DIFF
--- a/lib/spoom/deadcode.rb
+++ b/lib/spoom/deadcode.rb
@@ -35,10 +35,10 @@ module Spoom
     class << self
       extend T::Sig
 
-      sig { params(index: Index, ruby: String, file: String).void }
-      def index_ruby(index, ruby, file:)
+      sig { params(index: Index, ruby: String, file: String, plugins: T::Array[Deadcode::Plugins::Base]).void }
+      def index_ruby(index, ruby, file:, plugins: [])
         node = SyntaxTree.parse(ruby)
-        visitor = Spoom::Deadcode::Indexer.new(file, ruby, index)
+        visitor = Spoom::Deadcode::Indexer.new(file, ruby, index, plugins: plugins)
         visitor.visit(node)
       rescue SyntaxTree::Parser::ParseError => e
         raise ParserError.new("Error while parsing #{file} (#{e.message} at #{e.lineno}:#{e.column})", parent: e)
@@ -46,10 +46,10 @@ module Spoom
         raise IndexerError.new("Error while indexing #{file} (#{e.message})", parent: e)
       end
 
-      sig { params(index: Index, erb: String, file: String).void }
-      def index_erb(index, erb, file:)
+      sig { params(index: Index, erb: String, file: String, plugins: T::Array[Deadcode::Plugins::Base]).void }
+      def index_erb(index, erb, file:, plugins: [])
         ruby = ERB.new(erb).src
-        index_ruby(index, ruby, file: file)
+        index_ruby(index, ruby, file: file, plugins: plugins)
       end
     end
   end

--- a/lib/spoom/deadcode.rb
+++ b/lib/spoom/deadcode.rb
@@ -12,6 +12,7 @@ require_relative "deadcode/location"
 require_relative "deadcode/definition"
 require_relative "deadcode/reference"
 require_relative "deadcode/send"
+require_relative "deadcode/plugins"
 
 module Spoom
   module Deadcode

--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -2,3 +2,4 @@
 # frozen_string_literal: true
 
 require_relative "plugins/base"
+require_relative "plugins/ruby"

--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative "plugins/base"

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -1,0 +1,201 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "set"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Base
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        class << self
+          extend T::Sig
+
+          # Plugins DSL
+
+          # Mark methods matching `names` as ignored.
+          #
+          # Names can be either strings or regexps:
+          #
+          # ~~~rb
+          # class MyPlugin < Spoom::Deadcode::Plugins::Base
+          #   ignore_method_names(
+          #     "foo",
+          #     "bar",
+          #     /baz.*/,
+          #   )
+          # end
+          # ~~~
+          sig { params(names: T.any(String, Regexp)).void }
+          def ignore_method_names(*names)
+            save_names_and_patterns(names, :@ignored_method_names, :@ignored_method_patterns)
+          end
+
+          private
+
+          sig { params(names: T::Array[T.any(String, Regexp)], names_variable: Symbol, patterns_variable: Symbol).void }
+          def save_names_and_patterns(names, names_variable, patterns_variable)
+            ignored_names = instance_variable_set(names_variable, Set.new)
+            ignored_patterns = instance_variable_set(patterns_variable, [])
+
+            names.each do |name|
+              case name
+              when String
+                ignored_names << name
+              when Regexp
+                ignored_patterns << name
+              end
+            end
+          end
+        end
+
+        # Indexing event methods
+
+        # Called when an accessor is defined.
+        #
+        # Will be called when the indexer processes a `attr_reader`, `attr_writer` or `attr_accessor` node.
+        # Note that when this method is called, the definition for the node has already been added to the index.
+        # It is still possible to ignore it from the plugin:
+        #
+        # ~~~rb
+        # class MyPlugin < Spoom::Deadcode::Plugins::Base
+        #   def on_define_accessor(indexer, definition)
+        #     definition.ignored! if definition.name == "foo"
+        #   end
+        # end
+        # ~~~
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def on_define_accessor(indexer, definition)
+          # no-op
+        end
+
+        # Called when a class is defined.
+        #
+        # Will be called when the indexer processes a `class` node.
+        # Note that when this method is called, the definition for the node has already been added to the index.
+        # It is still possible to ignore it from the plugin:
+        #
+        # ~~~rb
+        # class MyPlugin < Spoom::Deadcode::Plugins::Base
+        #   def on_define_class(indexer, definition)
+        #     definition.ignored! if definition.name == "Foo"
+        #   end
+        # end
+        # ~~~
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def on_define_class(indexer, definition)
+          # no-op
+        end
+
+        # Called when a constant is defined.
+        #
+        # Will be called when the indexer processes a `CONST =` node.
+        # Note that when this method is called, the definition for the node has already been added to the index.
+        # It is still possible to ignore it from the plugin:
+        #
+        # ~~~rb
+        # class MyPlugin < Spoom::Deadcode::Plugins::Base
+        #   def on_define_constant(indexer, definition)
+        #     definition.ignored! if definition.name == "FOO"
+        #   end
+        # end
+        # ~~~
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def on_define_constant(indexer, definition)
+          # no-op
+        end
+
+        # Called when a method is defined.
+        #
+        # Will be called when the indexer processes a `def` or `defs` node.
+        # Note that when this method is called, the definition for the node has already been added to the index.
+        # It is still possible to ignore it from the plugin:
+        #
+        # ~~~rb
+        # class MyPlugin < Spoom::Deadcode::Plugins::Base
+        #   def on_define_method(indexer, definition)
+        #     super # So the `ignore_method_names` DSL is still applied
+        #
+        #     definition.ignored! if definition.name == "foo"
+        #   end
+        # end
+        # ~~~
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def on_define_method(indexer, definition)
+          definition.ignored! if ignored_method_name?(definition.name)
+        end
+
+        # Called when a module is defined.
+        #
+        # Will be called when the indexer processes a `module` node.
+        # Note that when this method is called, the definition for the node has already been added to the index.
+        # It is still possible to ignore it from the plugin:
+        #
+        # ~~~rb
+        # class MyPlugin < Spoom::Deadcode::Plugins::Base
+        #   def on_define_module(indexer, definition)
+        #     definition.ignored! if definition.name == "Foo"
+        #   end
+        # end
+        # ~~~
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def on_define_module(indexer, definition)
+          # no-op
+        end
+
+        # Called when a send is being processed
+        #
+        # ~~~rb
+        # class MyPlugin < Spoom::Deadcode::Plugins::Base
+        #   def on_send(indexer, send)
+        #     return unless send.name == "dsl_method"
+        #     return if send.args.empty?
+        #
+        #     method_name = indexer.node_string(send.args.first).delete_prefix(":")
+        #     indexer.reference_method(method_name, send.node)
+        #   end
+        # end
+        # ~~~
+        sig { params(indexer: Indexer, send: Send).void }
+        def on_send(indexer, send)
+          # no-op
+        end
+
+        private
+
+        sig { params(name: String).returns(T::Boolean) }
+        def ignored_method_name?(name)
+          ignored_name?(name, :@ignored_method_names, :@ignored_method_patterns)
+        end
+
+        sig { params(const: Symbol).returns(T::Set[String]) }
+        def names(const)
+          self.class.instance_variable_get(const) || Set.new
+        end
+
+        sig { params(name: String, names_variable: Symbol, patterns_variable: Symbol).returns(T::Boolean) }
+        def ignored_name?(name, names_variable, patterns_variable)
+          names(names_variable).include?(name) || patterns(patterns_variable).any? { |pattern| pattern.match?(name) }
+        end
+
+        sig { params(const: Symbol).returns(T::Array[Regexp]) }
+        def patterns(const)
+          self.class.instance_variable_get(const) || []
+        end
+
+        sig { params(indexer: Indexer, send: Send).void }
+        def reference_send_first_symbol_as_method(indexer, send)
+          first_arg = send.args.first
+          return unless first_arg.is_a?(SyntaxTree::SymbolLiteral)
+
+          name = indexer.node_string(first_arg.value)
+          indexer.reference_method(name, send.node)
+        end
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/ruby.rb
+++ b/lib/spoom/deadcode/plugins/ruby.rb
@@ -1,0 +1,64 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Ruby < Base
+        extend T::Sig
+
+        ignore_method_names(
+          "==",
+          "extended",
+          "included",
+          "inherited",
+          "initialize",
+          "method_added",
+          "method_missing",
+          "prepended",
+          "respond_to_missing?",
+          "to_s",
+        )
+
+        sig { override.params(indexer: Indexer, send: Send).void }
+        def on_send(indexer, send)
+          case send.name
+          when "const_defined?", "const_get", "const_source_location"
+            reference_symbol_as_constant(indexer, send, T.must(send.args.first))
+          when "send", "__send__", "try"
+            reference_send_first_symbol_as_method(indexer, send)
+          when "alias_method"
+            last_arg = send.args.last
+
+            name = case last_arg
+            when SyntaxTree::SymbolLiteral
+              indexer.node_string(last_arg.value)
+            when SyntaxTree::StringLiteral
+              last_arg.parts.map { |part| indexer.node_string(part) }.join
+            end
+
+            return unless name
+
+            indexer.reference_method(name, send.node)
+          end
+        end
+
+        private
+
+        sig { params(indexer: Indexer, send: Send, node: SyntaxTree::Node).void }
+        def reference_symbol_as_constant(indexer, send, node)
+          case node
+          when SyntaxTree::SymbolLiteral
+            name = indexer.node_string(node.value)
+            indexer.reference_constant(name, send.node)
+          when SyntaxTree::StringLiteral
+            string = T.must(indexer.node_string(node)[1..-2])
+            string.split("::").each do |name|
+              indexer.reference_constant(name, send.node) unless name.empty?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -14,8 +14,8 @@ module Spoom
 
         # Indexing
 
-        sig { returns(Deadcode::Index) }
-        def deadcode_index
+        sig { params(plugins: T::Array[Deadcode::Plugins::Base]).returns(Deadcode::Index) }
+        def deadcode_index(plugins: [])
           files = project.collect_files(
             allow_extensions: [".rb", ".erb", ".rake", ".rakefile", ".gemspec"],
             allow_mime_types: ["text/x-ruby", "text/x-ruby-script"],
@@ -26,9 +26,9 @@ module Spoom
           files.each do |file|
             content = project.read(file)
             if file.end_with?(".erb")
-              Spoom::Deadcode.index_erb(index, content, file: file)
+              Spoom::Deadcode.index_erb(index, content, file: file, plugins: plugins)
             else
-              Spoom::Deadcode.index_ruby(index, content, file: file)
+              Spoom::Deadcode.index_ruby(index, content, file: file, plugins: plugins)
             end
           end
 

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -1,0 +1,148 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class BaseTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        class TestPlugin < Spoom::Deadcode::Plugins::Base
+          ignore_method_names(
+            "name1",
+            "name2",
+            /^name_re.*/,
+          )
+
+          def on_define_accessor(indexer, definition)
+            definition.ignored! if definition.name == "attr_reader1"
+          end
+
+          def on_define_class(indexer, definition)
+            definition.ignored! if definition.name == "Class1"
+          end
+
+          def on_define_constant(indexer, definition)
+            definition.ignored! if definition.name == "CONST1"
+          end
+
+          def on_define_method(indexer, definition)
+            super
+
+            definition.ignored! if definition.name == "method1"
+          end
+
+          def on_define_module(indexer, definition)
+            definition.ignored! if definition.name == "Module1"
+          end
+
+          def on_send(indexer, send)
+            return unless send.name == "dsl_method"
+            return if send.args.empty?
+
+            method_name = indexer.node_string(send.args.first).delete_prefix(":")
+            indexer.reference_method(method_name, send.node)
+          end
+        end
+
+        def test_ignore_method_by_names
+          @project.write!("foo.rb", <<~RB)
+            def name1; end
+            def name2; end
+            def name3; end
+            def name_regexp1; end
+            def name_regexp2; end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "name1")
+          assert_ignored(index, "name2")
+          refute_ignored(index, "name3")
+          assert_ignored(index, "name_regexp1")
+          assert_ignored(index, "name_regexp2")
+        end
+
+        def test_on_define_accessor
+          @project.write!("foo.rb", <<~RB)
+            attr_reader :attr_reader1
+            attr_reader :attr_reader2
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "attr_reader1")
+          refute_ignored(index, "attr_reader2")
+        end
+
+        def test_on_define_class
+          @project.write!("foo.rb", <<~RB)
+            class Class1; end
+            class Class2; end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "Class1")
+          refute_ignored(index, "Class2")
+        end
+
+        def test_on_define_constant
+          @project.write!("foo.rb", <<~RB)
+            CONST1 = 1
+            CONST2 = 2
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "CONST1")
+          refute_ignored(index, "CONST2")
+        end
+
+        def test_on_define_method
+          @project.write!("foo.rb", <<~RB)
+            def method1; end
+            def method2; end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "method1")
+          refute_ignored(index, "method2")
+        end
+
+        def test_on_define_module
+          @project.write!("foo.rb", <<~RB)
+            module Module1; end
+            module Module2; end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "Module1")
+          refute_ignored(index, "Module2")
+        end
+
+        def test_on_send
+          @project.write!("foo.rb", <<~RB)
+            dsl_method :method1
+            dsl_method :method2
+
+            def method1; end
+            def method2; end
+            def method3; end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "method1")
+          assert_alive(index, "method2")
+          assert_dead(index, "method3")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [TestPlugin.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/ruby_test.rb
+++ b/test/spoom/deadcode/plugins/ruby_test.rb
@@ -1,0 +1,175 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class RubyTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_initialize
+          @project.write!("foo.rb", <<~RB)
+            def initialize; end
+            def foo; end
+
+            class Foo
+              def initialize(x); end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "initialize")
+          refute_ignored(index, "foo")
+        end
+
+        def test_ignore_hooks
+          @project.write!("foo.rb", <<~RB)
+            def extended; end
+            def included; end
+            def method_missing; end
+            def prepended; end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "extended")
+          assert_ignored(index, "included")
+          assert_ignored(index, "method_missing")
+          assert_ignored(index, "prepended")
+        end
+
+        def test_alive_sends
+          @project.write!("foo.rb", <<~RB)
+            send(:alive1)
+            send :alive2, :dead, nil
+
+            __send__(:alive3)
+            __send__ :alive4
+
+
+            def alive1; end
+            def alive2; end
+            def alive3; end
+            def alive4; end
+
+            def dead; end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "alive1")
+          assert_alive(index, "alive2")
+          assert_alive(index, "alive3")
+          assert_alive(index, "alive4")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_trys
+          @project.write!("foo.rb", <<~RB)
+            try(:alive1)
+            try :alive2, :dead, nil
+
+            def alive1; end
+            def alive2; end
+
+            def dead; end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "alive1")
+          assert_alive(index, "alive2")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_aliases
+          @project.write!("foo.rb", <<~RB)
+            def dead1; end
+            def alive1; end
+
+            alias_method "dead1", "alive1"
+
+            def dead2; end
+            def alive2; end
+
+            alias_method :dead1, :alive2
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "alive1")
+          assert_alive(index, "alive2")
+          assert_dead(index, "dead1")
+          assert_dead(index, "dead2")
+        end
+
+        def test_alive_constants_with_const_defined?
+          @project.write!("foo.rb", <<~RB)
+            ALIVE1 = 1
+            ALIVE2 = 2
+
+            DEAD = 42
+
+            Object.const_defined?(:ALIVE1)
+            Object.const_defined?("ALIVE2")
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "ALIVE1")
+          assert_alive(index, "ALIVE2")
+          assert_dead(index, "DEAD")
+        end
+
+        def test_alive_constants_with_const_get
+          @project.write!("foo.rb", <<~RB)
+            ALIVE1 = 1
+            ALIVE2 = 2
+            ALIVE3 = 3
+            ALIVE4 = 4
+            ALIVE5 = 5
+            ALIVE6 = 6
+
+            DEAD = 42
+
+            Object.const_get(:ALIVE1)
+            Object.const_get("ALIVE2")
+            Object.const_get("::ALIVE3")
+            Object.const_get("::ALIVE4::ALIVE5::ALIVE6")
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "ALIVE1")
+          assert_alive(index, "ALIVE2")
+          assert_alive(index, "ALIVE3")
+          assert_alive(index, "ALIVE4")
+          assert_alive(index, "ALIVE5")
+          assert_alive(index, "ALIVE6")
+          assert_dead(index, "DEAD")
+        end
+
+        def test_alive_constants_with_const_source_location
+          @project.write!("foo.rb", <<~RB)
+            ALIVE1 = 1
+            ALIVE2 = 2
+
+            DEAD = 42
+
+            Object.const_source_location('ALIVE1')
+            Object.const_source_location("ALIVE2")
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "ALIVE1")
+          assert_alive(index, "ALIVE2")
+          assert_dead(index, "DEAD")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::Ruby.new])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the base concept for dead code plugins.

The idea is pretty simple, as the indexer visits the code it adds the definitions it finds to the index then calls the plugins to let them ignore those definitions or add references to them.

Here's a very simple example of plugin to ignore a class that has been indexed:

```rb
class MyPlugin < Spoom::Deadcode::Plugins::Base
  def on_define_class(indexer, definition)
    definition.ignored! if definition.name == "Foo"
  end
end
```

This plugin will be called then the indexer processes the `class Foo; end` node. It will call the `on_define_class` from each registered plugin and pass it the indexed `Foo` definition. Note that when `on_define_class` the definition has already been indexed.

Plugins can also be used to handle DSLs and meta-programming.
Let's consider this DSL for example:

```rb
class Foo
  will_call :foo

  def foo; end
end
```

Through meta-programming, the `Foo` class will call the `foo` method so we want to mark it as alive.
Here's how it can be done in the plugin:

```rb
class MyPlugin < Spoom::Deadcode::Plugins::Base
  def on_send(indexer, send)
    return unless send.name == "will_call"
    return if send.args.empty?
    
    method_name = indexer.node_string(send.args.first).delete_prefix(":")
    indexer.reference_method(method_name, send.node)
  end
end
```

This PR is easier to review commit by commit.