### PR TITLE
Ignore constants, classes and modules from dead code plugins

### DIFF
--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -3,12 +3,15 @@
 
 require_relative "plugins/base"
 
+require_relative "plugins/actionpack"
 require_relative "plugins/active_job"
 require_relative "plugins/active_model"
 require_relative "plugins/active_record"
 require_relative "plugins/active_support"
 require_relative "plugins/graphql"
 require_relative "plugins/minitest"
+require_relative "plugins/rails"
+require_relative "plugins/rake"
 require_relative "plugins/rspec"
 require_relative "plugins/ruby"
 require_relative "plugins/thor"

--- a/lib/spoom/deadcode/plugins/actionpack.rb
+++ b/lib/spoom/deadcode/plugins/actionpack.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActionPack < Base
+        ignore_class_names(/Controller$/)
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/active_job.rb
+++ b/lib/spoom/deadcode/plugins/active_job.rb
@@ -5,6 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveJob < Base
+        ignore_class_names("ApplicationJob")
         ignore_method_names("perform", "build_enumerator", "each_iteration")
       end
     end

--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -5,6 +5,8 @@ module Spoom
   module Deadcode
     module Plugins
       class Minitest < Base
+        ignore_class_names(/Test$/)
+
         ignore_method_names(
           "after_all",
           "around",

--- a/lib/spoom/deadcode/plugins/rails.rb
+++ b/lib/spoom/deadcode/plugins/rails.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Rails < Base
+        ignore_constant_names("APP_PATH", "ENGINE_PATH", "ENGINE_ROOT")
+      end
+    end
+  end
+end

--- a/lib/spoom/deadcode/plugins/rake.rb
+++ b/lib/spoom/deadcode/plugins/rake.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class Rake < Base
+        ignore_constant_names("APP_RAKEFILE")
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/actionpack_test.rb
+++ b/test/spoom/deadcode/plugins/actionpack_test.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class ActionPackTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_actionpack_controllers
+          @project.write!("app/controllers/foo.rb", <<~RB)
+            class FooController
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "FooController")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::ActionPack.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/active_job_test.rb
+++ b/test/spoom/deadcode/plugins/active_job_test.rb
@@ -10,6 +10,15 @@ module Spoom
       class ActiveJobTest < TestWithProject
         include Test::Helpers::DeadcodeHelper
 
+        def test_ignore_active_job_application_job_class
+          @project.write!("app/jobs/application_job.rb", <<~RB)
+            class ApplicationJob; end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "ApplicationJob")
+        end
+
         def test_ignore_active_job_methods_based_on_class_name
           @project.write!("foo.rb", <<~RB)
             class Foo

--- a/test/spoom/deadcode/plugins/rails_test.rb
+++ b/test/spoom/deadcode/plugins/rails_test.rb
@@ -1,0 +1,39 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class RailsTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_rails_app_path
+          @project.write!("bin/rails", <<~RB)
+            #!/usr/bin/env ruby
+
+            APP_PATH = "."
+            ENGINE_ROOT = "."
+            ENGINE_PATH = "."
+            FOO = 1
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "APP_PATH")
+          assert_ignored(index, "ENGINE_ROOT")
+          assert_ignored(index, "ENGINE_PATH")
+          refute_ignored(index, "FOO")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::Rails.new])
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/rake_test.rb
+++ b/test/spoom/deadcode/plugins/rake_test.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class RakeTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_rake_constants
+          @project.write!("foo.rb", <<~RB)
+            APP_RAKEFILE = "foo"
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "APP_RAKEFILE")
+        end
+
+        private
+
+        sig { returns(Deadcode::Index) }
+        def index_with_plugins
+          deadcode_index(plugins: [Plugins::Rake.new])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
On top of #420, this PR introduces 3 new DSL methods for dead code plugins:

* `ignore_class_names`
* `ignore_constant_names`
* `ignore_module_names`