### PR TITLE
Compute class and module hierarchy

### DIFF
--- a/lib/spoom/model/model.rb
+++ b/lib/spoom/model/model.rb
@@ -231,9 +231,13 @@ module Spoom
     sig { returns(T::Hash[String, Symbol]) }
     attr_reader :symbols
 
+    sig { returns(Poset[Symbol]) }
+    attr_reader :symbols_hierarchy
+
     sig { void }
     def initialize
       @symbols = T.let({}, T::Hash[String, Symbol])
+      @symbols_hierarchy = T.let(Poset[Symbol].new, Poset[Symbol])
     end
 
     # Get a symbol by it's full name
@@ -280,6 +284,45 @@ module Spoom
     def supertypes(symbol)
       poe = @symbols_hierarchy[symbol]
       poe.ancestors
+    end
+
+    sig { params(symbol: Symbol).returns(T::Array[Symbol]) }
+    def subtypes(symbol)
+      poe = @symbols_hierarchy[symbol]
+      poe.descendants
+    end
+
+    sig { void }
+    def finalize!
+      compute_symbols_hierarchy!
+    end
+
+    private
+
+    sig { void }
+    def compute_symbols_hierarchy!
+      @symbols.dup.each do |_full_name, symbol|
+        symbol.definitions.each do |definition|
+          next unless definition.is_a?(Namespace)
+
+          @symbols_hierarchy.add_node(symbol)
+
+          if definition.is_a?(Class)
+            superclass_name = definition.superclass_name
+            if superclass_name
+              superclass = resolve_symbol(superclass_name, context: symbol)
+              @symbols_hierarchy.add_direct_edge(symbol, superclass)
+            end
+          end
+
+          definition.mixins.each do |mixin|
+            next if mixin.is_a?(Extend)
+
+            target = resolve_symbol(mixin.name, context: symbol)
+            @symbols_hierarchy.add_direct_edge(symbol, target)
+          end
+        end
+      end
     end
   end
 end

--- a/test/spoom/model/model_test.rb
+++ b/test/spoom/model/model_test.rb
@@ -1,0 +1,66 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Spoom
+  class Model
+    class ModelTest < Minitest::Test
+      extend T::Sig
+
+      def test_resolve_symbol
+        model = model(<<~RB)
+          module Foo
+            class Bar
+              class Baz; end
+            end
+          end
+        RB
+
+        context = model["Foo"]
+        assert_equal(model["Foo"], model.resolve_symbol("::Foo", context: context))
+        assert_equal(model["Foo"], model.resolve_symbol("Foo", context: context))
+        assert_equal(model["Foo::Bar"], model.resolve_symbol("Bar", context: context))
+        assert_equal(model["Foo::Bar"], model.resolve_symbol("Foo::Bar", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Bar::Baz", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Foo::Bar::Baz", context: context))
+
+        context = model["Foo::Bar"]
+        assert_equal(model["Foo"], model.resolve_symbol("::Foo", context: context))
+        assert_equal(model["Foo"], model.resolve_symbol("Foo", context: context))
+        assert_equal(model["Foo::Bar"], model.resolve_symbol("Bar", context: context))
+        assert_equal(model["Foo::Bar"], model.resolve_symbol("Foo::Bar", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Baz", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Bar::Baz", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Foo::Bar::Baz", context: context))
+
+        context = model["Foo::Bar::Baz"]
+        assert_equal(model["Foo"], model.resolve_symbol("::Foo", context: context))
+        assert_equal(model["Foo"], model.resolve_symbol("Foo", context: context))
+        assert_equal(model["Foo::Bar"], model.resolve_symbol("Bar", context: context))
+        assert_equal(model["Foo::Bar"], model.resolve_symbol("Foo::Bar", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Baz", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Bar::Baz", context: context))
+        assert_equal(model["Foo::Bar::Baz"], model.resolve_symbol("Foo::Bar::Baz", context: context))
+
+        context = model["Foo"]
+        assert_instance_of(UnresolvedSymbol, model.resolve_symbol("Qux", context: context))
+        assert_instance_of(UnresolvedSymbol, model.resolve_symbol("::Bar", context: context))
+        assert_instance_of(UnresolvedSymbol, model.resolve_symbol("::Baz", context: context))
+      end
+
+      private
+
+      sig { params(rb: String).returns(Model) }
+      def model(rb)
+        node = Spoom.parse_ruby(rb, file: "foo.rb")
+
+        model = Model.new
+        builder = Builder.new(model, "foo.rb")
+        builder.visit(node)
+        model.finalize!
+        model
+      end
+    end
+  end
+end


### PR DESCRIPTION
Now that we have a complete model (#557) and a poset (#558) we can compute the full class/module hierarchy.

This will allow deadcode plugins to reason about the whole ancestor chain rather than just the parent class.