### PR TITLE
Introduce dead code plugin loading mechanism

### DIFF
--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -19,3 +19,77 @@ require_relative "plugins/rubocop"
 require_relative "plugins/ruby"
 require_relative "plugins/sorbet"
 require_relative "plugins/thor"
+
+module Spoom
+  module Deadcode
+    DEFAULT_CUSTOM_PLUGINS_PATH = ".spoom/deadcode/plugins"
+
+    DEFAULT_PLUGINS = T.let(
+      Set.new([
+        Spoom::Deadcode::Plugins::Namespaces,
+        Spoom::Deadcode::Plugins::Ruby,
+      ]).freeze,
+      T::Set[T.class_of(Plugins::Base)],
+    )
+
+    PLUGINS_FOR_GEM = T.let(
+      {
+        "actionmailer" => Spoom::Deadcode::Plugins::ActionMailer,
+        "actionpack" => Spoom::Deadcode::Plugins::ActionPack,
+        "activejob" => Spoom::Deadcode::Plugins::ActiveJob,
+        "activemodel" => Spoom::Deadcode::Plugins::ActiveModel,
+        "activerecord" => Spoom::Deadcode::Plugins::ActiveRecord,
+        "activesupport" => Spoom::Deadcode::Plugins::ActiveSupport,
+        "graphql" => Spoom::Deadcode::Plugins::GraphQL,
+        "minitest" => Spoom::Deadcode::Plugins::Minitest,
+        "rails" => Spoom::Deadcode::Plugins::Rails,
+        "rake" => Spoom::Deadcode::Plugins::Rake,
+        "rspec" => Spoom::Deadcode::Plugins::RSpec,
+        "rubocop" => Spoom::Deadcode::Plugins::Rubocop,
+        "sorbet-runtime" => Spoom::Deadcode::Plugins::Sorbet,
+        "sorbet-static" => Spoom::Deadcode::Plugins::Sorbet,
+        "thor" => Spoom::Deadcode::Plugins::Thor,
+      }.freeze,
+      T::Hash[String, T.class_of(Plugins::Base)],
+    )
+
+    class << self
+      extend T::Sig
+
+      sig { params(context: Context).returns(T::Array[Plugins::Base]) }
+      def plugins_from_gemfile_lock(context)
+        # These plugins are always loaded
+        plugin_classes = DEFAULT_PLUGINS.dup
+
+        # These plugins depends on the gems used by the project
+        context.gemfile_lock_specs.keys.each do |name|
+          plugin_class = PLUGINS_FOR_GEM[name]
+          plugin_classes << plugin_class if plugin_class
+        end
+
+        plugin_classes.map(&:new)
+      end
+
+      sig { params(context: Context).returns(T::Array[Plugins::Base]) }
+      def load_custom_plugins(context)
+        context.glob("#{DEFAULT_CUSTOM_PLUGINS_PATH}/*.rb").each do |path|
+          require("#{context.absolute_path}/#{path}")
+        end
+
+        ObjectSpace
+          .each_object(Class)
+          .select do |klass|
+            next unless T.unsafe(klass).name # skip anonymous classes, we only use them in tests
+            next unless T.unsafe(klass) < Plugins::Base
+
+            location = Object.const_source_location(T.unsafe(klass).to_s)&.first
+            next unless location
+            next unless location.start_with?("#{context.absolute_path}/#{DEFAULT_CUSTOM_PLUGINS_PATH}")
+
+            true
+          end
+          .map { |klass| T.unsafe(klass).new }
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins/custom_test.rb
+++ b/test/spoom/deadcode/plugins/custom_test.rb
@@ -1,0 +1,56 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    module Plugins
+      class CustomTest < TestWithProject
+        include Test::Helpers::DeadcodeHelper
+
+        def test_ignore_using_custom_plugins
+          @project.write!("foo.rb", <<~RB)
+            class Foo
+              def foo1; end
+              def foo2; end
+              def foo3; end
+            end
+
+            class Bar; end
+            class Baz; end
+          RB
+
+          @project.write!("#{Deadcode::DEFAULT_CUSTOM_PLUGINS_PATH}/plugin1.rb", <<~RB)
+            class CustomPlugin1 < Spoom::Deadcode::Plugins::Base
+              ignore_classes_named("Bar")
+            end
+          RB
+
+          @project.write!("#{Deadcode::DEFAULT_CUSTOM_PLUGINS_PATH}/plugin2.rb", <<~RB)
+            class CustomPlugin2 < Spoom::Deadcode::Plugins::Base
+              ignore_methods_named("foo1", "foo2")
+            end
+          RB
+
+          index = index_with_plugins(@project)
+          refute_ignored(index, "Foo")
+          assert_ignored(index, "Bar")
+          refute_ignored(index, "Baz")
+          assert_ignored(index, "foo1")
+          assert_ignored(index, "foo2")
+          refute_ignored(index, "foo3")
+        end
+
+        private
+
+        sig { params(context: Context).returns(Deadcode::Index) }
+        def index_with_plugins(context)
+          plugins = Deadcode.load_custom_plugins(context)
+          deadcode_index(plugins: plugins)
+        end
+      end
+    end
+  end
+end

--- a/test/spoom/deadcode/plugins_test.rb
+++ b/test/spoom/deadcode/plugins_test.rb
@@ -1,0 +1,121 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_with_project"
+require "helpers/deadcode_helper"
+
+module Spoom
+  module Deadcode
+    class PluginsTest < Spoom::TestWithProject
+      def test_deadcode_plugins_with_no_gemfile_lock
+        plugins = plugins_classes_for_gemfile(<<~GEMFILE)
+          source "https://rubygems.org"
+        GEMFILE
+
+        assert_equal(
+          [
+            Spoom::Deadcode::Plugins::Namespaces,
+            Spoom::Deadcode::Plugins::Ruby,
+          ],
+          plugins,
+        )
+      end
+
+      def test_deadcode_plugins_with_rails
+        plugins = plugins_classes_for_gemfile(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem "rails"
+        GEMFILE
+
+        assert_equal(
+          [
+            Spoom::Deadcode::Plugins::Namespaces,
+            Spoom::Deadcode::Plugins::Ruby,
+            Spoom::Deadcode::Plugins::ActionMailer,
+            Spoom::Deadcode::Plugins::ActionPack,
+            Spoom::Deadcode::Plugins::ActiveJob,
+            Spoom::Deadcode::Plugins::ActiveModel,
+            Spoom::Deadcode::Plugins::ActiveRecord,
+            Spoom::Deadcode::Plugins::ActiveSupport,
+            Spoom::Deadcode::Plugins::Minitest,
+            Spoom::Deadcode::Plugins::Rails,
+            Spoom::Deadcode::Plugins::Rake,
+            Spoom::Deadcode::Plugins::Thor,
+          ],
+          plugins,
+        )
+      end
+
+      def test_deadcode_plugins_with_sorbet
+        plugins = plugins_classes_for_gemfile(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem "sorbet"
+          gem "sorbet-runtime"
+        GEMFILE
+
+        assert_equal(
+          [
+            Spoom::Deadcode::Plugins::Namespaces,
+            Spoom::Deadcode::Plugins::Ruby,
+            Spoom::Deadcode::Plugins::Sorbet,
+          ],
+          plugins,
+        )
+      end
+
+      def test_deadcode_load_custom_plugins
+        context = Context.mktmp!
+
+        context.write!("#{Spoom::Deadcode::DEFAULT_CUSTOM_PLUGINS_PATH}/plugin1.rb", <<~RB)
+          class Plugin1 < Spoom::Deadcode::Plugins::Base
+            ignore_classes_named("Foo", "Bar")
+          end
+        RB
+
+        context.write!("#{Spoom::Deadcode::DEFAULT_CUSTOM_PLUGINS_PATH}/plugin2.rb", <<~RB)
+          class Plugin2 < Spoom::Deadcode::Plugins::Base
+            ignore_classes_named("Foo", "Bar")
+          end
+        RB
+
+        context.write!("#{Spoom::Deadcode::DEFAULT_CUSTOM_PLUGINS_PATH}/not_a_plugin.rb", <<~RB)
+          class NotAPlugin
+          end
+        RB
+
+        plugins = Spoom::Deadcode.load_custom_plugins(context)
+
+        assert_equal(["Plugin1", "Plugin2"], plugins.map(&:class).map(&:name).sort)
+
+        context.destroy!
+      end
+
+      def test_deadcode_load_custom_plugins_ignore_anonymous_classes
+        # Create an anonymous plugin class that shouldn't be loaded
+        Class.new(Spoom::Deadcode::Plugins::Base)
+
+        context = Context.mktmp!
+        plugins = Spoom::Deadcode.load_custom_plugins(context)
+
+        assert_empty(plugins.map(&:class).map(&:name).sort)
+
+        context.destroy!
+      end
+
+      private
+
+      sig { params(gemfile_string: String).returns(T::Array[T.class_of(Plugins::Base)]) }
+      def plugins_classes_for_gemfile(gemfile_string)
+        context = Context.mktmp!
+        context.write_gemfile!(gemfile_string)
+        context.bundle("lock")
+
+        plugin_classes = Deadcode.plugins_from_gemfile_lock(context).map(&:class)
+        context.destroy!
+        plugin_classes
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces two services:

1. `Spoom::Deadcode::plugins_from_gemfile_lock` to instantiate the relevant dead code plugin classes depending on the dependencies found in the Gemfile.lock of the application.

2. `Spoom::Deadcode::load_custom_plugins` to instantiate custom plugins found under `.spoom/deadcode/plugins` so the application can provide custom plugins for DSL that are not handled by default by Spoom.

At this stage, none of these methods are used outside of test until we add the CLI in the next PR.