### PR TITLE
Fix ERB parsing when running deadcode CLI command

### DIFF
--- a/lib/spoom/cli/deadcode.rb
+++ b/lib/spoom/cli/deadcode.rb
@@ -85,7 +85,7 @@ module Spoom
         $stderr.puts "Indexing #{blue(files.size.to_s)} files..."
         files.each do |file|
           content = File.read(file)
-          content = ERB.new(content).src if file.end_with?(".erb")
+          content = Spoom::Deadcode::ERB.new(content).src if file.end_with?(".erb")
 
           tree = Spoom::Deadcode.parse_ruby(content, file: file)
           Spoom::Deadcode.index_node(index, tree, content, file: file, plugins: plugins)

--- a/test/spoom/cli/deadcode_test.rb
+++ b/test/spoom/cli/deadcode_test.rb
@@ -161,6 +161,24 @@ module Spoom
         assert(result.status)
       end
 
+      def test_deadcode_parse_erb
+        @project.write!("view.erb", <<~ERB)
+          <%= foo do %>
+          <% end %>
+        ERB
+
+        result = @project.spoom("deadcode --no-color")
+        assert_equal(<<~ERR, result.err)
+          Collecting files...
+          Indexing 1 files...
+          Analyzing 0 definitions against 5 references...
+
+          No dead code found!
+        ERR
+        assert_empty(result.out)
+        assert(result.status)
+      end
+
       def test_remove
         @project.write!("lib/foo.rb", <<~RUBY)
           def foo; end


### PR DESCRIPTION
The CLI command was resolving ERB to `::ERB` instead of `Spoom::Deadcode::ERB` which is not applying all the needed transformation to the compiled Ruby code and was resulting in parse errors.