### PR TITLE
Update deprecation warnings to be correct

### DIFF
--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -63,7 +63,7 @@ module Spoom
 
       desc "coverage", "Collect metrics related to Sorbet coverage"
       def coverage(*args)
-        say_warning("This command is deprecated. Please use `spoom srb bump` instead.")
+        say_warning("This command is deprecated. Please use `spoom srb coverage` instead.")
 
         invoke(Cli::Srb::Coverage, args, options)
       end
@@ -73,7 +73,7 @@ module Spoom
 
       desc "lsp", "Send LSP requests to Sorbet"
       def lsp(*args)
-        say_warning("This command is deprecated. Please use `spoom srb bump` instead.")
+        say_warning("This command is deprecated. Please use `spoom srb lsp` instead.")
 
         invoke(Cli::Srb::LSP, args, options)
       end


### PR DESCRIPTION
I noticed that when running `spoom coverage` the warning told me to run `spoom srb bump` instead of `spoom srb coverage`. Just a simple commit to update the deprecation warnings with the correct replacement commands.