### PR TITLE
Fix indexer visit order

### DIFF
--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -157,10 +157,10 @@ module Spoom
 
       sig { override.params(node: SyntaxTree::DefNode).void }
       def visit_def(node)
-        super
-
         name = node_string(node.name)
         define_method(name, [*@names_nesting, name].join("::"), node)
+
+        super
       end
 
       sig { override.params(node: SyntaxTree::Field).void }

--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -3,12 +3,15 @@
 
 require_relative "plugins/base"
 
+require_relative "plugins/actionpack"
 require_relative "plugins/active_job"
 require_relative "plugins/active_model"
 require_relative "plugins/active_record"
 require_relative "plugins/active_support"
 require_relative "plugins/graphql"
 require_relative "plugins/minitest"
+require_relative "plugins/rails"
+require_relative "plugins/rake"
 require_relative "plugins/rspec"
 require_relative "plugins/ruby"
 require_relative "plugins/thor"

--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -2,4 +2,13 @@
 # frozen_string_literal: true
 
 require_relative "plugins/base"
+
+require_relative "plugins/active_job"
+require_relative "plugins/active_model"
+require_relative "plugins/active_record"
+require_relative "plugins/active_support"
+require_relative "plugins/graphql"
+require_relative "plugins/minitest"
+require_relative "plugins/rspec"
 require_relative "plugins/ruby"
+require_relative "plugins/thor"

--- a/lib/spoom/deadcode/plugins/actionpack.rb
+++ b/lib/spoom/deadcode/plugins/actionpack.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActionPack < Base
+        ignore_class_names(/Controller$/)
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/active_job.rb
+++ b/lib/spoom/deadcode/plugins/active_job.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActiveJob < Base
+        ignore_method_names("perform", "build_enumerator", "each_iteration")
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/active_job.rb
+++ b/lib/spoom/deadcode/plugins/active_job.rb
@@ -5,6 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveJob < Base
+        ignore_class_names("ApplicationJob")
         ignore_method_names("perform", "build_enumerator", "each_iteration")
       end
     end

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActiveModel < Base
+        ignore_method_names("validate_each")
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/active_record.rb
+++ b/lib/spoom/deadcode/plugins/active_record.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActiveRecord < Base
+        ignore_method_names(
+          "change",
+          "down",
+          "up",
+          "table_name_prefix",
+          "to_param",
+        )
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/active_support.rb
+++ b/lib/spoom/deadcode/plugins/active_support.rb
@@ -1,0 +1,19 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActiveSupport < Base
+        ignore_method_names(
+          "after_all",
+          "after_setup",
+          "after_teardown",
+          "before_all",
+          "before_setup",
+          "before_teardown",
+        )
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/graphql.rb
+++ b/lib/spoom/deadcode/plugins/graphql.rb
@@ -1,0 +1,20 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class GraphQL < Base
+        ignore_method_names(
+          "coerce_input",
+          "coerce_result",
+          "graphql_name",
+          "resolve",
+          "resolve_type",
+          "subscribed",
+          "unsubscribed",
+        )
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -5,6 +5,8 @@ module Spoom
   module Deadcode
     module Plugins
       class Minitest < Base
+        ignore_class_names(/Test$/)
+
         ignore_method_names(
           "after_all",
           "around",

--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -1,0 +1,19 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Minitest < Base
+        ignore_method_names(
+          "after_all",
+          "around",
+          "around_all",
+          "before_all",
+          "setup",
+          "teardown",
+        )
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/rails.rb
+++ b/lib/spoom/deadcode/plugins/rails.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Rails < Base
+        ignore_constant_names("APP_PATH", "ENGINE_PATH", "ENGINE_ROOT")
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/rake.rb
+++ b/lib/spoom/deadcode/plugins/rake.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Rake < Base
+        ignore_constant_names("APP_RAKEFILE")
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/rspec.rb
+++ b/lib/spoom/deadcode/plugins/rspec.rb
@@ -1,0 +1,17 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class RSpec < Base
+        ignore_method_names(
+          "after_setup",
+          "after_teardown",
+          "before_setup",
+          "before_teardown",
+        )
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/thor.rb
+++ b/lib/spoom/deadcode/plugins/thor.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Thor < Base
+        ignore_method_names("exit_on_failure?")
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/actionpack_test.rb
+++ b/test/spoom/deadcode/plugins/actionpack_test.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActionPackTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_actionpack_controllers
+          @project.write!("app/controllers/foo.rb", <<~RB)
+            class FooController
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "FooController")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::ActionPack.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/active_job_test.rb
+++ b/test/spoom/deadcode/plugins/active_job_test.rb
@@ -1,0 +1,57 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActiveJobTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_active_job_methods_based_on_class_name
+          @project.write!("foo.rb", <<~RB)
+            class Foo
+              def build_enumerator; end
+              def each_iteration; end
+              def perform; end
+            end
+          RB
+
+          @project.write!("app/jobs/foo.rb", <<~RB)
+            class FooJob
+              def build_enumerator; end
+              def each_iteration; end
+              def perform; end
+            end
+          RB
+
+          assert_equal(
+            [
+              "app/jobs/foo.rb:2:2-2:27",
+              "app/jobs/foo.rb:3:2-3:25",
+              "app/jobs/foo.rb:4:2-4:18",
+              "foo.rb:2:2-2:27",
+              "foo.rb:3:2-3:25",
+              "foo.rb:4:2-4:18",
+            ],
+            ignored_locations(index_with_plugins).map(&:to_s).sort,
+          )
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::ActiveJob.new])
+        end
+
+        sig { params(index: Deadcode::Index).returns(T::Array[Location]) }
+        def ignored_locations(index)
+          index.all_definitions.select(&:method?).select(&:ignored?).map(&:location)
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/active_job_test.rb
+++ b/test/spoom/deadcode/plugins/active_job_test.rb
@@ -10,6 +10,15 @@ module Spoom
       class ActiveJobTest < TestWithProject
         include Test::Helpers::DeadcodeHelper
 
+        def test_ignore_active_job_application_job_class
+          @project.write!("app/jobs/application_job.rb", <<~RB)
+            class ApplicationJob; end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "ApplicationJob")
+        end
+
         def test_ignore_active_job_methods_based_on_class_name
           @project.write!("foo.rb", <<~RB)
             class Foo

--- a/test/spoom/deadcode/plugins/active_model_test.rb
+++ b/test/spoom/deadcode/plugins/active_model_test.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActiveModelTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_validation_class
+          @project.write!("app/model/validators/my_validator.rb", <<~RB)
+            class MyValidator < ActiveModel::EachValidator
+              def validate_each(record, attribute, value); end
+              def another_method; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "validate_each")
+        end
+
+        private
+
+        sig { returns(Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [ActiveModel.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/active_record_test.rb
+++ b/test/spoom/deadcode/plugins/active_record_test.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActiveRecordTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_migration_classes
+          @project.write!("db/migrate/20230101000000_create_model.rb", <<~RB)
+            class CreateModel < ActiveRecord::Migration[7.0]
+              def change; end
+              def down; end
+              def up; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "change")
+          assert_ignored(index, "down")
+          assert_ignored(index, "up")
+        end
+
+        private
+
+        sig { returns(Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [ActiveRecord.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/graphql_test.rb
+++ b/test/spoom/deadcode/plugins/graphql_test.rb
@@ -1,0 +1,43 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class GraphQLTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_graphql_methods
+          @project.write!("foo.rb", <<~RB)
+            class SomeClass
+              def coerce_input; end
+              def coerce_result; end
+              def graphql_name; end
+              def resolve_type; end
+              def subscribed; end
+              def unsubscribed; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "coerce_input")
+          assert_ignored(index, "coerce_result")
+          assert_ignored(index, "graphql_name")
+          assert_ignored(index, "resolve_type")
+          assert_ignored(index, "subscribed")
+          assert_ignored(index, "unsubscribed")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::GraphQL.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/minitest_test.rb
+++ b/test/spoom/deadcode/plugins/minitest_test.rb
@@ -1,0 +1,43 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class MinitestTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_minitest_methods
+          @project.write!("test/foo_test.rb", <<~RB)
+            class FooTest
+              def after_all; end
+              def around; end
+              def around_all; end
+              def before_all; end
+              def setup; end
+              def teardown; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "after_all")
+          assert_ignored(index, "around")
+          assert_ignored(index, "around_all")
+          assert_ignored(index, "before_all")
+          assert_ignored(index, "setup")
+          assert_ignored(index, "teardown")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::Minitest.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/rails_test.rb
+++ b/test/spoom/deadcode/plugins/rails_test.rb
@@ -1,0 +1,39 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class RailsTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_rails_app_path
+          @project.write!("bin/rails", <<~RB)
+            #!/usr/bin/env ruby
+
+            APP_PATH = "."
+            ENGINE_ROOT = "."
+            ENGINE_PATH = "."
+            FOO = 1
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "APP_PATH")
+          assert_ignored(index, "ENGINE_ROOT")
+          assert_ignored(index, "ENGINE_PATH")
+          refute_ignored(index, "FOO")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::Rails.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/rake_test.rb
+++ b/test/spoom/deadcode/plugins/rake_test.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class RakeTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_rake_constants
+          @project.write!("foo.rb", <<~RB)
+            APP_RAKEFILE = "foo"
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "APP_RAKEFILE")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::Rake.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/rspec_test.rb
+++ b/test/spoom/deadcode/plugins/rspec_test.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class RSpecTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_rspec_methods
+          @project.write!("spec/foo_spec.rb", <<~RB)
+            class FooSpec
+              def before_setup; end
+              def after_teardown; end
+              def foo; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "before_setup")
+          assert_ignored(index, "after_teardown")
+          refute_ignored(index, "foo")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::RSpec.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/thor_test.rb
+++ b/test/spoom/deadcode/plugins/thor_test.rb
@@ -1,0 +1,35 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ThorTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_thor_methods
+          @project.write!("foo.rb", <<~RB)
+            class Foo < Thor
+              class << self
+                def exit_on_failure?; end
+              end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "exit_on_failure?")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::Thor.new])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When visiting method, we should first add the method to the index _then_ visit its body.

This PR moves the `super` call after the indexing.

Apologies, I merged #436 and #437 by mistake into this branch, please consider only the first commit 🙏 