### PR TITLE
Do not mark classes that inherit from `ActiveJob::TestCase` as dead

### DIFF
--- a/lib/spoom/deadcode/plugins/active_job.rb
+++ b/lib/spoom/deadcode/plugins/active_job.rb
@@ -5,6 +5,7 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveJob < Base
+        ignore_classes_inheriting_from("ActiveJob::TestCase")
         ignore_classes_named("ApplicationJob")
         ignore_methods_named("perform", "build_enumerator", "each_iteration")
       end

--- a/test/spoom/deadcode/plugins/active_job_test.rb
+++ b/test/spoom/deadcode/plugins/active_job_test.rb
@@ -49,6 +49,15 @@ module Spoom
           )
         end
 
+        def test_ignores_activejob_testcase_class_definition
+          @project.write!("test/foo_test.rb", <<~RB)
+            class FooTest < ActiveJob::TestCase
+            end
+          RB
+
+          assert_ignored(index_with_plugins, "FooTest")
+        end
+
         private
 
         sig { returns(Deadcode::Index) }


### PR DESCRIPTION
In https://github.com/Shopify/spoom/pull/579 we stopped ignoring class names that end with `Test` which caused test classes that inherit from `ActiveJob::TestCase` to be indexed as dead. It's not an issue for classes inherited from `ActiveSupport::TestCase` because we have a plugin that ignores those:
https://github.com/Shopify/spoom/blob/3e8ae2092aad7561476925c47a15bdaaeedaa1b5/lib/spoom/deadcode/plugins/active_support.rb#L8

We should do the same for `ActiveJob::TestCase`. Since we already have `ActiveJob` plugin I add an ignore macro to the plugin.