### PR TITLE
preserve trailing whitespace when bumping sigil

### DIFF
--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -28,7 +28,7 @@ module Spoom
         T::Array[String],
       )
 
-      SIGIL_REGEXP = T.let(/^#[\ t]*typed[\ t]*:[ \t]*(\w*)[ \t]*/, Regexp)
+      SIGIL_REGEXP = T.let(/^#[\ t]*typed[\ t]*:[ \t]*(\S*)/, Regexp)
 
       class << self
         extend T::Sig

--- a/test/spoom/sorbet/sigils_test.rb
+++ b/test/spoom/sorbet/sigils_test.rb
@@ -74,6 +74,17 @@ module Spoom
         assert_equal("no", strictness)
       end
 
+      def test_strictness_invalid_string
+        content = <<~STR
+          # typed: true# rubocop:todo Sorbet/StrictSigil
+          class A; end
+        STR
+
+        strictness = Sigils.strictness_in_content(content)
+        assert_equal("true#", strictness)
+        refute(Sigils.valid_strictness?(T.must(strictness)))
+      end
+
       def test_update_sigil_to_use_valid_strictness
         content = <<~STR
           # typed: ignore


### PR DESCRIPTION
closes https://github.com/Shopify/spoom/issues/427

By preserving trailing whitespace we can prevent spoom from generating invalid sorbet sigils which lead to invalid spoom bumps.

This regex change also makes `Sigils#strictness_in_content` match more closely to the sigils as [parsed](https://github.com/sorbet/sorbet/blob/fd0e613e946e84c11d92e9353c5b40d7b91b1af4/core/Files.cc#L24-L96) by sorbet.

Tests added in this PR fail with the previous `SIGIL_REGEXP` value as follows:

<summary>

`test_valid_bump_with_rubocop_on_sigil`
<details>

```
        --- expected
        +++ actual
        @@ -1,4 +1,4 @@
        -"# typed: true # rubocop:todo Sorbet/StrictSigil
        +"# typed: true# rubocop:todo Sorbet/StrictSigil
         class PassesTypeChecking; end
         PassesTypeChecking
         "
```

</details>
</summary>

<summary>

`test_invalid_bump_with_rubocop_on_sigil`
<details>

```
        --- expected
        +++ actual
        @@ -1,4 +1,5 @@
         "Checking files...

        -No files to bump from `false` to `true`
        +Bumped `1` file from `false` to `true`:
        + + file1.rb
         "
```

</details>
</summary>

<summary>

`test_strictness_invalid_string`
<details>

```
        Expected: "true#"
          Actual: "true"
```

</details>
</summary>