### PR TITLE
Add a typed? method to the Deadcode::Definition class

### DIFF
--- a/lib/spoom/deadcode/definition.rb
+++ b/lib/spoom/deadcode/definition.rb
@@ -34,6 +34,7 @@ module Spoom
       const :full_name, String
       const :location, Location
       const :status, Status, default: Status::DEAD
+      const :typed, T::Boolean, default: false
 
       # Kind
 
@@ -92,6 +93,13 @@ module Spoom
       sig { void }
       def ignored!
         @status = Status::IGNORED
+      end
+
+      sig { returns(T.nilable(T::Boolean)) }
+      def typed?
+        if method?
+          @typed
+        end
       end
     end
   end

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "debug"
+
 module Spoom
   module Deadcode
     class Indexer < SyntaxTree::Visitor
@@ -327,11 +329,13 @@ module Spoom
 
       sig { params(name: String, full_name: String, node: SyntaxTree::Node).void }
       def define_method(name, full_name, node)
+        typed = !!(last_sig && last_sig !~ /T.untyped/)
         definition = Definition.new(
           kind: Definition::Kind::Method,
           name: name,
           full_name: full_name,
           location: node_location(node),
+          typed: typed,
         )
         @index.define(definition)
         @plugins.each { |plugin| plugin.internal_on_define_method(self, definition) }

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -57,6 +57,18 @@ module Spoom
         end
 
         sig { params(index: Deadcode::Index, name: String).void }
+        def assert_typed(index, name)
+          defs = definitions_for_name(index, name)
+          assert(defs.all?(&:typed?), "Expected all definitions for `#{name}` to be typed")
+        end
+
+        sig { params(index: Deadcode::Index, name: String).void }
+        def assert_untyped(index, name)
+          defs = definitions_for_name(index, name)
+          assert(defs.none?(&:typed?), "Expected all definitions for `#{name}` to be untyped")
+        end
+
+        sig { params(index: Deadcode::Index, name: String).void }
         def refute_ignored(index, name)
           defs = definitions_for_name(index, name)
           assert(defs.none?(&:ignored?), "Expected all definitions for `#{name}` to not be ignored")

--- a/test/spoom/deadcode/index_finalize_test.rb
+++ b/test/spoom/deadcode/index_finalize_test.rb
@@ -151,6 +151,37 @@ module Spoom
         assert_alive(index, "alive")
         assert_dead(index, "dead")
       end
+
+      def test_with_sig_metadata
+        @project.write!("foo_with_sigs.rb", <<~RB)
+          class ALIVE1
+            sig { void }
+            def initialize
+              @x = ALIVE1.new
+            end
+
+            sig { T::Boolean }
+            def present?
+              true
+            end
+
+            def missing
+            end
+
+            sig { T.untyped }
+            def untyped
+            end
+          end
+
+          ALIVE1.new
+        RB
+
+        index = deadcode_index
+        assert_typed(index, "initialize")
+        assert_typed(index, "present?")
+        assert_untyped(index, "missing")
+        assert_untyped(index, "untyped")
+      end
     end
   end
 end


### PR DESCRIPTION
This is a first step in a process designed to find the methods which cause the most viral untypedness to be able to target the highest leverage places to add type information.

The method that I've used to identify if a method is untyped or not is probably wildly oversimplistic, it checks that the method a) has a sig and b) that that sig does not use T.untyped.

It's worth noting that [Sorbet can do this, but only with a special build.](https://github.com/sorbet/sorbet/blob/master/docs/untyped-blame.md) 