### PR TITLE
Indexer calls internal methods of plugin base

### DIFF
--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -230,7 +230,7 @@ module Spoom
           end
         else
           @plugins.each do |plugin|
-            plugin.on_send(self, send)
+            plugin.internal_on_send(self, send)
           end
 
           reference_method(send.name, send.node)
@@ -286,7 +286,7 @@ module Spoom
           location: node_location(node),
         )
         @index.define(definition)
-        @plugins.each { |plugin| plugin.on_define_accessor(self, definition) }
+        @plugins.each { |plugin| plugin.internal_on_define_accessor(self, definition) }
       end
 
       sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
@@ -298,7 +298,7 @@ module Spoom
           location: node_location(node),
         )
         @index.define(definition)
-        @plugins.each { |plugin| plugin.on_define_accessor(self, definition) }
+        @plugins.each { |plugin| plugin.internal_on_define_accessor(self, definition) }
       end
 
       sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
@@ -310,7 +310,7 @@ module Spoom
           location: node_location(node),
         )
         @index.define(definition)
-        @plugins.each { |plugin| plugin.on_define_class(self, definition) }
+        @plugins.each { |plugin| plugin.internal_on_define_class(self, definition) }
       end
 
       sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
@@ -322,7 +322,7 @@ module Spoom
           location: node_location(node),
         )
         @index.define(definition)
-        @plugins.each { |plugin| plugin.on_define_constant(self, definition) }
+        @plugins.each { |plugin| plugin.internal_on_define_constant(self, definition) }
       end
 
       sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
@@ -334,7 +334,7 @@ module Spoom
           location: node_location(node),
         )
         @index.define(definition)
-        @plugins.each { |plugin| plugin.on_define_method(self, definition) }
+        @plugins.each { |plugin| plugin.internal_on_define_method(self, definition) }
       end
 
       sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
@@ -346,7 +346,7 @@ module Spoom
           location: node_location(node),
         )
         @index.define(definition)
-        @plugins.each { |plugin| plugin.on_define_module(self, definition) }
+        @plugins.each { |plugin| plugin.internal_on_define_module(self, definition) }
       end
 
       # Reference indexing

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -127,6 +127,12 @@ module Spoom
           # no-op
         end
 
+        # Do not override this method, use `on_define_accessor` instead.
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def internal_on_define_accessor(indexer, definition)
+          on_define_accessor(indexer, definition)
+        end
+
         # Called when a class is defined.
         #
         # Will be called when the indexer processes a `class` node.
@@ -142,7 +148,15 @@ module Spoom
         # ~~~
         sig { params(indexer: Indexer, definition: Definition).void }
         def on_define_class(indexer, definition)
+          # no-op
+        end
+
+        # Do not override this method, use `on_define_class` instead.
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def internal_on_define_class(indexer, definition)
           definition.ignored! if ignored_class_name?(definition.name)
+
+          on_define_class(indexer, definition)
         end
 
         # Called when a constant is defined.
@@ -160,7 +174,15 @@ module Spoom
         # ~~~
         sig { params(indexer: Indexer, definition: Definition).void }
         def on_define_constant(indexer, definition)
+          # no-op
+        end
+
+        # Do not override this method, use `on_define_constant` instead.
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def internal_on_define_constant(indexer, definition)
           definition.ignored! if ignored_constant_name?(definition.name)
+
+          on_define_constant(indexer, definition)
         end
 
         # Called when a method is defined.
@@ -180,7 +202,15 @@ module Spoom
         # ~~~
         sig { params(indexer: Indexer, definition: Definition).void }
         def on_define_method(indexer, definition)
+          # no-op
+        end
+
+        # Do not override this method, use `on_define_method` instead.
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def internal_on_define_method(indexer, definition)
           definition.ignored! if ignored_method_name?(definition.name)
+
+          on_define_method(indexer, definition)
         end
 
         # Called when a module is defined.
@@ -198,7 +228,15 @@ module Spoom
         # ~~~
         sig { params(indexer: Indexer, definition: Definition).void }
         def on_define_module(indexer, definition)
+          # no-op
+        end
+
+        # Do not override this method, use `on_define_module` instead.
+        sig { params(indexer: Indexer, definition: Definition).void }
+        def internal_on_define_module(indexer, definition)
           definition.ignored! if ignored_module_name?(definition.name)
+
+          on_define_module(indexer, definition)
         end
 
         # Called when a send is being processed
@@ -217,6 +255,12 @@ module Spoom
         sig { params(indexer: Indexer, send: Send).void }
         def on_send(indexer, send)
           # no-op
+        end
+
+        # Do not override this method, use `on_send` instead.
+        sig { params(indexer: Indexer, send: Send).void }
+        def internal_on_send(indexer, send)
+          on_send(indexer, send)
         end
 
         private


### PR DESCRIPTION
By making the indexer call the `internal_on_*` method rather than `on_*` directly, we make it easier for plugin implementors to override the public API without breaking internal behavior.

Without this change, if a plugin overrides `on_define_class` and forgets to call `super`, it would break the `ignore_class_names` DSL.