### PR TITLE
Refactor plugin base tests

### DIFF
--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -284,7 +284,7 @@ module Spoom
 
         sig { params(name: String).returns(T::Boolean) }
         def ignored_module_name?(name)
-          ignored_name?(name, :@ignored_module_names, :@ignored_pattern_names)
+          ignored_name?(name, :@ignored_module_names, :@ignored_module_patterns)
         end
 
         sig { params(name: String, names_variable: Symbol, patterns_variable: Symbol).returns(T::Boolean) }

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -199,6 +199,31 @@ module Spoom
           assert_ignored(index, "name_regexp1")
           assert_ignored(index, "name_regexp2")
         end
+
+        def test_ignore_modules_named
+          plugin = Class.new(Base) do
+            ignore_modules_named(
+              "Module1",
+              "Module2",
+              /^ModuleRE.*/,
+            )
+          end
+
+          @project.write!("foo.rb", <<~RB)
+            module Module1; end
+            module Module2; end
+            module Module3; end
+            module ModuleRE1; end
+            module ModuleRE2; end
+          RB
+
+          index = deadcode_index(plugins: [plugin.new])
+          assert_ignored(index, "Module1")
+          assert_ignored(index, "Module2")
+          refute_ignored(index, "Module3")
+          assert_ignored(index, "ModuleRE1")
+          assert_ignored(index, "ModuleRE2")
+        end
       end
     end
   end


### PR DESCRIPTION
Make it easier to test each feature of `Spoom::Deadcode::Plugins::Base` in isolation.

Also added a few test for the `ignore_*_named` DSLs that caught an error in the one for modules.