### PR TITLE
Centralize Ruby Version to `.ruby-version`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ["3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ inherit_gem:
 
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 3.0
   SuggestExtensions: false
   Exclude:
   - 'vendor/**/*'


### PR DESCRIPTION
## What are you trying to accomplish?
The `.ruby-version` file is the ecosystem standard for defining a Ruby version.  This PR adds the `.ruby-version` file, ensures a `required_ruby_version` is set, and removes all other references to Ruby in this repository, aligning it with the standard.

## What should reviewers focus on?
> [!IMPORTANT] 
> Please verify the following before merging:

Verify that the changes in the PR meets the following requirements or adjust manually to make it compliant:
  - [x] `.ruby-version` file is present with the correct Ruby version defined
  - [x] A `required_ruby_version` in your gemspec is set
  - [x] There is no Ruby version/requirement referenced in the `Gemfile` (no lines with `ruby  <some-version>`)
  - [x] A `Gemfile.lock` is built with the defined Ruby version
  - [x] The version of Rubocop installed is 1.61.0 or greater
  - [x] There is no `TargetRubyVersion` defined  in `rubocop.yml` (reads from  `required_ruby_version` on Rubocop 1.61.0)
  - [x] There is no Ruby argument  present in  `ruby/setup-ruby` Github Actions that do **not**  run on a Ruby matrix (no lines with `ruby-version: “x.x”`)

Please merge this PR if it looks good, this PR will be addressed if there isn't any activity after 4 weeks.
