### PR TITLE
Improve deadcode plugin for Minitest

### DIFF
--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -7,7 +7,7 @@ module Spoom
       class Minitest < Base
         extend T::Sig
 
-        ignore_classes_named(/Test$/)
+        ignore_classes_inheriting_from("Minitest::Test")
 
         ignore_methods_named(
           "after_all",

--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -30,6 +30,16 @@ module Spoom
 
           @index.ignore(definition) if ignored_subclass?(owner)
         end
+
+        sig { override.params(send: Send).void }
+        def on_send(send)
+          case send.name
+          when "assert_predicate", "refute_predicate"
+            name = send.args[1]&.slice
+            return unless name
+
+            @index.reference_method(name.delete_prefix(":"), send.location)
+          end
         end
       end
     end

--- a/test/spoom/deadcode/plugins/minitest_test.rb
+++ b/test/spoom/deadcode/plugins/minitest_test.rb
@@ -10,25 +10,27 @@ module Spoom
       class MinitestTest < TestWithProject
         include Test::Helpers::DeadcodeHelper
 
-        def test_ignore_minitest_classes_based_on_name
+        def test_ignore_minitest_classes_based_on_superclasses
           @project.write!("foo.rb", <<~RB)
             class C1Test < Minitest::Test; end
           RB
 
           @project.write!("test/foo.rb", <<~RB)
-            class C2Test < SomeTest; end
+            class C2Test < ::Minitest::Test; end
           RB
 
           @project.write!("test/foo_test.rb", <<~RB)
-            class C3Test; end
-            class C4; end
+            class C3Test < ::Minitest::Test; end
+            class C4Test < C3Test; end
+            class C5Test; end
           RB
 
           index = index_with_plugins
           assert_ignored(index, "C1Test")
           assert_ignored(index, "C2Test")
-          assert_ignored(index, "C3Test")
-          refute_ignored(index, "C4")
+          assert_alive(index, "C3Test")
+          assert_ignored(index, "C4Test")
+          refute_ignored(index, "C5Test")
         end
 
         def test_ignore_minitest_methods

--- a/test/spoom/deadcode/plugins/minitest_test.rb
+++ b/test/spoom/deadcode/plugins/minitest_test.rb
@@ -84,6 +84,26 @@ module Spoom
           refute_ignored(index, "some_other_test")
         end
 
+        def test_ignore_minitest_predicates
+          @project.write!("test/foo_test.rb", <<~RB)
+            class FooTest
+              def alive1; end
+              def alive2; end
+              def dead; end
+
+              def test_something
+                assert_predicate(foo, :alive1)
+                refute_predicate(foo, :alive2)
+              end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "alive1")
+          assert_alive(index, "alive2")
+          assert_dead(index, "dead")
+        end
+
         private
 
         sig { returns(Deadcode::Index) }

--- a/test/spoom/deadcode/plugins/minitest_test.rb
+++ b/test/spoom/deadcode/plugins/minitest_test.rb
@@ -33,9 +33,34 @@ module Spoom
           refute_ignored(index, "C5Test")
         end
 
-        def test_ignore_minitest_methods
+        def test_does_not_ignore_minitest_methods_if_not_in_minitest_test_subclass
           @project.write!("test/foo_test.rb", <<~RB)
-            class FooTest
+            class FooTest < Test
+              def after_all; end
+              def around; end
+              def around_all; end
+              def before_all; end
+              def setup; end
+              def teardown; end
+              def test_something; end
+
+              def some_other_test; end
+            end
+          RB
+
+          index = index_with_plugins
+          refute_ignored(index, "after_all")
+          refute_ignored(index, "around")
+          refute_ignored(index, "around_all")
+          refute_ignored(index, "before_all")
+          refute_ignored(index, "setup")
+          refute_ignored(index, "teardown")
+          refute_ignored(index, "test_something")
+        end
+
+        def test_ignore_minitest_methods_if_in_minitest_test_subclass
+          @project.write!("test/foo_test.rb", <<~RB)
+            class FooTest < Minitest::Test
               def after_all; end
               def around; end
               def around_all; end


### PR DESCRIPTION
* Make plugin ignore classes that inherit from `Minitest::Test` instead of those ending with `Test`
* Modified the `on_define_method` method to ignore methods starting with `test_` or included in the `MINITEST_METHODS` set only when inside a `Minitest::Test` subclass.
* Define `on_send` to mark methods used in `assert_predicate` and `refute_predicate` as alive.