### PR TITLE
Add `spoom srb sigs strip` command

### DIFF
--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -7,6 +7,7 @@ module Spoom
   module Cli
     module Srb
       class Sigs < Thor
+        extend T::Sig
         include Helper
 
         desc "translate", "Translate signatures from/to RBI and RBS"
@@ -15,20 +16,7 @@ module Spoom
         def translate(*paths)
           from = options[:from]
           to = options[:to]
-          paths << "." if paths.empty?
-
-          files = paths.flat_map do |path|
-            if File.file?(path)
-              [path]
-            else
-              Dir.glob("#{path}/**/*.rb")
-            end
-          end
-
-          if files.empty?
-            say_error("No files to translate")
-            exit(1)
-          end
+          files = collect_files(paths)
 
           say("Translating signatures from `#{from}` to `#{to}` " \
             "in `#{files.size}` file#{files.size == 1 ? "" : "s"}...\n\n")
@@ -52,6 +40,31 @@ module Spoom
           end
 
           say("Translated signatures in `#{translated_files}` file#{translated_files == 1 ? "" : "s"}.")
+        end
+
+        desc "strip", "Strip all the signatures from the files"
+        def strip(*path)
+        end
+
+        no_commands do
+          def collect_files(paths)
+            paths << "." if paths.empty?
+
+            files = paths.flat_map do |path|
+              if File.file?(path)
+                [path]
+              else
+                Dir.glob("#{path}/**/*.rb")
+              end
+            end
+
+            if files.empty?
+              say_error("No files to transform")
+              exit(1)
+            end
+
+            files
+          end
         end
       end
     end

--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require "spoom/sorbet/translate_sigs"
+require "spoom/sorbet/sigs"
 
 module Spoom
   module Cli
@@ -22,7 +22,7 @@ module Spoom
             "in `#{files.size}` file#{files.size == 1 ? "" : "s"}...\n\n")
 
           transformed_files = transform_files(files) do |_file, contents|
-            Spoom::Sorbet::TranslateSigs.rbi_to_rbs(contents)
+            Spoom::Sorbet::Sigs.rbi_to_rbs(contents)
           end
 
           say("Translated signatures in `#{transformed_files}` file#{transformed_files == 1 ? "" : "s"}.")

--- a/lib/spoom/sorbet/sigs.rb
+++ b/lib/spoom/sorbet/sigs.rb
@@ -12,12 +12,7 @@ module Spoom
         sig { params(ruby_contents: String).returns(String) }
         def rbi_to_rbs(ruby_contents)
           ruby_contents = ruby_contents.dup
-
-          tree = RBI::Parser.parse_string(ruby_contents)
-
-          visitor = SigsLocator.new
-          visitor.visit(tree)
-          sigs = visitor.sigs.sort_by { |sig, _rbs_string| -T.must(sig.loc&.begin_line) }
+          sigs = collect_sigs(ruby_contents)
 
           sigs.each do |sig, node|
             scanner = Scanner.new(ruby_contents)
@@ -33,6 +28,16 @@ module Spoom
           end
 
           ruby_contents
+        end
+
+        private
+
+        sig { params(ruby_contents: String).returns(T::Array[[RBI::Sig, T.any(RBI::Method, RBI::Attr)]]) }
+        def collect_sigs(ruby_contents)
+          tree = RBI::Parser.parse_string(ruby_contents)
+          visitor = SigsLocator.new
+          visitor.visit(tree)
+          visitor.sigs.sort_by { |sig, _rbs_string| -T.must(sig.loc&.begin_line) }
         end
       end
 

--- a/lib/spoom/sorbet/sigs.rb
+++ b/lib/spoom/sorbet/sigs.rb
@@ -5,7 +5,7 @@ require "rbi"
 
 module Spoom
   module Sorbet
-    class TranslateSigs
+    class Sigs
       class << self
         extend T::Sig
 

--- a/lib/spoom/sorbet/sigs.rb
+++ b/lib/spoom/sorbet/sigs.rb
@@ -10,6 +10,18 @@ module Spoom
         extend T::Sig
 
         sig { params(ruby_contents: String).returns(String) }
+        def strip(ruby_contents)
+          sigs = collect_sigs(ruby_contents)
+          lines_to_strip = sigs.flat_map { |sig, _| (sig.loc&.begin_line..sig.loc&.end_line).to_a }
+
+          lines = []
+          ruby_contents.lines.each_with_index do |line, index|
+            lines << line unless lines_to_strip.include?(index + 1)
+          end
+          lines.join
+        end
+
+        sig { params(ruby_contents: String).returns(String) }
         def rbi_to_rbs(ruby_contents)
           ruby_contents = ruby_contents.dup
           sigs = collect_sigs(ruby_contents)

--- a/test/spoom/cli/srb/sigs_test.rb
+++ b/test/spoom/cli/srb/sigs_test.rb
@@ -11,6 +11,39 @@ module Spoom
           @project.bundle_install!
         end
 
+        # strip
+
+        def test_strip_sigs
+          @project.write!("a/file1.rb", <<~RB)
+            sig { void }
+            def foo; end
+
+            class B
+              sig { void }
+              def bar; end
+            end
+          RB
+
+          result = @project.spoom("srb sigs strip --no-color")
+
+          assert_equal(<<~OUT, result.out)
+            Stripping signatures from `1` file...
+
+            Stripped signatures from `1` file.
+          OUT
+          assert(result.status)
+
+          assert_equal(<<~RB, @project.read("a/file1.rb"))
+            def foo; end
+
+            class B
+              def bar; end
+            end
+          RB
+        end
+
+        # translate
+
         def test_only_supports_translation_from_rbi
           result = @project.spoom("srb sigs translate --from rbs")
 

--- a/test/spoom/cli/srb/sigs_test.rb
+++ b/test/spoom/cli/srb/sigs_test.rb
@@ -33,7 +33,7 @@ module Spoom
           result = @project.spoom("srb sigs translate --no-color")
 
           assert_equal(<<~OUT, result.err)
-            Error: No files to translate
+            Error: No files to transform
           OUT
           refute(result.status)
         end

--- a/test/spoom/sorbet/sigs_test.rb
+++ b/test/spoom/sorbet/sigs_test.rb
@@ -5,23 +5,23 @@ require "test_helper"
 
 module Spoom
   module Sorbet
-    class TranslateSigsTest < Minitest::Test
-      def test_empty
+    class SigsTest < Minitest::Test
+      def test_translate_empty
         contents = ""
-        assert_equal(contents, TranslateSigs.rbi_to_rbs(contents))
+        assert_equal(contents, Sigs.rbi_to_rbs(contents))
       end
 
-      def test_no_sigs
+      def test_translate_no_sigs
         contents = <<~RBI
           class A
             def foo; end
           end
         RBI
 
-        assert_equal(contents, TranslateSigs.rbi_to_rbs(contents))
+        assert_equal(contents, Sigs.rbi_to_rbs(contents))
       end
 
-      def test_top_level_sig
+      def test_translate_top_level_sig
         contents = <<~RBI
           # typed: true
 
@@ -31,7 +31,7 @@ module Spoom
           end
         RBI
 
-        assert_equal(<<~RBS, TranslateSigs.rbi_to_rbs(contents))
+        assert_equal(<<~RBS, Sigs.rbi_to_rbs(contents))
           # typed: true
 
           #: (Integer a, Integer b) -> Integer
@@ -41,7 +41,7 @@ module Spoom
         RBS
       end
 
-      def test_method_sigs
+      def test_translate_method_sigs
         contents = <<~RBI
           class A
             sig { params(a: Integer).void }
@@ -56,7 +56,7 @@ module Spoom
           end
         RBI
 
-        assert_equal(<<~RBS, TranslateSigs.rbi_to_rbs(contents))
+        assert_equal(<<~RBS, Sigs.rbi_to_rbs(contents))
           class A
             #: (Integer a) -> void
             def initialize(a)
@@ -71,7 +71,7 @@ module Spoom
         RBS
       end
 
-      def test_singleton_method_sigs
+      def test_translate_singleton_method_sigs
         contents = <<~RBI
           class A
             sig { returns(Integer) }
@@ -81,7 +81,7 @@ module Spoom
           end
         RBI
 
-        assert_equal(<<~RBS, TranslateSigs.rbi_to_rbs(contents))
+        assert_equal(<<~RBS, Sigs.rbi_to_rbs(contents))
           class A
             #: -> Integer
             def self.foo
@@ -91,7 +91,7 @@ module Spoom
         RBS
       end
 
-      def test_attr_sigs
+      def test_translate_attr_sigs
         contents = <<~RBI
           class A
             sig { returns(Integer) }
@@ -105,7 +105,7 @@ module Spoom
           end
         RBI
 
-        assert_equal(<<~RBS, TranslateSigs.rbi_to_rbs(contents))
+        assert_equal(<<~RBS, Sigs.rbi_to_rbs(contents))
           class A
             #: Integer
             attr_accessor :a

--- a/test/spoom/sorbet/sigs_test.rb
+++ b/test/spoom/sorbet/sigs_test.rb
@@ -6,6 +6,55 @@ require "test_helper"
 module Spoom
   module Sorbet
     class SigsTest < Minitest::Test
+      # strip
+
+      def test_strip_empty
+        contents = ""
+        assert_equal(contents, Sigs.strip(contents))
+      end
+
+      def test_strip_no_sigs
+        contents = <<~RB
+          class A
+            def foo; end
+          end
+        RB
+
+        assert_equal(contents, Sigs.strip(contents))
+      end
+
+      def test_strip_sigs
+        contents = <<~RB
+          class A
+            sig { returns(Integer) }
+            attr_accessor :a
+
+            sig { void }
+            def foo; end
+
+            module B
+              sig { void }
+              sig { returns(Integer) }
+              def bar; end
+            end
+          end
+        RB
+
+        assert_equal(<<~RB, Sigs.strip(contents))
+          class A
+            attr_accessor :a
+
+            def foo; end
+
+            module B
+              def bar; end
+            end
+          end
+        RB
+      end
+
+      # translate
+
       def test_translate_empty
         contents = ""
         assert_equal(contents, Sigs.rbi_to_rbs(contents))


### PR DESCRIPTION
Add a command to strip Sorbet signatures from files.

I refactored the signature translation code to reuse some logic, this PR is easier to review commit by commit.

cc. @dirceu 