### PR TITLE
Ignore `persisted?` method definitions

### DIFF
--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -8,7 +8,7 @@ module Spoom
         extend T::Sig
 
         ignore_classes_inheriting_from("ActiveModel::EachValidator")
-        ignore_methods_named("validate_each")
+        ignore_methods_named("validate_each", "persisted?")
 
         sig { override.params(send: Send).void }
         def on_send(send)

--- a/test/spoom/deadcode/plugins/active_model_test.rb
+++ b/test/spoom/deadcode/plugins/active_model_test.rb
@@ -24,6 +24,17 @@ module Spoom
           refute_ignored(index, "another_method")
         end
 
+        def test_ignore_persisted
+          @project.write!("app/model/validators/my_validator.rb", <<~RB)
+            class MyModel
+              def persisted?; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_ignored(index, "persisted?")
+        end
+
         def test_dead_validation_callbacks
           @project.write!("app/models/my_model.rb", <<~RB)
             class MyModel


### PR DESCRIPTION
`ActiveModel::Conversion` defines `to_param` so models can be serialized when passing them through the URL.

Under the hood, `to_param` calls `persisted?` which will need to be defined on the model.

```rb
def to_param
  (persisted? && key = to_key) ? key.join('-') : nil
end
```

We should ignore `persisted?` definitions so they do not appear dead.