### PR TITLE
Fix removal of def nodes with a rescue

### DIFF
--- a/test/spoom/deadcode/remover_test.rb
+++ b/test/spoom/deadcode/remover_test.rb
@@ -1027,6 +1027,26 @@ module Spoom
         RB
       end
 
+      def test_deadcode_remover_removes_method_with_rescue
+        res = remove(<<~RB, "foo")
+          def bar; end
+
+          def foo
+            puts "foo"
+          rescue => error
+            puts error
+          end
+
+          def baz; end
+        RB
+
+        assert_equal(<<~RB, res)
+          def bar; end
+
+          def baz; end
+        RB
+      end
+
       def test_deadcode_remover_does_not_remove_singleton_class_if_more_than_one_node
         res = remove(<<~RB, "foo")
           class Foo


### PR DESCRIPTION
When the def node contains a `rescue` we were matching against the `BeginNode` location instead of the `DefNode`.

To this this we can stop the descendant lookup as soon as we find a node that as both the right location and kind.