### PR TITLE
Return Gem::Version from Bundle#gem_version_from_gemfile_lock

### DIFF
--- a/lib/spoom/context/bundle.rb
+++ b/lib/spoom/context/bundle.rb
@@ -58,9 +58,9 @@ module Spoom
       # Get `gem` version from the `Gemfile.lock` content
       #
       # Returns `nil` if `gem` cannot be found in the Gemfile.
-      sig { params(gem: String).returns(T.nilable(String)) }
+      sig { params(gem: String).returns(T.nilable(Gem::Version)) }
       def gem_version_from_gemfile_lock(gem)
-        gemfile_lock_specs[gem]&.version&.to_s
+        gemfile_lock_specs[gem]&.version
       end
     end
   end

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -70,8 +70,8 @@ module Spoom
           end
         end
 
-        snapshot.version_static = context.gem_version_from_gemfile_lock("sorbet-static")
-        snapshot.version_runtime = context.gem_version_from_gemfile_lock("sorbet-runtime")
+        snapshot.version_static = context.gem_version_from_gemfile_lock("sorbet-static").to_s
+        snapshot.version_runtime = context.gem_version_from_gemfile_lock("sorbet-runtime").to_s
 
         files = context.srb_files(with_config: new_config)
         snapshot.rbi_files = files.count { |file| file.end_with?(".rbi") }

--- a/test/spoom/context/bundle_test.rb
+++ b/test/spoom/context/bundle_test.rb
@@ -143,15 +143,15 @@ module Spoom
         STR
         assert_equal(
           "0.5.5001",
-          context.gem_version_from_gemfile_lock("sorbet"),
+          context.gem_version_from_gemfile_lock("sorbet").to_s,
         )
         assert_equal(
           "0.5.5002",
-          context.gem_version_from_gemfile_lock("sorbet-runtime"),
+          context.gem_version_from_gemfile_lock("sorbet-runtime").to_s,
         )
         assert_equal(
           "0.5.5003",
-          context.gem_version_from_gemfile_lock("sorbet-static"),
+          context.gem_version_from_gemfile_lock("sorbet-static").to_s,
         )
       end
     end


### PR DESCRIPTION
Started using this in `rbi-central` and returning a `Gem::Version` is closer to what a user would expect.

https://github.com/Shopify/rbi-central/pull/286#discussion_r1781353676