### PR TITLE
Make dead code indexing use a `Model` to index constants

### DIFF
--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -60,6 +60,15 @@ module Spoom
               )
               define(definition)
               plugins.each { |plugin| plugin.internal_on_define_module(symbol_def, definition) }
+            when Model::Constant
+              definition = Definition.new(
+                kind: Definition::Kind::Constant,
+                name: symbol.name,
+                full_name: symbol.full_name,
+                location: symbol_def.location,
+              )
+              define(definition)
+              plugins.each { |plugin| plugin.internal_on_define_constant(symbol_def, definition) }
             end
           end
         end

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -189,22 +189,22 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_constant(indexer, definition)
-        #     definition.ignored! if definition.name == "FOO"
+        #   def on_define_constant(symbol_def, definition)
+        #     definition.ignored! if symbol_def.name == "FOO"
         #   end
         # end
         # ~~~
-        sig { params(indexer: Indexer, definition: Definition).void }
-        def on_define_constant(indexer, definition)
+        sig { params(symbol_def: Model::Constant, definition: Definition).void }
+        def on_define_constant(symbol_def, definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_constant` instead.
-        sig { params(indexer: Indexer, definition: Definition).void }
-        def internal_on_define_constant(indexer, definition)
-          definition.ignored! if ignored_constant_name?(definition.name)
+        sig { params(symbol_def: Model::Constant, definition: Definition).void }
+        def internal_on_define_constant(symbol_def, definition)
+          definition.ignored! if ignored_constant_name?(symbol_def.name)
 
-          on_define_constant(indexer, definition)
+          on_define_constant(symbol_def, definition)
         end
 
         # Called when a method is defined.

--- a/lib/spoom/deadcode/plugins/sorbet.rb
+++ b/lib/spoom/deadcode/plugins/sorbet.rb
@@ -7,9 +7,9 @@ module Spoom
       class Sorbet < Base
         extend T::Sig
 
-        sig { override.params(indexer: Indexer, definition: Definition).void }
-        def on_define_constant(indexer, definition)
-          definition.ignored! if sorbet_type_member?(indexer, definition) || sorbet_enum_constant?(indexer, definition)
+        sig { override.params(symbol_def: Model::Constant, definition: Definition).void }
+        def on_define_constant(symbol_def, definition)
+          definition.ignored! if sorbet_type_member?(symbol_def) || sorbet_enum_constant?(symbol_def)
         end
 
         sig { override.params(indexer: Indexer, definition: Definition).void }
@@ -19,20 +19,20 @@ module Spoom
 
         private
 
-        sig { params(indexer: Indexer, definition: Definition).returns(T::Boolean) }
-        def sorbet_type_member?(indexer, definition)
-          assign = indexer.nesting_node(Prism::ConstantWriteNode)
-          return false unless assign
-
-          value = assign.value
-          return false unless value.is_a?(Prism::CallNode)
-
-          value.name == :type_member || value.name == :type_template
+        sig { params(symbol_def: Model::Constant).returns(T::Boolean) }
+        def sorbet_type_member?(symbol_def)
+          symbol_def.value.match?(/^(type_member|type_template)/)
         end
 
-        sig { params(indexer: Indexer, definition: Definition).returns(T::Boolean) }
-        def sorbet_enum_constant?(indexer, definition)
-          /^(::)?T::Enum$/.match?(indexer.nesting_class_superclass_name) && indexer.nesting_call&.name == :enums
+        sig { params(symbol_def: Model::Constant).returns(T::Boolean) }
+        def sorbet_enum_constant?(symbol_def)
+          owner = symbol_def.owner
+          return false unless owner.is_a?(Model::Class)
+
+          superclass_name = owner.superclass_name
+          return false unless superclass_name
+
+          superclass_name.match?(/^(::)?T::Enum$/)
         end
       end
     end

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -48,8 +48,8 @@ module Spoom
 
         def test_on_define_constant
           plugin = Class.new(Base) do
-            def on_define_constant(indexer, definition)
-              definition.ignored! if definition.name == "CONST1"
+            def on_define_constant(symbol_def, definition)
+              definition.ignored! if symbol_def.name == "CONST1"
             end
           end
 

--- a/test/spoom/deadcode/plugins/sorbet_test.rb
+++ b/test/spoom/deadcode/plugins/sorbet_test.rb
@@ -32,22 +32,16 @@ module Spoom
             end
 
             class BadEnum < T::Enum
-              something do
-                DEAD2 = new
-              end
-            end
-
-            class BadEnum < T::Enum
               class BadEnum
                 enums do
-                  DEAD3 = new
+                  DEAD2 = new
                 end
               end
             end
 
             class Foo
               enums do
-                DEAD4 = new
+                DEAD3 = new
               end
             end
 
@@ -66,6 +60,12 @@ module Spoom
                 end
               end
             end
+
+            class BadEnum < T::Enum
+              something do
+                IGNORED5 = new
+              end
+            end
           RB
 
           index = index_with_plugins
@@ -73,10 +73,10 @@ module Spoom
           assert_ignored(index, "IGNORED2")
           assert_ignored(index, "IGNORED3")
           assert_ignored(index, "IGNORED4")
+          assert_ignored(index, "IGNORED5")
           refute_ignored(index, "DEAD1")
           refute_ignored(index, "DEAD2")
           refute_ignored(index, "DEAD3")
-          refute_ignored(index, "DEAD4")
         end
 
         def test_ignore_sorbet_overrides


### PR DESCRIPTION
Follow-up on #563.

This time, we switch the indexing of constants to Model:

* Remove constants indexing from Deadcode::Indexer (41250bbb902f373aa3b2d5ba9c751badf70f32c8)
* Make the Deadcode::Plugins take Model::SymbolDef when calling `on_define_constant` (7894f64d094c9e03d987e4a9dfb6410201bc49cc)

There is a slight behavior change, before we were able to look at the nesting context when defining `T::Enum` constants. So with this code:

```rb
class Foo < T::Enum
  CONST = new
end
```

We could tell that `CONST` wasn't defined inside a `enums do ... end` block and thus ignore `CONST` within the `sorbet` plugin.

To avoid carrying the `enums do ... end` information and putting pressure on the GC, I dropped this feature, so `CONST` will be marked as `ignored`.

In practice this case doesn't happen much, this is a regression that I deemed acceptable.

This PR is easier to review commit by commit.