### PR TITLE
Always strip prefix before name comparison with string DSL

### DIFF
--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -99,7 +99,7 @@ module Spoom
             names.each do |name|
               case name
               when String
-                ignored_names << name
+                ignored_names << name.delete_prefix("::")
               when Regexp
                 ignored_patterns << name
               end

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -129,13 +129,13 @@ module Spoom
           plugin = Class.new(Base) do
             ignore_classes_named(
               "Class1",
-              "Class2",
+              "::Class2",
               /^ClassRE.*/,
             )
           end
 
           @project.write!("foo.rb", <<~RB)
-            class Class1; end
+            class ::Class1; end
             class Class2; end
             class Class3; end
             class ClassRE1; end
@@ -154,13 +154,13 @@ module Spoom
           plugin = Class.new(Base) do
             ignore_constants_named(
               "CONST1",
-              "CONST2",
+              "::CONST2",
               /^CONSTRE.*/,
             )
           end
 
           @project.write!("foo.rb", <<~RB)
-            CONST1 = 42
+            ::CONST1 = 42
             CONST2 = 42
             CONST3 = 42
             CONSTRE1 = 42
@@ -204,17 +204,17 @@ module Spoom
           plugin = Class.new(Base) do
             ignore_modules_named(
               "Module1",
-              "Module2",
-              /^ModuleRE.*/,
+              "::Module2",
+              /^(::)?ModuleRE.*/,
             )
           end
 
           @project.write!("foo.rb", <<~RB)
-            module Module1; end
+            module ::Module1; end
             module Module2; end
             module Module3; end
             module ModuleRE1; end
-            module ModuleRE2; end
+            module ::ModuleRE2; end
           RB
 
           index = deadcode_index(plugins: [plugin.new])


### PR DESCRIPTION
Make it easier to use the `ignore_*_named` DSL by always stripping the `::` prefix.

This avoids confusion where people to not know which form they should use:

```rb
class MyPlugin < Spoom::Deadcode::Plugins::Base
  ignore_classes_named(
    "::Class1", # Before this PR, did not match code such as `class Class1; end`
    "Class2", # Before this PR, names in the index were already normalized so it matched `class ::Class2; end`
  )
end
```