### PR TITLE
Mark redefined ERB methods as `override`

### DIFF
--- a/lib/spoom/deadcode/erb.rb
+++ b/lib/spoom/deadcode/erb.rb
@@ -44,7 +44,7 @@ module Spoom
 
       private
 
-      sig { params(text: T.untyped).void }
+      sig { override.params(text: T.untyped).void }
       def add_text(text)
         return if text.empty?
 
@@ -62,7 +62,7 @@ module Spoom
 
       BLOCK_EXPR = /\s*((\s+|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
 
-      sig { params(indicator: T.untyped, code: T.untyped).void }
+      sig { override.params(indicator: T.untyped, code: T.untyped).void }
       def add_expression(indicator, code)
         flush_newline_if_pending(src)
 
@@ -79,13 +79,13 @@ module Spoom
         end
       end
 
-      sig { params(code: T.untyped).void }
+      sig { override.params(code: T.untyped).void }
       def add_code(code)
         flush_newline_if_pending(src)
         super
       end
 
-      sig { params(_: T.untyped).void }
+      sig { override.params(_: T.untyped).void }
       def add_postamble(_)
         flush_newline_if_pending(src)
         super


### PR DESCRIPTION
In https://github.com/Shopify/spoom/pull/433, CodeDB spotted the method `add_expression` as dead.

It's not correct since this method is a redefinition of the one coming from a dependency. It's never called locally but it is used.

We can properly mark it as override to help CodeDB understand it's a redefinition and may get called indirectly.