### PR TITLE
Revert Improve deadcode plugin for Minitest #579

### DIFF
--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -8,28 +8,20 @@ module Spoom
         extend T::Sig
 
         ignore_classes_named(/Test$/)
-        ignore_classes_inheriting_from("Minitest::Test")
 
-        MINITEST_METHODS = T.let(
-          Set.new([
-            "after_all",
-            "around",
-            "around_all",
-            "before_all",
-            "setup",
-            "teardown",
-          ]),
-          T::Set[String],
+        ignore_methods_named(
+          "after_all",
+          "around",
+          "around_all",
+          "before_all",
+          "setup",
+          "teardown",
         )
 
         sig { override.params(definition: Model::Method).void }
         def on_define_method(definition)
-          return unless definition.name.start_with?("test_") || MINITEST_METHODS.include?(definition.name)
-
-          owner = definition.owner
-          return unless owner.is_a?(Model::Class)
-
-          @index.ignore(definition) if ignored_subclass?(owner)
+          file = definition.location.file
+          @index.ignore(definition) if file.match?(%r{test/.*test\.rb$}) && definition.name.match?(/^test_/)
         end
 
         sig { override.params(send: Send).void }


### PR DESCRIPTION
Since we only index `.rb` files, the relationship between `ActiveJob::TestCase` and `ActiveSupport::TestCase` and other intermediate classes that may only exist in the RBI files isn't seen by Spoom...

cc. @nvasilevski 