### PR TITLE
Add public accessor for `Spoom::Plugins::Base#index`

### DIFF
--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -125,6 +125,9 @@ module Spoom
           end
         end
 
+        sig { returns(Index) }
+        attr_reader :index
+
         sig { params(index: Index).void }
         def initialize(index)
           @index = index


### PR DESCRIPTION
So Sorbet can see `index` being defined when writing plugins outside of `Spoom` and thus relying on RBI files.