### PR TITLE
Make all errors raised by spoom subclass Spoom::Error

### DIFF
--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -11,7 +11,7 @@ require "open3"
 
 module Spoom
   module Sorbet
-    class Error < StandardError
+    class Error < Spoom::Error
       extend T::Sig
 
       class Killed < Error; end

--- a/lib/spoom/sorbet/lsp/errors.rb
+++ b/lib/spoom/sorbet/lsp/errors.rb
@@ -3,7 +3,7 @@
 
 module Spoom
   module LSP
-    class Error < StandardError
+    class Error < Spoom::Error
       class AlreadyOpen < Error; end
       class BadHeaders < Error; end
 


### PR DESCRIPTION
This makes it easier to rescue `Spoom:Error` from clients