### PR TITLE
Fix removing first method in class

### DIFF
--- a/lib/spoom/deadcode/remover.rb
+++ b/lib/spoom/deadcode/remover.rb
@@ -312,7 +312,7 @@ module Spoom
           # Adjust the lines to remove to include following blank lines
           after = context.next_node
           if before.nil? && after && after.location.start_line > end_line + 1
-            end_line = after.location.end_line - 1
+            end_line = after.location.start_line - 1
           elsif after.nil? && context.parent_node.location.end_line > end_line + 1
             end_line = context.parent_node.location.end_line - 1
           end

--- a/test/spoom/deadcode/remover_test.rb
+++ b/test/spoom/deadcode/remover_test.rb
@@ -821,6 +821,25 @@ module Spoom
         RB
       end
 
+      def test_deadcode_remover_removes_first_node_with_blank_lines
+        res = remove(<<~RB, "foo")
+          class Foo
+            def foo
+            end
+
+            def bar
+            end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def bar
+            end
+          end
+        RB
+      end
+
       def test_deadcode_remover_removes_node_with_blank_lines
         res = remove(<<~RB, "bar")
           class Foo


### PR DESCRIPTION
when following by a multi-line node.

Previously, trying to remove the first method in a module/class when there was another method after it would also remove all but the last line of the following method as well. The problem can be seen below:

```
module Foo
  def foo
  end
          # after.location.start_line - 1
  def bar # after.location.end_line - 1
  end
end
```

To account for blank lines, the end_line of the node to remove needs to be adjusted to include all lines upto the _start_ of the next node, whereas the code was previously including all lines upto the _end_ of the next node.