### PR TITLE
Rename `ignore_class_names` into `ignore_classes_named`

### DIFF
--- a/lib/spoom/deadcode/plugins/actionpack.rb
+++ b/lib/spoom/deadcode/plugins/actionpack.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class ActionPack < Base
-        ignore_class_names(/Controller$/)
+        ignore_classes_named(/Controller$/)
       end
     end
   end

--- a/lib/spoom/deadcode/plugins/active_job.rb
+++ b/lib/spoom/deadcode/plugins/active_job.rb
@@ -5,8 +5,8 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveJob < Base
-        ignore_class_names("ApplicationJob")
-        ignore_method_names("perform", "build_enumerator", "each_iteration")
+        ignore_classes_named("ApplicationJob")
+        ignore_methods_named("perform", "build_enumerator", "each_iteration")
       end
     end
   end

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveModel < Base
-        ignore_method_names("validate_each")
+        ignore_methods_named("validate_each")
       end
     end
   end

--- a/lib/spoom/deadcode/plugins/active_record.rb
+++ b/lib/spoom/deadcode/plugins/active_record.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveRecord < Base
-        ignore_method_names(
+        ignore_methods_named(
           "change",
           "down",
           "up",

--- a/lib/spoom/deadcode/plugins/active_support.rb
+++ b/lib/spoom/deadcode/plugins/active_support.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveSupport < Base
-        ignore_method_names(
+        ignore_methods_named(
           "after_all",
           "after_setup",
           "after_teardown",

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -31,7 +31,7 @@ module Spoom
           # end
           # ~~~
           sig { params(names: T.any(String, Regexp)).void }
-          def ignore_class_names(*names)
+          def ignore_classes_named(*names)
             save_names_and_patterns(names, :@ignored_class_names, :@ignored_class_patterns)
           end
 
@@ -49,7 +49,7 @@ module Spoom
           # end
           # ~~~
           sig { params(names: T.any(String, Regexp)).void }
-          def ignore_constant_names(*names)
+          def ignore_constants_named(*names)
             save_names_and_patterns(names, :@ignored_constant_names, :@ignored_constant_patterns)
           end
 
@@ -67,7 +67,7 @@ module Spoom
           # end
           # ~~~
           sig { params(names: T.any(String, Regexp)).void }
-          def ignore_method_names(*names)
+          def ignore_methods_named(*names)
             save_names_and_patterns(names, :@ignored_method_names, :@ignored_method_patterns)
           end
 
@@ -85,7 +85,7 @@ module Spoom
           # end
           # ~~~
           sig { params(names: T.any(String, Regexp)).void }
-          def ignore_module_names(*names)
+          def ignore_modules_named(*names)
             save_names_and_patterns(names, :@ignored_module_names, :@ignored_module_patterns)
           end
 

--- a/lib/spoom/deadcode/plugins/graphql.rb
+++ b/lib/spoom/deadcode/plugins/graphql.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class GraphQL < Base
-        ignore_method_names(
+        ignore_methods_named(
           "coerce_input",
           "coerce_result",
           "graphql_name",

--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -5,9 +5,9 @@ module Spoom
   module Deadcode
     module Plugins
       class Minitest < Base
-        ignore_class_names(/Test$/)
+        ignore_classes_named(/Test$/)
 
-        ignore_method_names(
+        ignore_methods_named(
           "after_all",
           "around",
           "around_all",

--- a/lib/spoom/deadcode/plugins/rails.rb
+++ b/lib/spoom/deadcode/plugins/rails.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class Rails < Base
-        ignore_constant_names("APP_PATH", "ENGINE_PATH", "ENGINE_ROOT")
+        ignore_constants_named("APP_PATH", "ENGINE_PATH", "ENGINE_ROOT")
       end
     end
   end

--- a/lib/spoom/deadcode/plugins/rake.rb
+++ b/lib/spoom/deadcode/plugins/rake.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class Rake < Base
-        ignore_constant_names("APP_RAKEFILE")
+        ignore_constants_named("APP_RAKEFILE")
       end
     end
   end

--- a/lib/spoom/deadcode/plugins/rspec.rb
+++ b/lib/spoom/deadcode/plugins/rspec.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class RSpec < Base
-        ignore_method_names(
+        ignore_methods_named(
           "after_setup",
           "after_teardown",
           "before_setup",

--- a/lib/spoom/deadcode/plugins/ruby.rb
+++ b/lib/spoom/deadcode/plugins/ruby.rb
@@ -7,7 +7,7 @@ module Spoom
       class Ruby < Base
         extend T::Sig
 
-        ignore_method_names(
+        ignore_methods_named(
           "==",
           "extended",
           "included",

--- a/lib/spoom/deadcode/plugins/thor.rb
+++ b/lib/spoom/deadcode/plugins/thor.rb
@@ -5,7 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class Thor < Base
-        ignore_method_names("exit_on_failure?")
+        ignore_methods_named("exit_on_failure?")
       end
     end
   end

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -11,7 +11,7 @@ module Spoom
         include Test::Helpers::DeadcodeHelper
 
         class TestPlugin < Spoom::Deadcode::Plugins::Base
-          ignore_method_names(
+          ignore_methods_named(
             "name1",
             "name2",
             /^name_re.*/,


### PR DESCRIPTION
And similar for constants, methods and modules.

As discussed in https://github.com/Shopify/spoom/pull/438#discussion_r1294799135.