### PR TITLE
Spoom depends on RBI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     spoom (1.5.1)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
+      rbi (>= 0.2.3)
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
 

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("erubi", ">= 1.10.0")
   spec.add_dependency("prism", ">= 0.28.0")
+  spec.add_dependency("rbi", ">= 0.2.3")
   spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.10187")
   spec.add_dependency("thor", ">= 0.19.2")
 


### PR DESCRIPTION
This gem depends on `rbi` ([here](https://github.com/Shopify/spoom/blob/10a69d3bfe6298d20bf3221e958e7e8c82510151/lib/spoom/sorbet/sigs.rb#L4)), but `rbi` does not appear in the gemspec.

```
$ mkdir spoom-test
$ cd spoom-test
$ bundle init    
$ bundle add spoom
$ bundle exec ruby -r spoom -e 'puts "OK"'
<internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- rbi (LoadError)
	from <internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/spoom-1.5.1/lib/spoom/sorbet/sigs.rb:4:in `<top (required)>'
	from <internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/spoom-1.5.1/lib/spoom/cli/srb/sigs.rb:4:in `<top (required)>'
	from /Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/spoom-1.5.1/lib/spoom/cli/srb.rb:7:in `require_relative'
	from /Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/spoom-1.5.1/lib/spoom/cli/srb.rb:7:in `<top (required)>'
	from /Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/spoom-1.5.1/lib/spoom/cli.rb:8:in `require_relative'
	from /Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/spoom-1.5.1/lib/spoom/cli.rb:8:in `<top (required)>'
	from <internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/spoom-1.5.1/lib/spoom.rb:22:in `<top (required)>'
	from <internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
```