### PR TITLE
Update hint to remove deprecated command

### DIFF
--- a/lib/spoom/cli/srb/bump.rb
+++ b/lib/spoom/cli/srb/bump.rb
@@ -186,7 +186,7 @@ module Spoom
             if dry && command
               say("\nRun `#{command}` to bump #{files_count > 1 ? "them" : "it"}")
             elsif dry
-              say("\nRun `spoom bump --from #{from} --to #{to}` locally then `commit the changes` and `push them`")
+              say("\nRun `spoom srb bump --from #{from} --to #{to}` locally then `commit the changes` and `push them`")
             end
           end
 

--- a/test/spoom/cli/srb/bump_test.rb
+++ b/test/spoom/cli/srb/bump_test.rb
@@ -254,7 +254,7 @@ module Spoom
             Can bump `1` file from `false` to `true`:
              + file1.rb
 
-            Run `spoom bump --from false --to true` locally then `commit the changes` and `push them`
+            Run `spoom srb bump --from false --to true` locally then `commit the changes` and `push them`
           OUT
           refute(result.status)
 
@@ -281,7 +281,7 @@ module Spoom
              + file1.rb
              + file2.rb
 
-            Run `spoom bump --from false --to true` locally then `commit the changes` and `push them`
+            Run `spoom srb bump --from false --to true` locally then `commit the changes` and `push them`
           OUT
           refute(result.status)
 
@@ -367,7 +367,7 @@ module Spoom
             Can bump `1` file from `false` to `true`:
              + file1.rb
 
-            Run `spoom bump --from false --to true` locally then `commit the changes` and `push them`
+            Run `spoom srb bump --from false --to true` locally then `commit the changes` and `push them`
           OUT
           refute(result.status)
 


### PR DESCRIPTION
Update hint after running `srb bump` to not reference the deprecated command.