### PR TITLE
Ignore `*Test` named classes again

### DIFF
--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -7,6 +7,7 @@ module Spoom
       class Minitest < Base
         extend T::Sig
 
+        ignore_classes_named(/Test$/)
         ignore_classes_inheriting_from("Minitest::Test")
 
         MINITEST_METHODS = T.let(

--- a/test/spoom/deadcode/plugins/minitest_test.rb
+++ b/test/spoom/deadcode/plugins/minitest_test.rb
@@ -10,6 +10,14 @@ module Spoom
       class MinitestTest < TestWithProject
         include Test::Helpers::DeadcodeHelper
 
+        def test_ignores_test_class_based_on_name
+          @project.write!("foo_test.rb", <<~RB)
+            class FooTest < NotAMinitestClass; end
+          RB
+
+          assert_ignored(index_with_plugins, "FooTest")
+        end
+
         def test_ignore_minitest_classes_based_on_superclasses
           @project.write!("foo.rb", <<~RB)
             class C1Test < Minitest::Test; end
@@ -22,7 +30,6 @@ module Spoom
           @project.write!("test/foo_test.rb", <<~RB)
             class C3Test < ::Minitest::Test; end
             class C4Test < C3Test; end
-            class C5Test; end
           RB
 
           index = index_with_plugins
@@ -30,7 +37,6 @@ module Spoom
           assert_ignored(index, "C2Test")
           assert_alive(index, "C3Test")
           assert_ignored(index, "C4Test")
-          refute_ignored(index, "C5Test")
         end
 
         def test_does_not_ignore_minitest_methods_if_not_in_minitest_test_subclass


### PR DESCRIPTION
Partially reverts https://github.com/Shopify/spoom/pull/579

Not ignoring classes named `*Test` end up resulting in a bug where test classes that inherit from Rails' framework specific test class like `ActiveJob::TestCase` started to be considered dead. https://github.com/Shopify/spoom/pull/592
 
All of the framework test cases inherit from `ActiveSupport::TestCase` so ultimately it should be enough to have it ignored
https://github.com/Shopify/spoom/blob/d4ccf209f2f244965be77d3644fc646ea26ff613/lib/spoom/deadcode/plugins/active_support.rb#L8

should suffice but at the moment spoom doesn't see the `AJ::TestCase < AS::TestCase` inheritance chain so until we get it fixed we are bringing the `*Test` ignore rule back
