### PR TITLE
Make dead code indexing use a Model to index accessors

### DIFF
--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -78,6 +78,42 @@ module Spoom
               )
               define(definition)
               plugins.each { |plugin| plugin.internal_on_define_method(symbol_def, definition) }
+            when Model::AttrAccessor
+              definition = Definition.new(
+                kind: Definition::Kind::AttrReader,
+                name: symbol.name,
+                full_name: symbol.full_name,
+                location: symbol_def.location,
+              )
+              define(definition)
+              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
+
+              definition = Definition.new(
+                kind: Definition::Kind::AttrWriter,
+                name: "#{symbol.name}=",
+                full_name: "#{symbol.full_name}=",
+                location: symbol_def.location,
+              )
+              define(definition)
+              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
+            when Model::AttrReader
+              definition = Definition.new(
+                kind: Definition::Kind::AttrReader,
+                name: symbol.name,
+                full_name: symbol.full_name,
+                location: symbol_def.location,
+              )
+              define(definition)
+              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
+            when Model::AttrWriter
+              definition = Definition.new(
+                kind: Definition::Kind::AttrWriter,
+                name: "#{symbol.name}=",
+                full_name: "#{symbol.full_name}=",
+                location: symbol_def.location,
+              )
+              define(definition)
+              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
             end
           end
         end

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -135,20 +135,20 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_accessor(indexer, definition)
-        #     definition.ignored! if definition.name == "foo"
+        #   def on_define_accessor(symbol_def, definition)
+        #     definition.ignored! if symbol_def.name == "foo"
         #   end
         # end
         # ~~~
-        sig { params(indexer: Indexer, definition: Definition).void }
-        def on_define_accessor(indexer, definition)
+        sig { params(symbol_def: Model::Attr, definition: Definition).void }
+        def on_define_accessor(symbol_def, definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_accessor` instead.
-        sig { params(indexer: Indexer, definition: Definition).void }
-        def internal_on_define_accessor(indexer, definition)
-          on_define_accessor(indexer, definition)
+        sig { params(symbol_def: Model::Attr, definition: Definition).void }
+        def internal_on_define_accessor(symbol_def, definition)
+          on_define_accessor(symbol_def, definition)
         end
 
         # Called when a class is defined.

--- a/lib/spoom/model/builder.rb
+++ b/lib/spoom/model/builder.rb
@@ -144,7 +144,7 @@ module Spoom
 
       sig { override.params(node: Prism::CallNode).void }
       def visit_call_node(node)
-        return if node.receiver
+        return if node.receiver && !node.receiver.is_a?(Prism::SelfNode)
 
         current_namespace = @namespace_nesting.last
 

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -14,8 +14,8 @@ module Spoom
 
         def test_on_define_accessor
           plugin = Class.new(Base) do
-            def on_define_accessor(indexer, definition)
-              definition.ignored! if definition.name == "attr_reader1"
+            def on_define_accessor(symbol_def, definition)
+              definition.ignored! if symbol_def.name == "attr_reader1"
             end
           end
 

--- a/test/spoom/model/builder_test.rb
+++ b/test/spoom/model/builder_test.rb
@@ -208,9 +208,9 @@ module Spoom
           end
 
           class C1
-            self.attr_reader :ignored
-            self.attr_writer :ignored
-            self.attr_accessor :ignored
+            self.attr_reader :a7
+            self.attr_writer :a8
+            self.attr_accessor :a9
           end
 
           C1.attr_reader :ignored
@@ -230,6 +230,9 @@ module Spoom
             "AttrAccessor(a4)",
             "AttrReader(C1::a5)",
             "AttrWriter(C1::a6)",
+            "AttrReader(C1::a7)",
+            "AttrWriter(C1::a8)",
+            "AttrAccessor(C1::a9)",
           ],
           model.symbols.values
             .flat_map(&:definitions)


### PR DESCRIPTION
Follow-up on #565/

This time, we switch the indexing of accessors to Model:

* Remove accessors indexing from Deadcode::Indexer + some cleaning (0a5d0dffd12059e817ef6fb8ec1958da91d7be20)
Make the Deadcode::Plugins take Model::SymbolDef when calling `on_define_accessor` (fea73f3b3fd3b107c46bdb28ed012a10514355bb)

There is no behavior change. 

This PR is easier to review commit by commit.