### PR TITLE
Depend on `sorbet-static-and-runtime`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,7 @@ PATH
   specs:
     spoom (1.2.2)
       erubi (>= 1.10.0)
-      sorbet (>= 0.5.10187)
-      sorbet-runtime (>= 0.5.9204)
+      sorbet-static-and-runtime (>= 0.5.10187)
       syntax_tree (>= 6.1.1)
       thor (>= 0.19.2)
 

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("rake", "~> 13.0.1")
 
   spec.add_dependency("erubi", ">= 1.10.0")
-  spec.add_dependency("sorbet", ">= 0.5.10187")
-  spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
+  spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.10187")
   spec.add_dependency("syntax_tree", ">= 6.1.1")
   spec.add_dependency("thor", ">= 0.19.2")
 


### PR DESCRIPTION
This will avoid `static` and `runtime` versions to drift apart.