### PR TITLE
Disable RBI->RBS translation for abstract signatures

### DIFF
--- a/lib/spoom/sorbet/sigs.rb
+++ b/lib/spoom/sorbet/sigs.rb
@@ -72,6 +72,8 @@ module Spoom
           case node
           when RBI::Method, RBI::Attr
             node.sigs.each do |sig|
+              next if sig.is_abstract
+
               @sigs << [sig, node]
             end
           when RBI::Tree

--- a/test/spoom/sorbet/sigs_test.rb
+++ b/test/spoom/sorbet/sigs_test.rb
@@ -120,16 +120,28 @@ module Spoom
         RBS
       end
 
+      def test_does_not_translate_abstract_methods
+        contents = <<~RBI
+          sig { abstract.void }
+          def foo; end
+        RBI
+
+        assert_equal(<<~RBS, Sigs.rbi_to_rbs(contents))
+          sig { abstract.void }
+          def foo; end
+        RBS
+      end
+
       def test_translate_method_sigs_with_annotations
         contents = <<~RBI
-          sig(:final) { abstract.override(allow_incompatible: true).void }
+          sig(:final) { overridable.override(allow_incompatible: true).void }
           def foo; end
         RBI
 
         assert_equal(<<~RBS, Sigs.rbi_to_rbs(contents))
           # @final
-          # @abstract
           # @override(allow_incompatible: true)
+          # @overridable
           #: -> void
           def foo; end
         RBS


### PR DESCRIPTION
We still need abstract methods to be wrapped out by the runtime component. Until we have a better story for those, let's avoid translating them.