### PR TITLE
[test only] Make sure `ActiveSupport` plugin ignores class definition

### DIFF
--- a/test/spoom/deadcode/plugins/active_support_test.rb
+++ b/test/spoom/deadcode/plugins/active_support_test.rb
@@ -10,9 +10,9 @@ module Spoom
       class ActiveSupportTest < TestWithProject
         include Test::Helpers::DeadcodeHelper
 
-        def test_ignore_minitest_setup_and_teardown_with_symbols
+        def setup
           @project.write!("test/foo_test.rb", <<~RB)
-            class FooTest
+            class FooTest < ActiveSupport::TestCase
               setup(:alive1, :alive2)
               teardown(:alive3)
 
@@ -22,12 +22,18 @@ module Spoom
               def dead; end
             end
           RB
+        end
 
+        def test_ignore_minitest_setup_and_teardown_with_symbols
           index = index_with_plugins
           assert_alive(index, "alive1")
           assert_alive(index, "alive2")
           assert_alive(index, "alive3")
           assert_dead(index, "dead")
+        end
+
+        def test_ignore_test_class_definition
+          assert_ignored(index_with_plugins, "FooTest")
         end
 
         private


### PR DESCRIPTION
This is a cosmetic change to the `ActiveSupport` plugin test to make sure setup is accurate. Since the plugin is intended for test files that inherit from  `ActiveSupport::TestCase` it would be more accurate for `FooTest` to be a subclass of `AS::TestCase` 
This way we can also assert that the class definition itself is being ignored and not marked as dead.
