### PR TITLE
Avoid raising bare runtime errors

### DIFF
--- a/lib/spoom/deadcode/remover.rb
+++ b/lib/spoom/deadcode/remover.rb
@@ -145,7 +145,7 @@ module Spoom
             delete_chars(node.location.start_offset, next_node.location.start_offset)
           else
             # Should have been removed as a single MLHS node
-            raise "Unexpected case while removing constant assignment"
+            raise Error, "Unexpected case while removing constant assignment"
           end
         end
 
@@ -202,7 +202,7 @@ module Spoom
             # ~~~
             delete_chars(context.node.location.start_offset, next_node.location.start_offset)
           else
-            raise "Unexpected case while removing attr_accessor"
+            raise Error, "Unexpected case while removing attr_accessor"
           end
 
           insert_accessor(context.node, send_context, was_removed: false) if need_accessor
@@ -399,7 +399,7 @@ module Spoom
         sig { returns(Prism::Node) }
         def parent_node
           parent = @nesting.last
-          raise "No parent for node #{node}" unless parent
+          raise Error, "No parent for node #{node}" unless parent
 
           parent
         end
@@ -408,7 +408,7 @@ module Spoom
         def parent_context
           nesting = @nesting.dup
           parent = nesting.pop
-          raise "No parent context for node #{@node}" unless parent
+          raise Error, "No parent context for node #{@node}" unless parent
 
           NodeContext.new(@source, @comments, parent, nesting)
         end
@@ -419,7 +419,7 @@ module Spoom
           child_nodes = parent.child_nodes.compact
 
           index = child_nodes.index(@node)
-          raise "Node #{@node} not found in parent #{parent}" unless index
+          raise Error, "Node #{@node} not found in parent #{parent}" unless index
 
           T.must(child_nodes[0...index])
         end
@@ -435,7 +435,7 @@ module Spoom
           child_nodes = parent.child_nodes.compact
 
           index = child_nodes.index(node)
-          raise "Node #{@node} not found in nesting node #{parent}" unless index
+          raise Error, "Node #{@node} not found in nesting node #{parent}" unless index
 
           T.must(child_nodes.compact[(index + 1)..-1])
         end

--- a/lib/spoom/sorbet/errors.rb
+++ b/lib/spoom/sorbet/errors.rb
@@ -18,6 +18,8 @@ module Spoom
       class Parser
         extend T::Sig
 
+        class ParseError < Spoom::Error; end
+
         HEADER = T.let(
           [
             "👋 Hey there! Heads up that this is not a release build of sorbet.",
@@ -97,14 +99,14 @@ module Spoom
 
         sig { params(error: Error).void }
         def open_error(error)
-          raise "Error: Already parsing an error!" if @current_error
+          raise ParseError, "Error: Already parsing an error!" if @current_error
 
           @current_error = error
         end
 
         sig { void }
         def close_error
-          raise "Error: Not already parsing an error!" unless @current_error
+          raise ParseError, "Error: Not already parsing an error!" unless @current_error
 
           @errors << @current_error
           @current_error = nil
@@ -112,7 +114,7 @@ module Spoom
 
         sig { params(line: String).void }
         def append_error(line)
-          raise "Error: Not already parsing an error!" unless @current_error
+          raise ParseError, "Error: Not already parsing an error!" unless @current_error
 
           filepath_match = line.match(/^    (.*?):\d+/)
           if filepath_match && filepath_match[1]


### PR DESCRIPTION
We should always raise a specific error to make it easier for client to rescue properly when something goes wrong.