### PR TITLE
Clean dead code analysis following migration to `Model`

### DIFF
--- a/lib/spoom/cli/deadcode.rb
+++ b/lib/spoom/cli/deadcode.rb
@@ -82,7 +82,7 @@ module Spoom
 
         model = Spoom::Model.new
         index = Spoom::Deadcode::Index.new(model)
-        plugins = plugin_classes.map(&:new)
+        plugins = plugin_classes.map { |plugin| plugin.new(index) }
 
         $stderr.puts "Indexing #{blue(files.size.to_s)} files..."
         files.each do |file|

--- a/lib/spoom/cli/deadcode.rb
+++ b/lib/spoom/cli/deadcode.rb
@@ -71,17 +71,18 @@ module Spoom
           $stderr.puts
         end
 
-        plugins = Spoom::Deadcode.plugins_from_gemfile_lock(context)
+        plugin_classes = Spoom::Deadcode.plugins_from_gemfile_lock(context)
         if options[:show_plugins]
-          $stderr.puts "\nLoaded #{blue(plugins.size.to_s)} plugins\n"
-          plugins.each do |plugin|
-            $stderr.puts "  #{gray(plugin.class.to_s)}"
+          $stderr.puts "\nLoaded #{blue(plugin_classes.size.to_s)} plugins\n"
+          plugin_classes.each do |plugin|
+            $stderr.puts "  #{gray(plugin.to_s)}"
           end
           $stderr.puts
         end
 
         model = Spoom::Model.new
         index = Spoom::Deadcode::Index.new(model)
+        plugins = plugin_classes.map(&:new)
 
         $stderr.puts "Indexing #{blue(files.size.to_s)} files..."
         files.each do |file|

--- a/lib/spoom/cli/deadcode.rb
+++ b/lib/spoom/cli/deadcode.rb
@@ -100,7 +100,8 @@ module Spoom
           next
         end
 
-        index.finalize!(plugins: plugins)
+        index.apply_plugins!(plugins)
+        index.finalize!
 
         if options[:show_defs]
           $stderr.puts "\nDefinitions:"

--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -29,9 +29,14 @@ module Spoom
         (@definitions[definition.name] ||= []) << definition
       end
 
-      sig { params(reference: Reference).void }
-      def reference(reference)
-        (@references[reference.name] ||= []) << reference
+      sig { params(name: String, location: Location).void }
+      def reference_constant(name, location)
+        (@references[name] ||= []) << Reference.new(name: name, kind: Reference::Kind::Constant, location: location)
+      end
+
+      sig { params(name: String, location: Location).void }
+      def reference_method(name, location)
+        (@references[name] ||= []) << Reference.new(name: name, kind: Reference::Kind::Method, location: location)
       end
 
       # Mark all definitions having a reference of the same name as `alive`

--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -20,6 +20,7 @@ module Spoom
         @model = model
         @definitions = T.let({}, T::Hash[String, T::Array[Definition]])
         @references = T.let({}, T::Hash[String, T::Array[Reference]])
+        @ignored = T.let(Set.new, T::Set[Model::SymbolDef])
       end
 
       # Indexing
@@ -39,11 +40,36 @@ module Spoom
         (@references[name] ||= []) << Reference.new(name: name, kind: Reference::Kind::Method, location: location)
       end
 
+      sig { params(symbol_def: Model::SymbolDef).void }
+      def ignore(symbol_def)
+        @ignored << symbol_def
+      end
+
+      sig { params(plugins: T::Array[Plugins::Base]).void }
+      def apply_plugins!(plugins)
+        @model.symbols.each do |_full_name, symbol|
+          symbol.definitions.each do |symbol_def|
+            case symbol_def
+            when Model::Class
+              plugins.each { |plugin| plugin.internal_on_define_class(symbol_def) }
+            when Model::Module
+              plugins.each { |plugin| plugin.internal_on_define_module(symbol_def) }
+            when Model::Constant
+              plugins.each { |plugin| plugin.internal_on_define_constant(symbol_def) }
+            when Model::Method
+              plugins.each { |plugin| plugin.internal_on_define_method(symbol_def) }
+            when Model::Attr
+              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def) }
+            end
+          end
+        end
+      end
+
       # Mark all definitions having a reference of the same name as `alive`
       #
       # To be called once all the files have been indexed and all the definitions and references discovered.
-      sig { params(plugins: T::Array[Plugins::Base]).void }
-      def finalize!(plugins: [])
+      sig { void }
+      def finalize!
         @model.symbols.each do |_full_name, symbol|
           symbol.definitions.each do |symbol_def|
             case symbol_def
@@ -54,8 +80,9 @@ module Spoom
                 full_name: symbol.full_name,
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_class(symbol_def, definition) }
             when Model::Module
               definition = Definition.new(
                 kind: Definition::Kind::Module,
@@ -63,8 +90,9 @@ module Spoom
                 full_name: symbol.full_name,
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_module(symbol_def, definition) }
             when Model::Constant
               definition = Definition.new(
                 kind: Definition::Kind::Constant,
@@ -72,8 +100,9 @@ module Spoom
                 full_name: symbol.full_name,
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_constant(symbol_def, definition) }
             when Model::Method
               definition = Definition.new(
                 kind: Definition::Kind::Method,
@@ -81,8 +110,9 @@ module Spoom
                 full_name: symbol.full_name,
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_method(symbol_def, definition) }
             when Model::AttrAccessor
               definition = Definition.new(
                 kind: Definition::Kind::AttrReader,
@@ -90,8 +120,9 @@ module Spoom
                 full_name: symbol.full_name,
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
 
               definition = Definition.new(
                 kind: Definition::Kind::AttrWriter,
@@ -99,8 +130,9 @@ module Spoom
                 full_name: "#{symbol.full_name}=",
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
             when Model::AttrReader
               definition = Definition.new(
                 kind: Definition::Kind::AttrReader,
@@ -108,8 +140,9 @@ module Spoom
                 full_name: symbol.full_name,
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
             when Model::AttrWriter
               definition = Definition.new(
                 kind: Definition::Kind::AttrWriter,
@@ -117,13 +150,11 @@ module Spoom
                 full_name: "#{symbol.full_name}=",
                 location: symbol_def.location,
               )
+              definition.ignored! if @ignored.include?(symbol_def)
+              definition.alive! if @references.key?(symbol.name)
               define(definition)
-              plugins.each { |plugin| plugin.internal_on_define_accessor(symbol_def, definition) }
             end
           end
-        end
-        @references.keys.each do |name|
-          definitions_for_name(name).each(&:alive!)
         end
       end
 

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -26,12 +26,12 @@ module Spoom
 
       sig { override.params(node: Prism::AliasMethodNode).void }
       def visit_alias_method_node(node)
-        reference_method(node.old_name.slice, node)
+        @index.reference_method(node.old_name.slice, node_location(node))
       end
 
       sig { override.params(node: Prism::AndNode).void }
       def visit_and_node(node)
-        reference_method(node.operator_loc.slice, node)
+        @index.reference_method(node.operator_loc.slice, node_location(node))
         super
       end
 
@@ -40,7 +40,7 @@ module Spoom
         expression = node.expression
         case expression
         when Prism::SymbolNode
-          reference_method(expression.unescaped, expression)
+          @index.reference_method(expression.unescaped, node_location(node))
         else
           visit(expression)
         end
@@ -49,24 +49,24 @@ module Spoom
       sig { override.params(node: Prism::CallAndWriteNode).void }
       def visit_call_and_write_node(node)
         visit(node.receiver)
-        reference_method(node.read_name.to_s, node)
-        reference_method(node.write_name.to_s, node)
+        @index.reference_method(node.read_name.to_s, node_location(node))
+        @index.reference_method(node.write_name.to_s, node_location(node))
         visit(node.value)
       end
 
       sig { override.params(node: Prism::CallOperatorWriteNode).void }
       def visit_call_operator_write_node(node)
         visit(node.receiver)
-        reference_method(node.read_name.to_s, node)
-        reference_method(node.write_name.to_s, node)
+        @index.reference_method(node.read_name.to_s, node_location(node))
+        @index.reference_method(node.write_name.to_s, node_location(node))
         visit(node.value)
       end
 
       sig { override.params(node: Prism::CallOrWriteNode).void }
       def visit_call_or_write_node(node)
         visit(node.receiver)
-        reference_method(node.read_name.to_s, node)
-        reference_method(node.write_name.to_s, node)
+        @index.reference_method(node.read_name.to_s, node_location(node))
+        @index.reference_method(node.write_name.to_s, node_location(node))
         visit(node.value)
       end
 
@@ -79,6 +79,7 @@ module Spoom
             recv: node.receiver,
             args: node.arguments&.arguments || [],
             block: node.block,
+            location: node_location(node),
           ),
         )
       end
@@ -92,19 +93,19 @@ module Spoom
 
       sig { override.params(node: Prism::ConstantAndWriteNode).void }
       def visit_constant_and_write_node(node)
-        reference_constant(node.name.to_s, node)
+        @index.reference_constant(node.name.to_s, node_location(node))
         visit(node.value)
       end
 
       sig { override.params(node: Prism::ConstantOperatorWriteNode).void }
       def visit_constant_operator_write_node(node)
-        reference_constant(node.name.to_s, node)
+        @index.reference_constant(node.name.to_s, node_location(node))
         visit(node.value)
       end
 
       sig { override.params(node: Prism::ConstantOrWriteNode).void }
       def visit_constant_or_write_node(node)
-        reference_constant(node.name.to_s, node)
+        @index.reference_constant(node.name.to_s, node_location(node))
         visit(node.value)
       end
 
@@ -113,7 +114,7 @@ module Spoom
         parent = node.parent
 
         visit(parent) if parent
-        reference_constant(node.name.to_s, node)
+        @index.reference_constant(node.name.to_s, node_location(node))
       end
 
       sig { override.params(node: Prism::ConstantPathWriteNode).void }
@@ -124,7 +125,7 @@ module Spoom
 
       sig { override.params(node: Prism::ConstantReadNode).void }
       def visit_constant_read_node(node)
-        reference_constant(node.name.to_s, node)
+        @index.reference_constant(node.name.to_s, node_location(node))
       end
 
       sig { override.params(node: Prism::ConstantWriteNode).void }
@@ -135,31 +136,31 @@ module Spoom
       sig { override.params(node: Prism::LocalVariableAndWriteNode).void }
       def visit_local_variable_and_write_node(node)
         name = node.name.to_s
-        reference_method(name, node)
-        reference_method("#{name}=", node)
+        @index.reference_method(name, node_location(node))
+        @index.reference_method("#{name}=", node_location(node))
         visit(node.value)
       end
 
       sig { override.params(node: Prism::LocalVariableOperatorWriteNode).void }
       def visit_local_variable_operator_write_node(node)
         name = node.name.to_s
-        reference_method(name, node)
-        reference_method("#{name}=", node)
+        @index.reference_method(name, node_location(node))
+        @index.reference_method("#{name}=", node_location(node))
         visit(node.value)
       end
 
       sig { override.params(node: Prism::LocalVariableOrWriteNode).void }
       def visit_local_variable_or_write_node(node)
         name = node.name.to_s
-        reference_method(name, node)
-        reference_method("#{name}=", node)
+        @index.reference_method(name, node_location(node))
+        @index.reference_method("#{name}=", node_location(node))
         visit(node.value)
       end
 
       sig { override.params(node: Prism::LocalVariableWriteNode).void }
       def visit_local_variable_write_node(node)
         visit(node.value)
-        reference_method("#{node.name}=", node)
+        @index.reference_method("#{node.name}=", node_location(node))
       end
 
       sig { override.params(node: Prism::ModuleNode).void }
@@ -173,7 +174,7 @@ module Spoom
         node.lefts.each do |const|
           case const
           when Prism::LocalVariableTargetNode
-            reference_method("#{const.name}=", node)
+            @index.reference_method("#{const.name}=", node_location(node))
           end
         end
         visit(node.value)
@@ -181,7 +182,7 @@ module Spoom
 
       sig { override.params(node: Prism::OrNode).void }
       def visit_or_node(node)
-        reference_method(node.operator_loc.slice, node)
+        @index.reference_method(node.operator_loc.slice, node_location(node))
         super
       end
 
@@ -193,31 +194,19 @@ module Spoom
           plugin.internal_on_send(self, send)
         end
 
-        reference_method(send.name, send.node)
+        @index.reference_method(send.name, send.location)
 
         case send.name
         when "<", ">", "<=", ">="
           # For comparison operators, we also reference the `<=>` method
-          reference_method("<=>", send.node)
+          @index.reference_method("<=>", send.location)
         end
 
         visit_all(send.args)
         visit(send.block)
       end
 
-      # Reference indexing
-
-      sig { params(name: String, node: Prism::Node).void }
-      def reference_constant(name, node)
-        @index.reference(Reference.new(name: name, kind: Reference::Kind::Constant, location: node_location(node)))
-      end
-
-      sig { params(name: String, node: Prism::Node).void }
-      def reference_method(name, node)
-        @index.reference(Reference.new(name: name, kind: Reference::Kind::Method, location: node_location(node)))
-      end
-
-      # Node utils
+      private
 
       sig { params(node: Prism::Node).returns(Location) }
       def node_location(node)

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -191,7 +191,7 @@ module Spoom
         visit(send.recv)
 
         @plugins.each do |plugin|
-          plugin.internal_on_send(self, send)
+          plugin.on_send(send)
         end
 
         @index.reference_method(send.name, send.location)

--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -57,7 +57,7 @@ module Spoom
     class << self
       extend T::Sig
 
-      sig { params(context: Context).returns(T::Array[Plugins::Base]) }
+      sig { params(context: Context).returns(T::Set[T.class_of(Plugins::Base)]) }
       def plugins_from_gemfile_lock(context)
         # These plugins are always loaded
         plugin_classes = DEFAULT_PLUGINS.dup
@@ -68,16 +68,16 @@ module Spoom
           plugin_classes << plugin_class if plugin_class
         end
 
-        plugin_classes.map(&:new)
+        plugin_classes
       end
 
-      sig { params(context: Context).returns(T::Array[Plugins::Base]) }
+      sig { params(context: Context).returns(T::Array[T.class_of(Plugins::Base)]) }
       def load_custom_plugins(context)
         context.glob("#{DEFAULT_CUSTOM_PLUGINS_PATH}/*.rb").each do |path|
           require("#{context.absolute_path}/#{path}")
         end
 
-        ObjectSpace
+        T.unsafe(ObjectSpace)
           .each_object(Class)
           .select do |klass|
             next unless T.unsafe(klass).name # skip anonymous classes, we only use them in tests
@@ -89,7 +89,6 @@ module Spoom
 
             true
           end
-          .map { |klass| T.unsafe(klass).new }
       end
     end
   end

--- a/lib/spoom/deadcode/plugins/action_mailer.rb
+++ b/lib/spoom/deadcode/plugins/action_mailer.rb
@@ -12,7 +12,7 @@ module Spoom
           return unless send.recv.nil? && ActionPack::CALLBACKS.include?(send.name)
 
           send.each_arg(Prism::SymbolNode) do |arg|
-            indexer.reference_method(arg.unescaped, send.node)
+            @index.reference_method(arg.unescaped, send.location)
           end
         end
       end

--- a/lib/spoom/deadcode/plugins/action_mailer.rb
+++ b/lib/spoom/deadcode/plugins/action_mailer.rb
@@ -7,8 +7,8 @@ module Spoom
       class ActionMailer < Base
         extend T::Sig
 
-        sig { override.params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { override.params(send: Send).void }
+        def on_send(send)
           return unless send.recv.nil? && ActionPack::CALLBACKS.include?(send.name)
 
           send.each_arg(Prism::SymbolNode) do |arg|

--- a/lib/spoom/deadcode/plugins/action_mailer_preview.rb
+++ b/lib/spoom/deadcode/plugins/action_mailer_preview.rb
@@ -9,15 +9,15 @@ module Spoom
 
         ignore_classes_inheriting_from("ActionMailer::Preview")
 
-        sig { override.params(symbol_def: Model::Method, definition: Definition).void }
-        def on_define_method(symbol_def, definition)
-          owner = symbol_def.owner
+        sig { override.params(definition: Model::Method).void }
+        def on_define_method(definition)
+          owner = definition.owner
           return unless owner.is_a?(Model::Class)
 
           superclass_name = owner.superclass_name
           return unless superclass_name
 
-          definition.ignored! if superclass_name == "ActionMailer::Preview"
+          @index.ignore(definition) if superclass_name == "ActionMailer::Preview"
         end
       end
     end

--- a/lib/spoom/deadcode/plugins/actionpack.rb
+++ b/lib/spoom/deadcode/plugins/actionpack.rb
@@ -27,12 +27,12 @@ module Spoom
 
         ignore_classes_named(/Controller$/)
 
-        sig { override.params(symbol_def: Model::Method, definition: Definition).void }
-        def on_define_method(symbol_def, definition)
-          owner = symbol_def.owner
+        sig { override.params(definition: Model::Method).void }
+        def on_define_method(definition)
+          owner = definition.owner
           return unless owner.is_a?(Model::Class)
 
-          definition.ignored! if ignored_class_name?(owner.name)
+          @index.ignore(definition) if ignored_class_name?(owner.name)
         end
 
         sig { override.params(send: Send).void }

--- a/lib/spoom/deadcode/plugins/actionpack.rb
+++ b/lib/spoom/deadcode/plugins/actionpack.rb
@@ -35,8 +35,8 @@ module Spoom
           definition.ignored! if ignored_class_name?(owner.name)
         end
 
-        sig { override.params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { override.params(send: Send).void }
+        def on_send(send)
           return unless send.recv.nil? && CALLBACKS.include?(send.name)
 
           arg = send.args.first

--- a/lib/spoom/deadcode/plugins/actionpack.rb
+++ b/lib/spoom/deadcode/plugins/actionpack.rb
@@ -42,7 +42,7 @@ module Spoom
           arg = send.args.first
           case arg
           when Prism::SymbolNode
-            indexer.reference_method(arg.unescaped, send.node)
+            @index.reference_method(arg.unescaped, send.location)
           end
 
           send.each_arg_assoc do |key, value|
@@ -50,9 +50,9 @@ module Spoom
 
             case key
             when "if", "unless"
-              indexer.reference_method(value.slice.delete_prefix(":"), send.node) if value
+              @index.reference_method(value.slice.delete_prefix(":"), send.location) if value
             else
-              indexer.reference_constant(camelize(key), send.node)
+              @index.reference_constant(camelize(key), send.location)
             end
           end
         end

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -17,26 +17,26 @@ module Spoom
           case send.name
           when "attribute", "attributes"
             send.each_arg(Prism::SymbolNode) do |arg|
-              indexer.reference_method(arg.unescaped, send.node)
+              @index.reference_method(arg.unescaped, send.location)
             end
           when "validate", "validates", "validates!", "validates_each"
             send.each_arg(Prism::SymbolNode) do |arg|
-              indexer.reference_method(arg.unescaped, send.node)
+              @index.reference_method(arg.unescaped, send.location)
             end
             send.each_arg_assoc do |key, value|
               key = key.slice.delete_suffix(":")
 
               case key
               when "if", "unless"
-                indexer.reference_method(value.slice.delete_prefix(":"), send.node) if value
+                @index.reference_method(value.slice.delete_prefix(":"), send.location) if value
               else
-                indexer.reference_constant(camelize(key), send.node)
+                @index.reference_constant(camelize(key), send.location)
               end
             end
           when "validates_with"
             arg = send.args.first
             if arg.is_a?(Prism::SymbolNode)
-              indexer.reference_constant(arg.unescaped, send.node)
+              @index.reference_constant(arg.unescaped, send.location)
             end
           end
         end

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -10,8 +10,8 @@ module Spoom
         ignore_classes_inheriting_from(/^(::)?ActiveModel::EachValidator$/)
         ignore_methods_named("validate_each")
 
-        sig { override.params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { override.params(send: Send).void }
+        def on_send(send)
           return if send.recv
 
           case send.name

--- a/lib/spoom/deadcode/plugins/active_record.rb
+++ b/lib/spoom/deadcode/plugins/active_record.rb
@@ -74,7 +74,7 @@ module Spoom
         def on_send(indexer, send)
           if send.recv.nil? && CALLBACKS.include?(send.name)
             send.each_arg(Prism::SymbolNode) do |arg|
-              indexer.reference_method(arg.unescaped, send.node)
+              @index.reference_method(arg.unescaped, send.location)
             end
             return
           end
@@ -85,7 +85,7 @@ module Spoom
           when *CRUD_METHODS
             send.each_arg_assoc do |key, _value|
               key = key.slice.delete_suffix(":")
-              indexer.reference_method("#{key}=", send.node)
+              @index.reference_method("#{key}=", send.location)
             end
           when *ARRAY_METHODS
             send.each_arg(Prism::ArrayNode) do |arg|
@@ -96,7 +96,7 @@ module Spoom
                   next unless assoc.is_a?(Prism::AssocNode)
 
                   key = assoc.key.slice.delete_suffix(":")
-                  indexer.reference_method("#{key}=", send.node)
+                  @index.reference_method("#{key}=", send.location)
                 end
               end
             end

--- a/lib/spoom/deadcode/plugins/active_record.rb
+++ b/lib/spoom/deadcode/plugins/active_record.rb
@@ -70,8 +70,8 @@ module Spoom
           T::Array[String],
         )
 
-        sig { override.params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { override.params(send: Send).void }
+        def on_send(send)
           if send.recv.nil? && CALLBACKS.include?(send.name)
             send.each_arg(Prism::SymbolNode) do |arg|
               @index.reference_method(arg.unescaped, send.location)

--- a/lib/spoom/deadcode/plugins/active_support.rb
+++ b/lib/spoom/deadcode/plugins/active_support.rb
@@ -18,8 +18,8 @@ module Spoom
 
         SETUP_AND_TEARDOWN_METHODS = T.let(["setup", "teardown"], T::Array[String])
 
-        sig { override.params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { override.params(send: Send).void }
+        def on_send(send)
           return unless send.recv.nil? && SETUP_AND_TEARDOWN_METHODS.include?(send.name)
 
           send.each_arg(Prism::SymbolNode) do |arg|

--- a/lib/spoom/deadcode/plugins/active_support.rb
+++ b/lib/spoom/deadcode/plugins/active_support.rb
@@ -23,7 +23,7 @@ module Spoom
           return unless send.recv.nil? && SETUP_AND_TEARDOWN_METHODS.include?(send.name)
 
           send.each_arg(Prism::SymbolNode) do |arg|
-            indexer.reference_method(T.must(arg.value), send.node)
+            @index.reference_method(T.must(arg.value), send.location)
           end
         end
       end

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -277,15 +277,9 @@ module Spoom
         #   end
         # end
         # ~~~
-        sig { params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { params(send: Send).void }
+        def on_send(send)
           # no-op
-        end
-
-        # Do not override this method, use `on_send` instead.
-        sig { params(indexer: Indexer, send: Send).void }
-        def internal_on_send(indexer, send)
-          on_send(indexer, send)
         end
 
         private

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -140,20 +140,20 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_accessor(symbol_def, definition)
-        #     definition.ignored! if symbol_def.name == "foo"
+        #   def on_define_accessor(definition)
+        #     @index.ignore(definition) if symbol_def.name == "foo"
         #   end
         # end
         # ~~~
-        sig { params(symbol_def: Model::Attr, definition: Definition).void }
-        def on_define_accessor(symbol_def, definition)
+        sig { params(definition: Model::Attr).void }
+        def on_define_accessor(definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_accessor` instead.
-        sig { params(symbol_def: Model::Attr, definition: Definition).void }
-        def internal_on_define_accessor(symbol_def, definition)
-          on_define_accessor(symbol_def, definition)
+        sig { params(definition: Model::Attr).void }
+        def internal_on_define_accessor(definition)
+          on_define_accessor(definition)
         end
 
         # Called when a class is defined.
@@ -164,26 +164,26 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_class(symbol_def, definition)
-        #     definition.ignored! if symbol_def.name == "Foo"
+        #   def on_define_class(definition)
+        #     @index.ignore(definition) if definition.name == "Foo"
         #   end
         # end
         # ~~~
-        sig { params(symbol_def: Model::Class, definition: Definition).void }
-        def on_define_class(symbol_def, definition)
+        sig { params(definition: Model::Class).void }
+        def on_define_class(definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_class` instead.
-        sig { params(symbol_def: Model::Class, definition: Definition).void }
-        def internal_on_define_class(symbol_def, definition)
-          if ignored_class_name?(symbol_def.name)
-            definition.ignored!
-          elsif ignored_subclass?(symbol_def.superclass_name&.delete_prefix("::"))
-            definition.ignored!
+        sig { params(definition: Model::Class).void }
+        def internal_on_define_class(definition)
+          if ignored_class_name?(definition.name)
+            @index.ignore(definition)
+          elsif ignored_subclass?(definition.superclass_name&.delete_prefix("::"))
+            @index.ignore(definition)
           end
 
-          on_define_class(symbol_def, definition)
+          on_define_class(definition)
         end
 
         # Called when a constant is defined.
@@ -194,22 +194,22 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_constant(symbol_def, definition)
-        #     definition.ignored! if symbol_def.name == "FOO"
+        #   def on_define_constant(definition)
+        #     @index.ignore(definition) if definition.name == "FOO"
         #   end
         # end
         # ~~~
-        sig { params(symbol_def: Model::Constant, definition: Definition).void }
-        def on_define_constant(symbol_def, definition)
+        sig { params(definition: Model::Constant).void }
+        def on_define_constant(definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_constant` instead.
-        sig { params(symbol_def: Model::Constant, definition: Definition).void }
-        def internal_on_define_constant(symbol_def, definition)
-          definition.ignored! if ignored_constant_name?(symbol_def.name)
+        sig { params(definition: Model::Constant).void }
+        def internal_on_define_constant(definition)
+          @index.ignore(definition) if ignored_constant_name?(definition.name)
 
-          on_define_constant(symbol_def, definition)
+          on_define_constant(definition)
         end
 
         # Called when a method is defined.
@@ -220,22 +220,22 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_method(symbol_def, symbol)
-        #     definition.ignored! if symbol_def.name == "foo"
+        #   def on_define_method(definition)
+        #     @index.ignore(definition) if definition.name == "foo"
         #   end
         # end
         # ~~~
-        sig { params(symbol_def: Model::Method, definition: Definition).void }
-        def on_define_method(symbol_def, definition)
+        sig { params(definition: Model::Method).void }
+        def on_define_method(definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_method` instead.
-        sig { params(symbol_def: Model::Method, definition: Definition).void }
-        def internal_on_define_method(symbol_def, definition)
-          definition.ignored! if ignored_method_name?(symbol_def.name)
+        sig { params(definition: Model::Method).void }
+        def internal_on_define_method(definition)
+          @index.ignore(definition) if ignored_method_name?(definition.name)
 
-          on_define_method(symbol_def, definition)
+          on_define_method(definition)
         end
 
         # Called when a module is defined.
@@ -246,34 +246,34 @@ module Spoom
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_define_module(symbol_def, definition)
-        #     definition.ignored! if symbol_def.name == "Foo"
+        #   def on_define_module(definition)
+        #     @index.ignore(definition) if definition.name == "Foo"
         #   end
         # end
         # ~~~
-        sig { params(symbol_def: Model::Module, definition: Definition).void }
-        def on_define_module(symbol_def, definition)
+        sig { params(definition: Model::Module).void }
+        def on_define_module(definition)
           # no-op
         end
 
         # Do not override this method, use `on_define_module` instead.
-        sig { params(symbol_def: Model::Module, definition: Definition).void }
-        def internal_on_define_module(symbol_def, definition)
-          definition.ignored! if ignored_module_name?(symbol_def.name)
+        sig { params(definition: Model::Module).void }
+        def internal_on_define_module(definition)
+          @index.ignore(definition) if ignored_module_name?(definition.name)
 
-          on_define_module(symbol_def, definition)
+          on_define_module(definition)
         end
 
         # Called when a send is being processed
         #
         # ~~~rb
         # class MyPlugin < Spoom::Deadcode::Plugins::Base
-        #   def on_send(indexer, send)
+        #   def on_send(send)
         #     return unless send.name == "dsl_method"
         #     return if send.args.empty?
         #
         #     method_name = send.args.first.slice.delete_prefix(":")
-        #     indexer.reference_method(method_name, send.node)
+        #     @index.reference_method(method_name, send.node, send.loc)
         #   end
         # end
         # ~~~

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -125,6 +125,11 @@ module Spoom
           end
         end
 
+        sig { params(index: Index).void }
+        def initialize(index)
+          @index = index
+        end
+
         # Indexing event methods
 
         # Called when an accessor is defined.

--- a/lib/spoom/deadcode/plugins/graphql.rb
+++ b/lib/spoom/deadcode/plugins/graphql.rb
@@ -24,8 +24,8 @@ module Spoom
           "unsubscribed",
         )
 
-        sig { override.params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { override.params(send: Send).void }
+        def on_send(send)
           return unless send.recv.nil? && send.name == "field"
 
           arg = send.args.first

--- a/lib/spoom/deadcode/plugins/graphql.rb
+++ b/lib/spoom/deadcode/plugins/graphql.rb
@@ -31,14 +31,14 @@ module Spoom
           arg = send.args.first
           return unless arg.is_a?(Prism::SymbolNode)
 
-          indexer.reference_method(arg.unescaped, send.node)
+          @index.reference_method(arg.unescaped, send.location)
 
           send.each_arg_assoc do |key, value|
             key = key.slice.delete_suffix(":")
             next unless key == "resolver_method"
             next unless value
 
-            indexer.reference_method(value.slice.delete_prefix(":"), send.node)
+            @index.reference_method(value.slice.delete_prefix(":"), send.location)
           end
         end
       end

--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -18,10 +18,10 @@ module Spoom
           "teardown",
         )
 
-        sig { override.params(symbol_def: Model::Method, definition: Definition).void }
-        def on_define_method(symbol_def, definition)
-          file = symbol_def.location.file
-          definition.ignored! if file.match?(%r{test/.*test\.rb$}) && symbol_def.name.match?(/^test_/)
+        sig { override.params(definition: Model::Method).void }
+        def on_define_method(definition)
+          file = definition.location.file
+          @index.ignore(definition) if file.match?(%r{test/.*test\.rb$}) && definition.name.match?(/^test_/)
         end
       end
     end

--- a/lib/spoom/deadcode/plugins/namespaces.rb
+++ b/lib/spoom/deadcode/plugins/namespaces.rb
@@ -7,14 +7,14 @@ module Spoom
       class Namespaces < Base
         extend T::Sig
 
-        sig { override.params(symbol_def: Model::Class, definition: Definition).void }
-        def on_define_class(symbol_def, definition)
-          definition.ignored! if used_as_namespace?(symbol_def)
+        sig { override.params(definition: Model::Class).void }
+        def on_define_class(definition)
+          @index.ignore(definition) if used_as_namespace?(definition)
         end
 
-        sig { override.params(symbol_def: Model::Module, definition: Definition).void }
-        def on_define_module(symbol_def, definition)
-          definition.ignored! if used_as_namespace?(symbol_def)
+        sig { override.params(definition: Model::Module).void }
+        def on_define_module(definition)
+          @index.ignore(definition) if used_as_namespace?(definition)
         end
 
         private

--- a/lib/spoom/deadcode/plugins/rails.rb
+++ b/lib/spoom/deadcode/plugins/rails.rb
@@ -9,14 +9,14 @@ module Spoom
 
         ignore_constants_named("APP_PATH", "ENGINE_PATH", "ENGINE_ROOT")
 
-        sig { override.params(symbol_def: Model::Class, definition: Definition).void }
-        def on_define_class(symbol_def, definition)
-          definition.ignored! if file_is_helper?(symbol_def)
+        sig { override.params(definition: Model::Class).void }
+        def on_define_class(definition)
+          @index.ignore(definition) if file_is_helper?(definition)
         end
 
-        sig { override.params(symbol_def: Model::Module, definition: Definition).void }
-        def on_define_module(symbol_def, definition)
-          definition.ignored! if file_is_helper?(symbol_def)
+        sig { override.params(definition: Model::Module).void }
+        def on_define_module(definition)
+          @index.ignore(definition) if file_is_helper?(definition)
         end
 
         private

--- a/lib/spoom/deadcode/plugins/rubocop.rb
+++ b/lib/spoom/deadcode/plugins/rubocop.rb
@@ -14,28 +14,28 @@ module Spoom
           /^(::)?RuboCop::Cop::Base$/,
         )
 
-        sig { override.params(symbol_def: Model::Constant, definition: Definition).void }
-        def on_define_constant(symbol_def, definition)
-          owner = symbol_def.owner
+        sig { override.params(definition: Model::Constant).void }
+        def on_define_constant(definition)
+          owner = definition.owner
           return false unless owner.is_a?(Model::Class)
 
           superclass_name = owner.superclass_name
           return false unless superclass_name
 
-          definition.ignored! if ignored_subclass?(superclass_name) && RUBOCOP_CONSTANTS.include?(symbol_def.name)
+          @index.ignore(definition) if ignored_subclass?(superclass_name) && RUBOCOP_CONSTANTS.include?(definition.name)
         end
 
-        sig { override.params(symbol_def: Model::Method, definition: Definition).void }
-        def on_define_method(symbol_def, definition)
-          return unless symbol_def.name == "on_send"
+        sig { override.params(definition: Model::Method).void }
+        def on_define_method(definition)
+          return unless definition.name == "on_send"
 
-          owner = symbol_def.owner
+          owner = definition.owner
           return unless owner.is_a?(Model::Class)
 
           superclass_name = owner.superclass_name
           return unless superclass_name
 
-          definition.ignored! if ignored_subclass?(superclass_name)
+          @index.ignore(definition) if ignored_subclass?(superclass_name)
         end
       end
     end

--- a/lib/spoom/deadcode/plugins/ruby.rb
+++ b/lib/spoom/deadcode/plugins/ruby.rb
@@ -20,8 +20,8 @@ module Spoom
           "to_s",
         )
 
-        sig { override.params(indexer: Indexer, send: Send).void }
-        def on_send(indexer, send)
+        sig { override.params(send: Send).void }
+        def on_send(send)
           case send.name
           when "const_defined?", "const_get", "const_source_location"
             reference_symbol_as_constant(send, T.must(send.args.first))

--- a/lib/spoom/deadcode/plugins/ruby.rb
+++ b/lib/spoom/deadcode/plugins/ruby.rb
@@ -24,29 +24,29 @@ module Spoom
         def on_send(indexer, send)
           case send.name
           when "const_defined?", "const_get", "const_source_location"
-            reference_symbol_as_constant(indexer, send, T.must(send.args.first))
+            reference_symbol_as_constant(send, T.must(send.args.first))
           when "send", "__send__", "try"
             arg = send.args.first
-            indexer.reference_method(arg.unescaped, send.node) if arg.is_a?(Prism::SymbolNode)
+            @index.reference_method(arg.unescaped, send.location) if arg.is_a?(Prism::SymbolNode)
           when "alias_method"
             last_arg = send.args.last
 
             if last_arg.is_a?(Prism::SymbolNode) || last_arg.is_a?(Prism::StringNode)
-              indexer.reference_method(last_arg.unescaped, send.node)
+              @index.reference_method(last_arg.unescaped, send.location)
             end
           end
         end
 
         private
 
-        sig { params(indexer: Indexer, send: Send, node: Prism::Node).void }
-        def reference_symbol_as_constant(indexer, send, node)
+        sig { params(send: Send, node: Prism::Node).void }
+        def reference_symbol_as_constant(send, node)
           case node
           when Prism::SymbolNode
-            indexer.reference_constant(node.unescaped, send.node)
+            @index.reference_constant(node.unescaped, send.location)
           when Prism::StringNode
             node.unescaped.split("::").each do |name|
-              indexer.reference_constant(name, send.node) unless name.empty?
+              @index.reference_constant(name, send.location) unless name.empty?
             end
           end
         end

--- a/lib/spoom/deadcode/plugins/sorbet.rb
+++ b/lib/spoom/deadcode/plugins/sorbet.rb
@@ -7,26 +7,26 @@ module Spoom
       class Sorbet < Base
         extend T::Sig
 
-        sig { override.params(symbol_def: Model::Constant, definition: Definition).void }
-        def on_define_constant(symbol_def, definition)
-          definition.ignored! if sorbet_type_member?(symbol_def) || sorbet_enum_constant?(symbol_def)
+        sig { override.params(definition: Model::Constant).void }
+        def on_define_constant(definition)
+          @index.ignore(definition) if sorbet_type_member?(definition) || sorbet_enum_constant?(definition)
         end
 
-        sig { override.params(symbol_def: Model::Method, definition: Definition).void }
-        def on_define_method(symbol_def, definition)
-          definition.ignored! if symbol_def.sigs.any? { |sig| sig.string =~ /(override|overridable)/ }
+        sig { override.params(definition: Model::Method).void }
+        def on_define_method(definition)
+          @index.ignore(definition) if definition.sigs.any? { |sig| sig.string =~ /(override|overridable)/ }
         end
 
         private
 
-        sig { params(symbol_def: Model::Constant).returns(T::Boolean) }
-        def sorbet_type_member?(symbol_def)
-          symbol_def.value.match?(/^(type_member|type_template)/)
+        sig { params(definition: Model::Constant).returns(T::Boolean) }
+        def sorbet_type_member?(definition)
+          definition.value.match?(/^(type_member|type_template)/)
         end
 
-        sig { params(symbol_def: Model::Constant).returns(T::Boolean) }
-        def sorbet_enum_constant?(symbol_def)
-          owner = symbol_def.owner
+        sig { params(definition: Model::Constant).returns(T::Boolean) }
+        def sorbet_enum_constant?(definition)
+          owner = definition.owner
           return false unless owner.is_a?(Model::Class)
 
           superclass_name = owner.superclass_name

--- a/lib/spoom/deadcode/plugins/thor.rb
+++ b/lib/spoom/deadcode/plugins/thor.rb
@@ -9,15 +9,15 @@ module Spoom
 
         ignore_methods_named("exit_on_failure?")
 
-        sig { override.params(symbol_def: Model::Method, definition: Definition).void }
-        def on_define_method(symbol_def, definition)
-          owner = symbol_def.owner
+        sig { override.params(definition: Model::Method).void }
+        def on_define_method(definition)
+          owner = definition.owner
           return unless owner.is_a?(Model::Class)
 
           superclass_name = owner.superclass_name
           return unless superclass_name
 
-          definition.ignored! if superclass_name =~ /^(::)?Thor$/
+          @index.ignore(definition) if superclass_name =~ /^(::)?Thor$/
         end
       end
     end

--- a/lib/spoom/deadcode/send.rb
+++ b/lib/spoom/deadcode/send.rb
@@ -12,6 +12,7 @@ module Spoom
       const :recv, T.nilable(Prism::Node), default: nil
       const :args, T::Array[Prism::Node], default: []
       const :block, T.nilable(Prism::Node), default: nil
+      const :location, Location
 
       sig do
         type_parameters(:T)

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -14,8 +14,8 @@ module Spoom
 
         # Indexing
 
-        sig { params(plugins: T::Array[Deadcode::Plugins::Base]).returns(Deadcode::Index) }
-        def deadcode_index(plugins: [])
+        sig { params(plugin_classes: T::Array[T.class_of(Deadcode::Plugins::Base)]).returns(Deadcode::Index) }
+        def deadcode_index(plugin_classes: [])
           files = project.collect_files(
             allow_extensions: [".rb", ".erb", ".rake", ".rakefile", ".gemspec"],
             allow_mime_types: ["text/x-ruby", "text/x-ruby-script"],
@@ -23,6 +23,7 @@ module Spoom
 
           model = Model.new
           index = Deadcode::Index.new(model)
+          plugins = plugin_classes.map(&:new)
 
           files.each do |file|
             content = project.read(file)

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -23,7 +23,7 @@ module Spoom
 
           model = Model.new
           index = Deadcode::Index.new(model)
-          plugins = plugin_classes.map(&:new)
+          plugins = plugin_classes.map { |plugin| plugin.new(index) }
 
           files.each do |file|
             content = project.read(file)

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -34,7 +34,8 @@ module Spoom
             end
           end
 
-          index.finalize!(plugins: plugins)
+          index.apply_plugins!(plugins)
+          index.finalize!
           index
         end
 

--- a/test/spoom/deadcode/plugins/action_mailer_preview_test.rb
+++ b/test/spoom/deadcode/plugins/action_mailer_preview_test.rb
@@ -48,7 +48,7 @@ module Spoom
 
         sig { returns(Index) }
         def index_with_plugins
-          deadcode_index(plugins: [ActionMailerPreview.new])
+          deadcode_index(plugin_classes: [ActionMailerPreview])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/action_mailer_test.rb
+++ b/test/spoom/deadcode/plugins/action_mailer_test.rb
@@ -33,7 +33,7 @@ module Spoom
 
         sig { returns(Index) }
         def index_with_plugins
-          deadcode_index(plugins: [ActionMailer.new])
+          deadcode_index(plugin_classes: [ActionMailer])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/actionpack_test.rb
+++ b/test/spoom/deadcode/plugins/actionpack_test.rb
@@ -73,7 +73,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::ActionPack.new])
+          deadcode_index(plugin_classes: [Plugins::ActionPack])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/active_job_test.rb
+++ b/test/spoom/deadcode/plugins/active_job_test.rb
@@ -53,7 +53,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::ActiveJob.new])
+          deadcode_index(plugin_classes: [Plugins::ActiveJob])
         end
 
         sig { params(index: Deadcode::Index).returns(T::Array[Location]) }

--- a/test/spoom/deadcode/plugins/active_model_test.rb
+++ b/test/spoom/deadcode/plugins/active_model_test.rb
@@ -113,7 +113,7 @@ module Spoom
 
         sig { returns(Index) }
         def index_with_plugins
-          deadcode_index(plugins: [ActiveModel.new])
+          deadcode_index(plugin_classes: [ActiveModel])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/active_record_test.rb
+++ b/test/spoom/deadcode/plugins/active_record_test.rb
@@ -120,7 +120,7 @@ module Spoom
 
         sig { returns(Index) }
         def index_with_plugins
-          deadcode_index(plugins: [ActiveRecord.new])
+          deadcode_index(plugin_classes: [ActiveRecord])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/active_support_test.rb
+++ b/test/spoom/deadcode/plugins/active_support_test.rb
@@ -34,7 +34,7 @@ module Spoom
 
         sig { returns(Index) }
         def index_with_plugins
-          deadcode_index(plugins: [ActiveSupport.new])
+          deadcode_index(plugin_classes: [ActiveSupport])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -24,7 +24,7 @@ module Spoom
             attr_reader :attr_reader2
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "attr_reader1")
           refute_ignored(index, "attr_reader2")
         end
@@ -41,7 +41,7 @@ module Spoom
             class Class2; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "Class1")
           refute_ignored(index, "Class2")
         end
@@ -58,7 +58,7 @@ module Spoom
             CONST2 = 2
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "CONST1")
           refute_ignored(index, "CONST2")
         end
@@ -75,7 +75,7 @@ module Spoom
             def method2; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "method1")
           refute_ignored(index, "method2")
         end
@@ -92,7 +92,7 @@ module Spoom
             module Module2; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "Module1")
           refute_ignored(index, "Module2")
         end
@@ -117,7 +117,7 @@ module Spoom
             def method3; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_alive(index, "method1")
           assert_alive(index, "method2")
           assert_dead(index, "method3")
@@ -142,7 +142,7 @@ module Spoom
             class ClassRE2; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "Class1")
           assert_ignored(index, "Class2")
           refute_ignored(index, "Class3")
@@ -167,7 +167,7 @@ module Spoom
             CONSTRE2 = 42
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "CONST1")
           assert_ignored(index, "CONST2")
           refute_ignored(index, "CONST3")
@@ -192,7 +192,7 @@ module Spoom
             def name_regexp2; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "name1")
           assert_ignored(index, "name2")
           refute_ignored(index, "name3")
@@ -217,7 +217,7 @@ module Spoom
             module ::ModuleRE2; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "Module1")
           assert_ignored(index, "Module2")
           refute_ignored(index, "Module3")
@@ -244,7 +244,7 @@ module Spoom
             class SubclassRE2 < SuperclassRE2; end
           RB
 
-          index = deadcode_index(plugins: [plugin.new])
+          index = deadcode_index(plugin_classes: [plugin])
           assert_ignored(index, "Subclass1")
           assert_ignored(index, "Subclass2")
           refute_ignored(index, "Subclass3")

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -99,7 +99,7 @@ module Spoom
 
         def test_on_send
           plugin = Class.new(Base) do
-            def on_send(indexer, send)
+            def on_send(send)
               return unless send.name == "dsl_method"
               return if send.args.empty?
 

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -104,7 +104,7 @@ module Spoom
               return if send.args.empty?
 
               method_name = send.args.first.slice.delete_prefix(":")
-              indexer.reference_method(method_name, send.node)
+              @index.reference_method(method_name, send.location)
             end
           end
 

--- a/test/spoom/deadcode/plugins/base_test.rb
+++ b/test/spoom/deadcode/plugins/base_test.rb
@@ -14,8 +14,8 @@ module Spoom
 
         def test_on_define_accessor
           plugin = Class.new(Base) do
-            def on_define_accessor(symbol_def, definition)
-              definition.ignored! if symbol_def.name == "attr_reader1"
+            def on_define_accessor(definition)
+              @index.ignore(definition) if definition.name == "attr_reader1"
             end
           end
 
@@ -31,8 +31,8 @@ module Spoom
 
         def test_on_define_class
           plugin = Class.new(Base) do
-            def on_define_class(symbol_def, definition)
-              definition.ignored! if symbol_def.name == "Class1"
+            def on_define_class(definition)
+              @index.ignore(definition) if definition.name == "Class1"
             end
           end
 
@@ -48,8 +48,8 @@ module Spoom
 
         def test_on_define_constant
           plugin = Class.new(Base) do
-            def on_define_constant(symbol_def, definition)
-              definition.ignored! if symbol_def.name == "CONST1"
+            def on_define_constant(definition)
+              @index.ignore(definition) if definition.name == "CONST1"
             end
           end
 
@@ -65,8 +65,8 @@ module Spoom
 
         def test_on_define_method
           plugin = Class.new(Base) do
-            def on_define_method(symbol_def, definition)
-              definition.ignored! if symbol_def.name == "method1"
+            def on_define_method(definition)
+              @index.ignore(definition) if definition.name == "method1"
             end
           end
 
@@ -82,8 +82,8 @@ module Spoom
 
         def test_on_define_module
           plugin = Class.new(Base) do
-            def on_define_module(symbol_def, definition)
-              definition.ignored! if symbol_def.name == "Module1"
+            def on_define_module(definition)
+              @index.ignore(definition) if definition.name == "Module1"
             end
           end
 

--- a/test/spoom/deadcode/plugins/custom_test.rb
+++ b/test/spoom/deadcode/plugins/custom_test.rb
@@ -48,7 +48,7 @@ module Spoom
         sig { params(context: Context).returns(Deadcode::Index) }
         def index_with_plugins(context)
           plugins = Deadcode.load_custom_plugins(context)
-          deadcode_index(plugins: plugins)
+          deadcode_index(plugin_classes: plugins)
         end
       end
     end

--- a/test/spoom/deadcode/plugins/graphql_test.rb
+++ b/test/spoom/deadcode/plugins/graphql_test.rb
@@ -81,7 +81,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::GraphQL.new])
+          deadcode_index(plugin_classes: [Plugins::GraphQL])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/minitest_test.rb
+++ b/test/spoom/deadcode/plugins/minitest_test.rb
@@ -61,7 +61,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Minitest.new])
+          deadcode_index(plugin_classes: [Plugins::Minitest])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/namespaces_test.rb
+++ b/test/spoom/deadcode/plugins/namespaces_test.rb
@@ -77,7 +77,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Namespaces.new])
+          deadcode_index(plugin_classes: [Plugins::Namespaces])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/rails_test.rb
+++ b/test/spoom/deadcode/plugins/rails_test.rb
@@ -51,7 +51,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Rails.new])
+          deadcode_index(plugin_classes: [Plugins::Rails])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/rake_test.rb
+++ b/test/spoom/deadcode/plugins/rake_test.rb
@@ -23,7 +23,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Rake.new])
+          deadcode_index(plugin_classes: [Plugins::Rake])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/rspec_test.rb
+++ b/test/spoom/deadcode/plugins/rspec_test.rb
@@ -42,7 +42,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::RSpec.new])
+          deadcode_index(plugin_classes: [Plugins::RSpec])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/rubocop_test.rb
+++ b/test/spoom/deadcode/plugins/rubocop_test.rb
@@ -70,7 +70,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Rubocop.new])
+          deadcode_index(plugin_classes: [Plugins::Rubocop])
         end
 
         sig { params(index: Deadcode::Index).returns(T::Array[Location]) }

--- a/test/spoom/deadcode/plugins/ruby_test.rb
+++ b/test/spoom/deadcode/plugins/ruby_test.rb
@@ -167,7 +167,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Ruby.new])
+          deadcode_index(plugin_classes: [Plugins::Ruby])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/sorbet_test.rb
+++ b/test/spoom/deadcode/plugins/sorbet_test.rb
@@ -107,7 +107,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Sorbet.new])
+          deadcode_index(plugin_classes: [Plugins::Sorbet])
         end
       end
     end

--- a/test/spoom/deadcode/plugins/thor_test.rb
+++ b/test/spoom/deadcode/plugins/thor_test.rb
@@ -47,7 +47,7 @@ module Spoom
 
         sig { returns(Deadcode::Index) }
         def index_with_plugins
-          deadcode_index(plugins: [Plugins::Thor.new])
+          deadcode_index(plugin_classes: [Plugins::Thor])
         end
       end
     end

--- a/test/spoom/deadcode/plugins_test.rb
+++ b/test/spoom/deadcode/plugins_test.rb
@@ -87,7 +87,7 @@ module Spoom
 
         plugins = Spoom::Deadcode.load_custom_plugins(context)
 
-        assert_equal(["Plugin1", "Plugin2"], plugins.map(&:class).map(&:name).sort)
+        assert_equal(["Plugin1", "Plugin2"], plugins.map(&:name).sort)
 
         context.destroy!
       end
@@ -99,7 +99,7 @@ module Spoom
         context = Context.mktmp!
         plugins = Spoom::Deadcode.load_custom_plugins(context)
 
-        assert_empty(plugins.map(&:class).map(&:name).sort)
+        assert_empty(plugins)
 
         context.destroy!
       end
@@ -114,9 +114,9 @@ module Spoom
 
         raise "Can't `bundle install`: #{result.err}" unless result.status
 
-        plugin_classes = Deadcode.plugins_from_gemfile_lock(context).map(&:class)
+        plugin_classes = Deadcode.plugins_from_gemfile_lock(context)
         context.destroy!
-        plugin_classes
+        plugin_classes.to_a
       end
     end
   end


### PR DESCRIPTION
This PR cleans a bunch of leftovers following #562, #563, #564, #565 and #566:

1. Do not instantiate plugins when loading them (6944c9341b3d16cdd9adee2d9ede0e2c2edeff19)
2. Initialize plugins with Index (98ad70922f83ba407cb6d0e27048f20d67a55b87)
3. Move reference creation to Index (8035cc4aed544a8026df73ed09c87c973cd1b317)
4. Do not pass indexer to plugin on_send (108d6fdf930e31758f19a8e53836474d800580f2)
5. Do not pass the Deadcode::Definition to plugins on_define_* methods (e74068584d5f63ce6b85353191e9ce5488419f9c)

No functional changes, this PR is easier to review commit by commit.
