### PR TITLE
Make dead code indexing use a `Model` to index classes

### DIFF
--- a/lib/spoom/deadcode.rb
+++ b/lib/spoom/deadcode.rb
@@ -58,6 +58,7 @@ module Spoom
       sig { params(index: Index, ruby: String, file: String, plugins: T::Array[Deadcode::Plugins::Base]).void }
       def index_ruby(index, ruby, file:, plugins: [])
         node = Spoom.parse_ruby(ruby, file: file)
+        Model::Builder.new(index.model, file).visit(node)
         index_node(index, node, ruby, file: file, plugins: plugins)
       end
 

--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -6,14 +6,18 @@ module Spoom
     class Index
       extend T::Sig
 
+      sig { returns(Model) }
+      attr_reader :model
+
       sig { returns(T::Hash[String, T::Array[Definition]]) }
       attr_reader :definitions
 
       sig { returns(T::Hash[String, T::Array[Reference]]) }
       attr_reader :references
 
-      sig { void }
-      def initialize
+      sig { params(model: Model).void }
+      def initialize(model)
+        @model = model
         @definitions = T.let({}, T::Hash[String, T::Array[Definition]])
         @references = T.let({}, T::Hash[String, T::Array[Reference]])
       end
@@ -33,8 +37,8 @@ module Spoom
       # Mark all definitions having a reference of the same name as `alive`
       #
       # To be called once all the files have been indexed and all the definitions and references discovered.
-      sig { void }
-      def finalize!
+      sig { params(plugins: T::Array[Plugins::Base]).void }
+      def finalize!(plugins: [])
         @references.keys.each do |name|
           definitions_for_name(name).each(&:alive!)
         end

--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -39,6 +39,21 @@ module Spoom
       # To be called once all the files have been indexed and all the definitions and references discovered.
       sig { params(plugins: T::Array[Plugins::Base]).void }
       def finalize!(plugins: [])
+        @model.symbols.each do |_full_name, symbol|
+          symbol.definitions.each do |symbol_def|
+            case symbol_def
+            when Model::Class
+              definition = Definition.new(
+                kind: Definition::Kind::Class,
+                name: symbol.name,
+                full_name: symbol.full_name,
+                location: symbol_def.location,
+              )
+              define(definition)
+              plugins.each { |plugin| plugin.internal_on_define_class(symbol_def, definition) }
+            end
+          end
+        end
         @references.keys.each do |name|
           definitions_for_name(name).each(&:alive!)
         end

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -112,8 +112,6 @@ module Spoom
           @names_nesting.clear
           @names_nesting << full_name
 
-          define_class(T.must(constant_path.split("::").last), full_name, node)
-
           # We do not call `super` here because we don't want to visit the `constant` again
           visit(node.superclass) if node.superclass
           visit(node.body)
@@ -123,7 +121,6 @@ module Spoom
           @names_nesting = old_nesting
         else
           @names_nesting << constant_path
-          define_class(T.must(constant_path.split("::").last), @names_nesting.join("::"), node)
 
           # We do not call `super` here because we don't want to visit the `constant` again
           visit(node.superclass) if node.superclass
@@ -349,18 +346,6 @@ module Spoom
         )
         @index.define(definition)
         @plugins.each { |plugin| plugin.internal_on_define_accessor(self, definition) }
-      end
-
-      sig { params(name: String, full_name: String, node: Prism::Node).void }
-      def define_class(name, full_name, node)
-        definition = Definition.new(
-          kind: Definition::Kind::Class,
-          name: name,
-          full_name: full_name,
-          location: node_location(node),
-        )
-        @index.define(definition)
-        @plugins.each { |plugin| plugin.internal_on_define_class(self, definition) }
       end
 
       sig { params(name: String, full_name: String, node: Prism::Node).void }

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -159,26 +159,26 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_class(indexer, definition)
-        #     definition.ignored! if definition.name == "Foo"
+        #   def on_define_class(symbol_def, definition)
+        #     definition.ignored! if symbol_def.name == "Foo"
         #   end
         # end
         # ~~~
-        sig { params(indexer: Indexer, definition: Definition).void }
-        def on_define_class(indexer, definition)
+        sig { params(symbol_def: Model::Class, definition: Definition).void }
+        def on_define_class(symbol_def, definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_class` instead.
-        sig { params(indexer: Indexer, definition: Definition).void }
-        def internal_on_define_class(indexer, definition)
-          if ignored_class_name?(definition.name)
+        sig { params(symbol_def: Model::Class, definition: Definition).void }
+        def internal_on_define_class(symbol_def, definition)
+          if ignored_class_name?(symbol_def.name)
             definition.ignored!
-          elsif ignored_subclass?(indexer.nesting_class_superclass_name)
+          elsif ignored_subclass?(symbol_def.superclass_name&.delete_prefix("::"))
             definition.ignored!
           end
 
-          on_define_class(indexer, definition)
+          on_define_class(symbol_def, definition)
         end
 
         # Called when a constant is defined.

--- a/lib/spoom/deadcode/plugins/namespaces.rb
+++ b/lib/spoom/deadcode/plugins/namespaces.rb
@@ -7,9 +7,9 @@ module Spoom
       class Namespaces < Base
         extend T::Sig
 
-        sig { override.params(indexer: Indexer, definition: Definition).void }
-        def on_define_class(indexer, definition)
-          definition.ignored! if used_as_namespace?(indexer)
+        sig { override.params(symbol_def: Model::Class, definition: Definition).void }
+        def on_define_class(symbol_def, definition)
+          definition.ignored! unless symbol_def.children.empty?
         end
 
         sig { override.params(indexer: Indexer, definition: Definition).void }

--- a/lib/spoom/deadcode/plugins/rails.rb
+++ b/lib/spoom/deadcode/plugins/rails.rb
@@ -9,9 +9,9 @@ module Spoom
 
         ignore_constants_named("APP_PATH", "ENGINE_PATH", "ENGINE_ROOT")
 
-        sig { override.params(indexer: Indexer, definition: Definition).void }
-        def on_define_class(indexer, definition)
-          definition.ignored! if file_is_helper?(indexer)
+        sig { override.params(symbol_def: Model::Class, definition: Definition).void }
+        def on_define_class(symbol_def, definition)
+          definition.ignored! if symbol_def.location.file.match?(%r{app/helpers/.*\.rb$})
         end
 
         sig { override.params(indexer: Indexer, definition: Definition).void }

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -21,7 +21,8 @@ module Spoom
             allow_mime_types: ["text/x-ruby", "text/x-ruby-script"],
           )
 
-          index = Deadcode::Index.new
+          model = Model.new
+          index = Deadcode::Index.new(model)
 
           files.each do |file|
             content = project.read(file)
@@ -32,7 +33,7 @@ module Spoom
             end
           end
 
-          index.finalize!
+          index.finalize!(plugins: plugins)
           index
         end
 

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -31,8 +31,8 @@ module Spoom
 
         def test_on_define_class
           plugin = Class.new(Base) do
-            def on_define_class(indexer, definition)
-              definition.ignored! if definition.name == "Class1"
+            def on_define_class(symbol_def, definition)
+              definition.ignored! if symbol_def.name == "Class1"
             end
           end
 

--- a/test/spoom/deadcode/remover_test.rb
+++ b/test/spoom/deadcode/remover_test.rb
@@ -1611,11 +1611,13 @@ module Spoom
 
       sig { params(ruby_string: String, def_name: String).returns(String) }
       def remove(ruby_string, def_name)
+        file = "file.rb"
         context = Context.mktmp!
-        context.write!("file.rb", ruby_string)
+        context.write!(file, ruby_string)
 
-        index = Index.new
-        Deadcode.index_ruby(index, ruby_string, file: "file.rb")
+        model = Model.new
+        index = Index.new(model)
+        Deadcode.index_ruby(index, ruby_string, file: file)
         index.finalize!
 
         definitions = definitions_for_name(index, def_name)


### PR DESCRIPTION
This is the first PR on a sequence moving the dead code analysis use the `Model` introduced in #557 rather than its custom indexer.

In this PR we migrate the indexing of classes:
* Make `Deadcode::Index` take a `Model` (bc1852074a4826acf12d701ee0186515ef8999ba)
* Remove classes indexing from `Deadcode::Indexer` (9433fda1d7f1a6655d9f872af4f579bc30fa9f5e)
* Make the `Deadcode::Plugins` take `Model::SymbolDef` when calling `on_define_class` (635977905fa69baed567f1e04ade5456dde2ade9)

There is no behavior change: no tests are changed.

This PR is easier to review commit by commit.