### PR TITLE
Bump version to v1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spoom (1.3.3)
+    spoom (1.4.0)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
       sorbet-static-and-runtime (>= 0.5.10187)

--- a/lib/spoom/version.rb
+++ b/lib/spoom/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Spoom
-  VERSION = "1.3.3"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
Releasing a new gem version so that `Spoom::Location` start/end line/column can be nilable. (#587)