### PR TITLE
Remove `extend T::Sig` where not needed.

### DIFF
--- a/lib/spoom.rb
+++ b/lib/spoom.rb
@@ -5,8 +5,6 @@ require "sorbet-runtime"
 require "pathname"
 
 module Spoom
-  extend T::Sig
-
   SPOOM_PATH = T.let((Pathname.new(__FILE__) / ".." / "..").to_s, String)
 
   class Error < StandardError; end

--- a/lib/spoom/backtrace_filter/minitest.rb
+++ b/lib/spoom/backtrace_filter/minitest.rb
@@ -6,8 +6,6 @@ require "minitest"
 module Spoom
   module BacktraceFilter
     class Minitest < ::Minitest::BacktraceFilter
-      extend T::Sig
-
       SORBET_PATHS = T.let(Gem.loaded_specs["sorbet-runtime"].full_require_paths.freeze, T::Array[String])
 
       # @override

--- a/lib/spoom/cli.rb
+++ b/lib/spoom/cli.rb
@@ -10,7 +10,6 @@ require_relative "cli/srb"
 module Spoom
   module Cli
     class Main < Thor
-      extend T::Sig
       include Helper
 
       class_option :color, type: :boolean, default: true, desc: "Use colors"

--- a/lib/spoom/cli/deadcode.rb
+++ b/lib/spoom/cli/deadcode.rb
@@ -6,7 +6,6 @@ require_relative "../deadcode"
 module Spoom
   module Cli
     class Deadcode < Thor
-      extend T::Sig
       include Helper
 
       default_task :deadcode

--- a/lib/spoom/cli/helper.rb
+++ b/lib/spoom/cli/helper.rb
@@ -8,7 +8,6 @@ require "stringio"
 module Spoom
   module Cli
     module Helper
-      extend T::Sig
       extend T::Helpers
 
       include Colorize

--- a/lib/spoom/cli/srb/assertions.rb
+++ b/lib/spoom/cli/srb/assertions.rb
@@ -5,7 +5,6 @@ module Spoom
   module Cli
     module Srb
       class Assertions < Thor
-        extend T::Sig
         include Helper
 
         desc "translate", "Translate type assertions from/to RBI and RBS"

--- a/lib/spoom/cli/srb/bump.rb
+++ b/lib/spoom/cli/srb/bump.rb
@@ -8,7 +8,6 @@ module Spoom
   module Cli
     module Srb
       class Bump < Thor
-        extend T::Sig
         include Helper
 
         default_task :bump

--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -7,7 +7,6 @@ module Spoom
   module Cli
     module Srb
       class Sigs < Thor
-        extend T::Sig
         include Helper
 
         desc "translate", "Translate signatures from/to RBI and RBS"

--- a/lib/spoom/colors.rb
+++ b/lib/spoom/colors.rb
@@ -3,8 +3,6 @@
 
 module Spoom
   class Color < T::Enum
-    extend T::Sig
-
     enums do
       CLEAR           = new("\e[0m")
       BOLD            = new("\e[1m")
@@ -35,8 +33,6 @@ module Spoom
   end
 
   module Colorize
-    extend T::Sig
-
     #: (String string, *Color color) -> String
     def set_color(string, *color)
       "#{color.map(&:ansi_code).join}#{string}#{Color::CLEAR.ansi_code}"

--- a/lib/spoom/context.rb
+++ b/lib/spoom/context.rb
@@ -18,8 +18,6 @@ module Spoom
   # A context maps to a directory in the file system.
   # It is used to manipulate files and run commands in the context of this directory.
   class Context
-    extend T::Sig
-
     include Bundle
     include Exec
     include FileSystem
@@ -27,8 +25,6 @@ module Spoom
     include Sorbet
 
     class << self
-      extend T::Sig
-
       # Create a new context in the system's temporary directory
       #
       # `name` is used as prefix to the temporary directory name.

--- a/lib/spoom/context/bundle.rb
+++ b/lib/spoom/context/bundle.rb
@@ -5,7 +5,6 @@ module Spoom
   class Context
     # Bundle features for a context
     module Bundle
-      extend T::Sig
       extend T::Helpers
 
       requires_ancestor { Context }

--- a/lib/spoom/context/exec.rb
+++ b/lib/spoom/context/exec.rb
@@ -3,8 +3,6 @@
 
 module Spoom
   class ExecResult < T::Struct
-    extend T::Sig
-
     const :out, String
     const :err, T.nilable(String)
     const :status, T::Boolean
@@ -25,7 +23,6 @@ module Spoom
   class Context
     # Execution features for a context
     module Exec
-      extend T::Sig
       extend T::Helpers
 
       requires_ancestor { Context }

--- a/lib/spoom/context/file_system.rb
+++ b/lib/spoom/context/file_system.rb
@@ -5,7 +5,6 @@ module Spoom
   class Context
     # File System features for a context
     module FileSystem
-      extend T::Sig
       extend T::Helpers
 
       requires_ancestor { Context }

--- a/lib/spoom/context/git.rb
+++ b/lib/spoom/context/git.rb
@@ -4,11 +4,7 @@
 module Spoom
   module Git
     class Commit < T::Struct
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         # Parse a line formatted as `%h %at` into a `Commit`
         #: (String string) -> Commit?
         def parse_line(string)
@@ -33,7 +29,6 @@ module Spoom
   class Context
     # Git features for a context
     module Git
-      extend T::Sig
       extend T::Helpers
 
       requires_ancestor { Context }

--- a/lib/spoom/context/sorbet.rb
+++ b/lib/spoom/context/sorbet.rb
@@ -5,7 +5,6 @@ module Spoom
   class Context
     # Sorbet features for a context
     module Sorbet
-      extend T::Sig
       extend T::Helpers
 
       requires_ancestor { Context }

--- a/lib/spoom/coverage.rb
+++ b/lib/spoom/coverage.rb
@@ -10,8 +10,6 @@ require "date"
 module Spoom
   module Coverage
     class << self
-      extend T::Sig
-
       #: (Context context, ?rbi: bool, ?sorbet_bin: String?) -> Snapshot
       def snapshot(context, rbi: true, sorbet_bin: nil)
         config = context.sorbet_config

--- a/lib/spoom/coverage/d3.rb
+++ b/lib/spoom/coverage/d3.rb
@@ -15,8 +15,6 @@ module Spoom
       COLOR_STRONG = "#064828"
 
       class << self
-        extend T::Sig
-
         #: -> String
         def header_style
           <<~CSS

--- a/lib/spoom/coverage/d3/base.rb
+++ b/lib/spoom/coverage/d3/base.rb
@@ -20,8 +20,6 @@ module Spoom
         end
 
         class << self
-          extend T::Sig
-
           #: -> String
           def header_style
             ""

--- a/lib/spoom/coverage/d3/circle_map.rb
+++ b/lib/spoom/coverage/d3/circle_map.rb
@@ -8,8 +8,6 @@ module Spoom
     module D3
       class CircleMap < Base
         class << self
-          extend T::Sig
-
           #: -> String
           def header_style
             <<~CSS
@@ -147,8 +145,6 @@ module Spoom
         end
 
         class Sigils < CircleMap
-          extend T::Sig
-
           #: (String id, FileTree file_tree, Hash[FileTree::Node, String?] nodes_strictnesses, Hash[FileTree::Node, Float] nodes_scores) -> void
           def initialize(id, file_tree, nodes_strictnesses, nodes_scores)
             @nodes_strictnesses = nodes_strictnesses

--- a/lib/spoom/coverage/d3/pie.rb
+++ b/lib/spoom/coverage/d3/pie.rb
@@ -7,7 +7,6 @@ module Spoom
   module Coverage
     module D3
       class Pie < Base
-        extend T::Sig
         extend T::Helpers
 
         abstract!
@@ -19,8 +18,6 @@ module Spoom
         end
 
         class << self
-          extend T::Sig
-
           #: -> String
           def header_style
             <<~CSS
@@ -122,8 +119,6 @@ module Spoom
         end
 
         class Sigils < Pie
-          extend T::Sig
-
           #: (String id, String title, Snapshot snapshot) -> void
           def initialize(id, title, snapshot)
             super(id, title, snapshot.sigils_excluding_rbis.select { |_k, v| v })
@@ -141,8 +136,6 @@ module Spoom
         end
 
         class Calls < Pie
-          extend T::Sig
-
           #: (String id, String title, Snapshot snapshot) -> void
           def initialize(id, title, snapshot)
             super(id, title, { true: snapshot.calls_typed, false: snapshot.calls_untyped })
@@ -160,8 +153,6 @@ module Spoom
         end
 
         class Sigs < Pie
-          extend T::Sig
-
           #: (String id, String title, Snapshot snapshot) -> void
           def initialize(id, title, snapshot)
             super(

--- a/lib/spoom/coverage/d3/timeline.rb
+++ b/lib/spoom/coverage/d3/timeline.rb
@@ -7,7 +7,6 @@ module Spoom
   module Coverage
     module D3
       class Timeline < Base
-        extend T::Sig
         extend T::Helpers
 
         abstract!
@@ -19,8 +18,6 @@ module Spoom
         end
 
         class << self
-          extend T::Sig
-
           #: -> String
           def header_style
             <<~CSS
@@ -231,8 +228,6 @@ module Spoom
         end
 
         class Versions < Timeline
-          extend T::Sig
-
           #: (String id, Array[Snapshot] snapshots) -> void
           def initialize(id, snapshots)
             data = snapshots.map do |snapshot|
@@ -283,8 +278,6 @@ module Spoom
         end
 
         class Runtimes < Timeline
-          extend T::Sig
-
           #: (String id, Array[Snapshot] snapshots) -> void
           def initialize(id, snapshots)
             data = snapshots.map do |snapshot|
@@ -332,7 +325,6 @@ module Spoom
         end
 
         class Stacked < Timeline
-          extend T::Sig
           extend T::Helpers
 
           abstract!
@@ -427,8 +419,6 @@ module Spoom
         end
 
         class Sigils < Stacked
-          extend T::Sig
-
           #: (String id, Array[Snapshot] snapshots) -> void
           def initialize(id, snapshots)
             keys = Snapshot::STRICTNESSES
@@ -455,8 +445,6 @@ module Spoom
         end
 
         class Calls < Stacked
-          extend T::Sig
-
           #: (String id, Array[Snapshot] snapshots) -> void
           def initialize(id, snapshots)
             keys = ["false", "true"]
@@ -483,8 +471,6 @@ module Spoom
         end
 
         class Sigs < Stacked
-          extend T::Sig
-
           #: (String id, Array[Snapshot] snapshots) -> void
           def initialize(id, snapshots)
             keys = ["false", "true"]
@@ -514,8 +500,6 @@ module Spoom
         end
 
         class RBIs < Stacked
-          extend T::Sig
-
           #: (String id, Array[Snapshot] snapshots) -> void
           def initialize(id, snapshots)
             keys = ["rbis", "files"]

--- a/lib/spoom/coverage/report.rb
+++ b/lib/spoom/coverage/report.rb
@@ -8,7 +8,6 @@ require "erb"
 module Spoom
   module Coverage
     class Template
-      extend T::Sig
       extend T::Helpers
 
       abstract!
@@ -103,7 +102,6 @@ module Spoom
       end
 
       class Erb < Card
-        extend T::Sig
         extend T::Helpers
 
         abstract!
@@ -122,8 +120,6 @@ module Spoom
       end
 
       class Snapshot < Card
-        extend T::Sig
-
         TEMPLATE = T.let("#{Spoom::SPOOM_PATH}/templates/card_snapshot.erb", String)
 
         #: Coverage::Snapshot
@@ -152,8 +148,6 @@ module Spoom
       end
 
       class Map < Card
-        extend T::Sig
-
         #: (file_tree: FileTree, nodes_strictnesses: Hash[FileTree::Node, String?], nodes_strictness_scores: Hash[FileTree::Node, Float], ?title: String) -> void
         def initialize(file_tree:, nodes_strictnesses:, nodes_strictness_scores:, title: "Strictness Map")
           super(
@@ -169,16 +163,12 @@ module Spoom
       end
 
       class Timeline < Card
-        extend T::Sig
-
         #: (title: String, timeline: D3::Timeline) -> void
         def initialize(title:, timeline:)
           super(title: title, body: timeline.html)
         end
 
         class Sigils < Timeline
-          extend T::Sig
-
           #: (snapshots: Array[Coverage::Snapshot], ?title: String) -> void
           def initialize(snapshots:, title: "Sigils Timeline")
             super(title: title, timeline: D3::Timeline::Sigils.new("timeline_sigils", snapshots))
@@ -186,8 +176,6 @@ module Spoom
         end
 
         class Calls < Timeline
-          extend T::Sig
-
           #: (snapshots: Array[Coverage::Snapshot], ?title: String) -> void
           def initialize(snapshots:, title: "Calls Timeline")
             super(title: title, timeline: D3::Timeline::Calls.new("timeline_calls", snapshots))
@@ -195,8 +183,6 @@ module Spoom
         end
 
         class Sigs < Timeline
-          extend T::Sig
-
           #: (snapshots: Array[Coverage::Snapshot], ?title: String) -> void
           def initialize(snapshots:, title: "Signatures Timeline")
             super(title: title, timeline: D3::Timeline::Sigs.new("timeline_sigs", snapshots))
@@ -204,8 +190,6 @@ module Spoom
         end
 
         class RBIs < Timeline
-          extend T::Sig
-
           #: (snapshots: Array[Coverage::Snapshot], ?title: String) -> void
           def initialize(snapshots:, title: "RBIs Timeline")
             super(title: title, timeline: D3::Timeline::RBIs.new("timeline_rbis", snapshots))
@@ -213,8 +197,6 @@ module Spoom
         end
 
         class Versions < Timeline
-          extend T::Sig
-
           #: (snapshots: Array[Coverage::Snapshot], ?title: String) -> void
           def initialize(snapshots:, title: "Sorbet Versions Timeline")
             super(title: title, timeline: D3::Timeline::Versions.new("timeline_versions", snapshots))
@@ -222,8 +204,6 @@ module Spoom
         end
 
         class Runtimes < Timeline
-          extend T::Sig
-
           #: (snapshots: Array[Coverage::Snapshot], ?title: String) -> void
           def initialize(snapshots:, title: "Sorbet Typechecking Time")
             super(title: title, timeline: D3::Timeline::Runtimes.new("timeline_runtimes", snapshots))
@@ -232,8 +212,6 @@ module Spoom
       end
 
       class SorbetIntro < Erb
-        extend T::Sig
-
         #: (?sorbet_intro_commit: String?, ?sorbet_intro_date: Time?) -> void
         def initialize(sorbet_intro_commit: nil, sorbet_intro_date: nil) # rubocop:disable Lint/MissingSuper
           @sorbet_intro_commit = sorbet_intro_commit
@@ -254,8 +232,6 @@ module Spoom
     end
 
     class Report < Page
-      extend T::Sig
-
       #: (project_name: String, palette: D3::ColorPalette, snapshots: Array[Snapshot], file_tree: FileTree, nodes_strictnesses: Hash[FileTree::Node, String?], nodes_strictness_scores: Hash[FileTree::Node, Float], ?sorbet_intro_commit: String?, ?sorbet_intro_date: Time?) -> void
       def initialize(
         project_name:,

--- a/lib/spoom/coverage/snapshot.rb
+++ b/lib/spoom/coverage/snapshot.rb
@@ -4,8 +4,6 @@
 module Spoom
   module Coverage
     class Snapshot < T::Struct
-      extend T::Sig
-
       prop :timestamp, Integer, default: Time.new.getutc.to_i
       prop :version_static, T.nilable(String), default: nil
       prop :version_runtime, T.nilable(String), default: nil
@@ -41,8 +39,6 @@ module Spoom
       end
 
       class << self
-        extend T::Sig
-
         #: (String json) -> Snapshot
         def from_json(json)
           from_obj(JSON.parse(json))
@@ -93,8 +89,6 @@ module Spoom
     end
 
     class SnapshotPrinter < Spoom::Printer
-      extend T::Sig
-
       #: (Snapshot snapshot) -> void
       def print_snapshot(snapshot)
         methods = snapshot.methods_with_sig + snapshot.methods_without_sig

--- a/lib/spoom/deadcode/definition.rb
+++ b/lib/spoom/deadcode/definition.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     # A definition is a class, module, method, constant, etc. being defined in the code
     class Definition < T::Struct
-      extend T::Sig
-
       class Kind < T::Enum
         enums do
           AttrReader = new("attr_reader")

--- a/lib/spoom/deadcode/erb.rb
+++ b/lib/spoom/deadcode/erb.rb
@@ -27,8 +27,6 @@ module Spoom
   module Deadcode
     # Custom engine to handle ERB templates as used by Rails
     class ERB < ::Erubi::Engine
-      extend T::Sig
-
       #: (untyped input, ?untyped properties) -> void
       def initialize(input, properties = {})
         @newline_pending = 0

--- a/lib/spoom/deadcode/index.rb
+++ b/lib/spoom/deadcode/index.rb
@@ -4,11 +4,7 @@
 module Spoom
   module Deadcode
     class Index
-      extend T::Sig
-
       class Error < Spoom::Error
-        extend T::Sig
-
         #: (String message, parent: Exception) -> void
         def initialize(message, parent:)
           super(message)

--- a/lib/spoom/deadcode/indexer.rb
+++ b/lib/spoom/deadcode/indexer.rb
@@ -4,8 +4,6 @@
 module Spoom
   module Deadcode
     class Indexer < Visitor
-      extend T::Sig
-
       #: String
       attr_reader :path
 

--- a/lib/spoom/deadcode/plugins.rb
+++ b/lib/spoom/deadcode/plugins.rb
@@ -55,8 +55,6 @@ module Spoom
     )
 
     class << self
-      extend T::Sig
-
       #: (Context context) -> Set[singleton(Plugins::Base)]
       def plugins_from_gemfile_lock(context)
         # These plugins are always loaded

--- a/lib/spoom/deadcode/plugins/action_mailer.rb
+++ b/lib/spoom/deadcode/plugins/action_mailer.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class ActionMailer < Base
-        extend T::Sig
-
         # @override
         #: (Send send) -> void
         def on_send(send)

--- a/lib/spoom/deadcode/plugins/action_mailer_preview.rb
+++ b/lib/spoom/deadcode/plugins/action_mailer_preview.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class ActionMailerPreview < Base
-        extend T::Sig
-
         ignore_classes_inheriting_from("ActionMailer::Preview")
 
         # @override

--- a/lib/spoom/deadcode/plugins/actionpack.rb
+++ b/lib/spoom/deadcode/plugins/actionpack.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class ActionPack < Base
-        extend T::Sig
-
         ignore_classes_inheriting_from("ApplicationController")
 
         CALLBACKS = T.let(

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveModel < Base
-        extend T::Sig
-
         ignore_classes_inheriting_from("ActiveModel::EachValidator")
         ignore_methods_named("validate_each", "persisted?")
 

--- a/lib/spoom/deadcode/plugins/active_record.rb
+++ b/lib/spoom/deadcode/plugins/active_record.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class ActiveRecord < Base
-        extend T::Sig
-
         ignore_classes_inheriting_from(/^(::)?ActiveRecord::Migration/)
 
         ignore_methods_named(

--- a/lib/spoom/deadcode/plugins/base.rb
+++ b/lib/spoom/deadcode/plugins/base.rb
@@ -7,14 +7,11 @@ module Spoom
   module Deadcode
     module Plugins
       class Base
-        extend T::Sig
         extend T::Helpers
 
         abstract!
 
         class << self
-          extend T::Sig
-
           # Plugins DSL
 
           # Mark classes matching `names` as ignored.

--- a/lib/spoom/deadcode/plugins/graphql.rb
+++ b/lib/spoom/deadcode/plugins/graphql.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class GraphQL < Base
-        extend T::Sig
-
         ignore_classes_inheriting_from(
           "GraphQL::Schema::Enum",
           "GraphQL::Schema::Object",

--- a/lib/spoom/deadcode/plugins/minitest.rb
+++ b/lib/spoom/deadcode/plugins/minitest.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class Minitest < Base
-        extend T::Sig
-
         ignore_classes_named(/Test$/)
 
         ignore_methods_named(

--- a/lib/spoom/deadcode/plugins/namespaces.rb
+++ b/lib/spoom/deadcode/plugins/namespaces.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class Namespaces < Base
-        extend T::Sig
-
         # @override
         #: (Model::Class definition) -> void
         def on_define_class(definition)

--- a/lib/spoom/deadcode/plugins/rails.rb
+++ b/lib/spoom/deadcode/plugins/rails.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class Rails < Base
-        extend T::Sig
-
         ignore_constants_named("APP_PATH", "ENGINE_PATH", "ENGINE_ROOT")
 
         # @override

--- a/lib/spoom/deadcode/plugins/rubocop.rb
+++ b/lib/spoom/deadcode/plugins/rubocop.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class Rubocop < Base
-        extend T::Sig
-
         RUBOCOP_CONSTANTS = T.let(["MSG", "RESTRICT_ON_SEND"].to_set.freeze, T::Set[String])
 
         ignore_classes_inheriting_from(

--- a/lib/spoom/deadcode/plugins/ruby.rb
+++ b/lib/spoom/deadcode/plugins/ruby.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class Ruby < Base
-        extend T::Sig
-
         ignore_methods_named(
           "==",
           "extended",

--- a/lib/spoom/deadcode/plugins/sorbet.rb
+++ b/lib/spoom/deadcode/plugins/sorbet.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class Sorbet < Base
-        extend T::Sig
-
         # @override
         #: (Model::Constant definition) -> void
         def on_define_constant(definition)

--- a/lib/spoom/deadcode/plugins/thor.rb
+++ b/lib/spoom/deadcode/plugins/thor.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     module Plugins
       class Thor < Base
-        extend T::Sig
-
         ignore_methods_named("exit_on_failure?")
 
         # @override

--- a/lib/spoom/deadcode/remover.rb
+++ b/lib/spoom/deadcode/remover.rb
@@ -4,8 +4,6 @@
 module Spoom
   module Deadcode
     class Remover
-      extend T::Sig
-
       class Error < Spoom::Error; end
 
       #: (Context context) -> void
@@ -27,8 +25,6 @@ module Spoom
       end
 
       class NodeRemover
-        extend T::Sig
-
         #: String
         attr_reader :new_source
 
@@ -364,8 +360,6 @@ module Spoom
       end
 
       class NodeContext
-        extend T::Sig
-
         #: Hash[Integer, Prism::Comment]
         attr_reader :comments
 
@@ -534,11 +528,7 @@ module Spoom
       end
 
       class NodeFinder < Visitor
-        extend T::Sig
-
         class << self
-          extend T::Sig
-
           #: (String source, Location location, Definition::Kind? kind) -> NodeContext
           def find(source, location, kind)
             result = Prism.parse(source)

--- a/lib/spoom/deadcode/send.rb
+++ b/lib/spoom/deadcode/send.rb
@@ -5,8 +5,6 @@ module Spoom
   module Deadcode
     # An abstraction to simplify handling of Prism::CallNode nodes.
     class Send < T::Struct
-      extend T::Sig
-
       const :node, Prism::CallNode
       const :name, String
       const :recv, T.nilable(Prism::Node), default: nil

--- a/lib/spoom/file_collector.rb
+++ b/lib/spoom/file_collector.rb
@@ -3,8 +3,6 @@
 
 module Spoom
   class FileCollector
-    extend T::Sig
-
     #: Array[String]
     attr_reader :files
 

--- a/lib/spoom/file_tree.rb
+++ b/lib/spoom/file_tree.rb
@@ -4,8 +4,6 @@
 module Spoom
   # Build a file hierarchy from a set of file paths.
   class FileTree
-    extend T::Sig
-
     #: (?T::Enumerable[String] paths) -> void
     def initialize(paths = [])
       @roots = T.let({}, T::Hash[String, Node])
@@ -76,8 +74,6 @@ module Spoom
 
     # A node representing either a file or a directory inside a FileTree
     class Node < T::Struct
-      extend T::Sig
-
       # Node parent or `nil` if the node is a root one
       const :parent, T.nilable(Node)
 
@@ -99,7 +95,6 @@ module Spoom
 
     # An abstract visitor for FileTree
     class Visitor
-      extend T::Sig
       extend T::Helpers
 
       abstract!
@@ -122,8 +117,6 @@ module Spoom
 
     # A visitor that collects all the nodes in a tree
     class CollectNodes < Visitor
-      extend T::Sig
-
       #: Array[FileTree::Node]
       attr_reader :nodes
 
@@ -143,8 +136,6 @@ module Spoom
 
     # A visitor that collects the strictness of each node in a tree
     class CollectStrictnesses < Visitor
-      extend T::Sig
-
       #: Hash[Node, String?]
       attr_reader :strictnesses
 
@@ -167,8 +158,6 @@ module Spoom
 
     # A visitor that collects the typing score of each node in a tree
     class CollectScores < CollectStrictnesses
-      extend T::Sig
-
       #: Hash[Node, Float]
       attr_reader :scores
 
@@ -213,8 +202,6 @@ module Spoom
     #
     # See `FileTree#print`
     class Printer < Visitor
-      extend T::Sig
-
       #: (Hash[FileTree::Node, String?] strictnesses, ?out: (IO | StringIO), ?colors: bool) -> void
       def initialize(strictnesses, out: $stdout, colors: true)
         super()

--- a/lib/spoom/location.rb
+++ b/lib/spoom/location.rb
@@ -3,15 +3,11 @@
 
 module Spoom
   class Location
-    extend T::Sig
-
     include Comparable
 
     class LocationError < Spoom::Error; end
 
     class << self
-      extend T::Sig
-
       #: (String location_string) -> Location
       def from_string(location_string)
         file, rest = location_string.split(":", 2)

--- a/lib/spoom/model/builder.rb
+++ b/lib/spoom/model/builder.rb
@@ -5,8 +5,6 @@ module Spoom
   class Model
     # Populate a Model by visiting the nodes from a Ruby file
     class Builder < NamespaceVisitor
-      extend T::Sig
-
       #: (Model model, String file, ?comments: Array[Prism::Comment]) -> void
       def initialize(model, file, comments:)
         super()

--- a/lib/spoom/model/model.rb
+++ b/lib/spoom/model/model.rb
@@ -3,13 +3,9 @@
 
 module Spoom
   class Model
-    extend T::Sig
-
     class Error < Spoom::Error; end
 
     class Comment
-      extend T::Sig
-
       #: String
       attr_reader :string
 
@@ -29,8 +25,6 @@ module Spoom
     # Sometimes a symbol can have multiple definitions of different types,
     # e.g. `foo` method can be defined both as a method and as an attribute accessor.
     class Symbol
-      extend T::Sig
-
       # The full, unique name of this symbol
       #: String
       attr_reader :full_name
@@ -70,7 +64,6 @@ module Spoom
     # It can be a class, module, constant, method, etc.
     # A SymbolDef has a location pointing to the actual code that defines the symbol.
     class SymbolDef
-      extend T::Sig
       extend T::Helpers
 
       abstract!
@@ -201,7 +194,6 @@ module Spoom
 
     # A mixin (include, prepend, extend) to a namespace
     class Mixin
-      extend T::Sig
       extend T::Helpers
 
       abstract!
@@ -221,8 +213,6 @@ module Spoom
 
     # A Sorbet signature (sig block)
     class Sig
-      extend T::Sig
-
       #: String
       attr_reader :string
 

--- a/lib/spoom/model/reference.rb
+++ b/lib/spoom/model/reference.rb
@@ -8,8 +8,6 @@ module Spoom
     # Constants could be classes, modules, or actual constants.
     # Methods could be accessors, instance or class methods, aliases, etc.
     class Reference < T::Struct
-      extend T::Sig
-
       class Kind < T::Enum
         enums do
           Constant = new("constant")
@@ -18,8 +16,6 @@ module Spoom
       end
 
       class << self
-        extend T::Sig
-
         #: (String name, Spoom::Location location) -> Reference
         def constant(name, location)
           new(name: name, kind: Kind::Constant, location: location)

--- a/lib/spoom/model/references_visitor.rb
+++ b/lib/spoom/model/references_visitor.rb
@@ -5,8 +5,6 @@ module Spoom
   class Model
     # Visit a file to collect all the references to constants and methods
     class ReferencesVisitor < Visitor
-      extend T::Sig
-
       #: Array[Reference]
       attr_reader :references
 

--- a/lib/spoom/parse.rb
+++ b/lib/spoom/parse.rb
@@ -7,8 +7,6 @@ module Spoom
   class ParseError < Error; end
 
   class << self
-    extend T::Sig
-
     #: (String ruby, file: String) -> Prism::Node
     def parse_ruby(ruby, file:)
       result = Prism.parse(ruby)

--- a/lib/spoom/poset.rb
+++ b/lib/spoom/poset.rb
@@ -7,7 +7,6 @@ module Spoom
   # The partial order relation is a binary relation that is reflexive, antisymmetric, and transitive.
   # It can be used to represent a hierarchy of classes or modules, the dependencies between gems, etc.
   class Poset
-    extend T::Sig
     extend T::Generic
 
     class Error < Spoom::Error; end
@@ -134,7 +133,6 @@ module Spoom
 
     # An element in a POSet
     class Element
-      extend T::Sig
       extend T::Generic
       include Comparable
 

--- a/lib/spoom/printer.rb
+++ b/lib/spoom/printer.rb
@@ -5,8 +5,6 @@ require "stringio"
 
 module Spoom
   class Printer
-    extend T::Helpers
-
     include Colorize
 
     #: (IO | StringIO)

--- a/lib/spoom/printer.rb
+++ b/lib/spoom/printer.rb
@@ -5,7 +5,6 @@ require "stringio"
 
 module Spoom
   class Printer
-    extend T::Sig
     extend T::Helpers
 
     include Colorize

--- a/lib/spoom/sorbet.rb
+++ b/lib/spoom/sorbet.rb
@@ -13,8 +13,6 @@ require "open3"
 module Spoom
   module Sorbet
     class Error < Spoom::Error
-      extend T::Sig
-
       class Killed < Error; end
       class Segfault < Error; end
 

--- a/lib/spoom/sorbet/assertions.rb
+++ b/lib/spoom/sorbet/assertions.rb
@@ -7,8 +7,6 @@ module Spoom
   module Sorbet
     class Assertions
       class << self
-        extend T::Sig
-
         #: (String, file: String) -> String
         def rbi_to_rbs(ruby_contents, file:)
           old_encoding = ruby_contents.encoding
@@ -122,8 +120,6 @@ module Spoom
       end
 
       class AssignNode
-        extend T::Sig
-
         #: AssignType
         attr_reader :node
 
@@ -148,8 +144,6 @@ module Spoom
       end
 
       class Locator < Spoom::Visitor
-        extend T::Sig
-
         ANNOTATION_METHODS = T.let([:let], T::Array[Symbol])
 
         #: Array[AssignNode]
@@ -255,8 +249,6 @@ module Spoom
         end
 
         class HeredocVisitor < Spoom::Visitor
-          extend T::Sig
-
           #: bool
           attr_reader :contains_heredoc
 

--- a/lib/spoom/sorbet/config.rb
+++ b/lib/spoom/sorbet/config.rb
@@ -24,8 +24,6 @@ module Spoom
     # puts config.ignore  # "c"
     # ```
     class Config
-      extend T::Sig
-
       DEFAULT_ALLOWED_EXTENSIONS = T.let([".rb", ".rbi"].freeze, T::Array[String])
 
       #: Array[String]
@@ -75,8 +73,6 @@ module Spoom
       end
 
       class << self
-        extend T::Sig
-
         #: (String sorbet_config_path) -> Spoom::Sorbet::Config
         def parse_file(sorbet_config_path)
           parse_string(File.read(sorbet_config_path))

--- a/lib/spoom/sorbet/errors.rb
+++ b/lib/spoom/sorbet/errors.rb
@@ -7,8 +7,6 @@ module Spoom
       DEFAULT_ERROR_URL_BASE = "https://srb.help/"
 
       class << self
-        extend T::Sig
-
         #: (Array[Error] errors) -> Array[Error]
         def sort_errors_by_code(errors)
           errors.sort_by { |e| [e.code, e.file, e.line, e.message] }
@@ -16,8 +14,6 @@ module Spoom
       end
       # Parse errors from Sorbet output
       class Parser
-        extend T::Sig
-
         class ParseError < Spoom::Error; end
 
         HEADER = T.let(
@@ -32,8 +28,6 @@ module Spoom
         )
 
         class << self
-          extend T::Sig
-
           #: (String output, ?error_url_base: String) -> Array[Error]
           def parse_string(output, error_url_base: DEFAULT_ERROR_URL_BASE)
             parser = Spoom::Sorbet::Errors::Parser.new(error_url_base: error_url_base)
@@ -126,7 +120,6 @@ module Spoom
 
       class Error
         include Comparable
-        extend T::Sig
 
         #: String?
         attr_reader :file, :message

--- a/lib/spoom/sorbet/lsp.rb
+++ b/lib/spoom/sorbet/lsp.rb
@@ -11,8 +11,6 @@ require_relative "lsp/errors"
 module Spoom
   module LSP
     class Client
-      extend T::Sig
-
       #: (String sorbet_bin, *String sorbet_args, ?path: String) -> void
       def initialize(sorbet_bin, *sorbet_args, path: ".")
         @id = T.let(0, Integer)

--- a/lib/spoom/sorbet/lsp/base.rb
+++ b/lib/spoom/sorbet/lsp/base.rb
@@ -10,8 +10,6 @@ module Spoom
     #
     # The language server protocol always uses `"2.0"` as the `jsonrpc` version.
     class Message
-      extend T::Sig
-
       #: -> void
       def initialize
         @jsonrpc = T.let("2.0", String)
@@ -35,8 +33,6 @@ module Spoom
     #
     # Every processed request must send a response back to the sender of the request.
     class Request < Message
-      extend T::Sig
-
       #: Integer
       attr_reader :id
 
@@ -56,8 +52,6 @@ module Spoom
     #
     # A processed notification message must not send a response back. They work like events.
     class Notification < Message
-      extend T::Sig
-
       #: String
       attr_reader :method
 

--- a/lib/spoom/sorbet/lsp/errors.rb
+++ b/lib/spoom/sorbet/lsp/errors.rb
@@ -8,8 +8,6 @@ module Spoom
       class BadHeaders < Error; end
 
       class Diagnostics < Error
-        extend T::Sig
-
         #: String
         attr_reader :uri
 
@@ -17,8 +15,6 @@ module Spoom
         attr_reader :diagnostics
 
         class << self
-          extend T::Sig
-
           #: (Hash[untyped, untyped] json) -> Diagnostics
           def from_json(json)
             Diagnostics.new(
@@ -38,8 +34,6 @@ module Spoom
     end
 
     class ResponseError < Error
-      extend T::Sig
-
       #: Integer
       attr_reader :code
 
@@ -47,8 +41,6 @@ module Spoom
       attr_reader :data
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> ResponseError
         def from_json(json)
           ResponseError.new(

--- a/lib/spoom/sorbet/lsp/structures.rb
+++ b/lib/spoom/sorbet/lsp/structures.rb
@@ -17,15 +17,12 @@ module Spoom
     end
 
     class Hover < T::Struct
-      extend T::Sig
       include PrintableSymbol
 
       const :contents, String
       const :range, T.nilable(Range)
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> Hover
         def from_json(json)
           Hover.new(
@@ -49,15 +46,12 @@ module Spoom
     end
 
     class Position < T::Struct
-      extend T::Sig
       include PrintableSymbol
 
       const :line, Integer
       const :char, Integer
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> Position
         def from_json(json)
           Position.new(
@@ -80,15 +74,12 @@ module Spoom
     end
 
     class Range < T::Struct
-      extend T::Sig
       include PrintableSymbol
 
       const :start, Position
       const :end, Position
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> Range
         def from_json(json)
           Range.new(
@@ -113,15 +104,12 @@ module Spoom
     end
 
     class Location < T::Struct
-      extend T::Sig
       include PrintableSymbol
 
       const :uri, String
       const :range, LSP::Range
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> Location
         def from_json(json)
           Location.new(
@@ -145,7 +133,6 @@ module Spoom
     end
 
     class SignatureHelp < T::Struct
-      extend T::Sig
       include PrintableSymbol
 
       const :label, T.nilable(String)
@@ -153,8 +140,6 @@ module Spoom
       const :params, T::Array[T.untyped] # TODO
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> SignatureHelp
         def from_json(json)
           SignatureHelp.new(
@@ -181,7 +166,6 @@ module Spoom
     end
 
     class Diagnostic < T::Struct
-      extend T::Sig
       include PrintableSymbol
 
       const :range, LSP::Range
@@ -190,8 +174,6 @@ module Spoom
       const :information, Object
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> Diagnostic
         def from_json(json)
           Diagnostic.new(
@@ -216,7 +198,6 @@ module Spoom
     end
 
     class DocumentSymbol < T::Struct
-      extend T::Sig
       include PrintableSymbol
 
       const :name, String
@@ -227,8 +208,6 @@ module Spoom
       const :children, T::Array[DocumentSymbol]
 
       class << self
-        extend T::Sig
-
         #: (Hash[untyped, untyped] json) -> DocumentSymbol
         def from_json(json)
           DocumentSymbol.new(
@@ -314,8 +293,6 @@ module Spoom
     end
 
     class SymbolPrinter < Printer
-      extend T::Sig
-
       #: Set[Integer]
       attr_reader :seen
 

--- a/lib/spoom/sorbet/metrics.rb
+++ b/lib/spoom/sorbet/metrics.rb
@@ -9,8 +9,6 @@ module Spoom
       DEFAULT_PREFIX = "ruby_typer.unknown."
 
       class << self
-        extend T::Sig
-
         #: (String path, ?String prefix) -> Hash[String, Integer]
         def parse_file(path, prefix = DEFAULT_PREFIX)
           parse_string(File.read(path), prefix)

--- a/lib/spoom/sorbet/sigils.rb
+++ b/lib/spoom/sorbet/sigils.rb
@@ -7,8 +7,6 @@
 module Spoom
   module Sorbet
     module Sigils
-      extend T::Sig
-
       STRICTNESS_IGNORE = "ignore"
       STRICTNESS_FALSE = "false"
       STRICTNESS_TRUE = "true"
@@ -31,8 +29,6 @@ module Spoom
       SIGIL_REGEXP = T.let(/^#[[:blank:]]*typed:[[:blank:]]*(\S*)/, Regexp)
 
       class << self
-        extend T::Sig
-
         # returns the full sigil comment string for the passed strictness
         #: (String strictness) -> String
         def sigil_string(strictness)

--- a/lib/spoom/sorbet/sigs.rb
+++ b/lib/spoom/sorbet/sigs.rb
@@ -7,8 +7,6 @@ module Spoom
   module Sorbet
     class Sigs
       class << self
-        extend T::Sig
-
         #: (String ruby_contents) -> String
         def strip(ruby_contents)
           sigs = collect_sigs(ruby_contents)
@@ -54,8 +52,6 @@ module Spoom
       end
 
       class SigsLocator < RBI::Visitor
-        extend T::Sig
-
         #: Array[[RBI::Sig, (RBI::Method | RBI::Attr)]]
         attr_reader :sigs
 
@@ -85,8 +81,6 @@ module Spoom
 
       class SigTranslator
         class << self
-          extend T::Sig
-
           #: (RBI::Sig sig, (RBI::Method | RBI::Attr) node) -> String
           def translate(sig, node)
             case node
@@ -146,8 +140,6 @@ module Spoom
 
       # From https://github.com/Shopify/ruby-lsp/blob/9154bfc6ef/lib/ruby_lsp/document.rb#L127
       class Scanner
-        extend T::Sig
-
         LINE_BREAK = T.let(0x0A, Integer)
 
         #: (String source) -> void

--- a/lib/spoom/timeline.rb
+++ b/lib/spoom/timeline.rb
@@ -3,8 +3,6 @@
 
 module Spoom
   class Timeline
-    extend T::Sig
-
     #: (Context context, Time from, Time to) -> void
     def initialize(context, from, to)
       @context = context

--- a/lib/spoom/visitor.rb
+++ b/lib/spoom/visitor.rb
@@ -5,8 +5,6 @@ require "prism"
 
 module Spoom
   class Visitor < Prism::Visitor
-    extend T::Sig
-
     # @override
     #: (Prism::Node node) -> void
     def visit_child_nodes(node)

--- a/test/helpers/deadcode_helper.rb
+++ b/test/helpers/deadcode_helper.rb
@@ -7,7 +7,6 @@ module Spoom
   module Test
     module Helpers
       module DeadcodeHelper
-        extend T::Sig
         extend T::Helpers
 
         requires_ancestor { TestWithProject }

--- a/test/spoom/cli/srb/coverage_test.rb
+++ b/test/spoom/cli/srb/coverage_test.rb
@@ -7,7 +7,6 @@ module Spoom
   module Cli
     module Srb
       class CoverageTest < TestWithProject
-        extend T::Sig
         include Spoom::TestHelper
 
         def setup

--- a/test/spoom/file_collector_test.rb
+++ b/test/spoom/file_collector_test.rb
@@ -6,8 +6,6 @@ require "test_helper"
 module Spoom
   module Sorbet
     class FileCollectorTest < Minitest::Test
-      extend T::Sig
-
       def test_collect_files_empty_dir
         context = Context.mktmp!
 

--- a/test/spoom/model/builder_test.rb
+++ b/test/spoom/model/builder_test.rb
@@ -6,8 +6,6 @@ require "test_helper"
 module Spoom
   class Model
     class BuilderTest < Minitest::Test
-      extend T::Sig
-
       def test_empty
         model = model("")
 

--- a/test/spoom/model/model_test.rb
+++ b/test/spoom/model/model_test.rb
@@ -6,8 +6,6 @@ require "test_helper"
 module Spoom
   class Model
     class ModelTest < Minitest::Test
-      extend T::Sig
-
       def test_resolve_symbol
         model = model(<<~RB)
           module Foo

--- a/test/spoom/model/namespace_visitor_test.rb
+++ b/test/spoom/model/namespace_visitor_test.rb
@@ -6,8 +6,6 @@ require "test_helper"
 module Spoom
   class Model
     class NamespaceVisitorTest < Minitest::Test
-      extend T::Sig
-
       class NamespacesForLocs < NamespaceVisitor
         #: Hash[String, String]
         attr_reader :namespaces_for_locs

--- a/test/spoom/model/references_visitor_test.rb
+++ b/test/spoom/model/references_visitor_test.rb
@@ -6,8 +6,6 @@ require "test_helper"
 module Spoom
   class Model
     class ReferencesVisitorTest < Minitest::Test
-      extend T::Sig
-
       def test_visit_constant_references
         refs = visit(<<~RB)
           puts C1

--- a/test/spoom/snapshot_test.rb
+++ b/test/spoom/snapshot_test.rb
@@ -6,7 +6,6 @@ require "test_helper"
 module Spoom
   module Sorbet
     class SnapshotTest < Minitest::Test
-      extend T::Sig
       include Spoom::TestHelper
 
       def test_serialize_snapshot_empty

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,6 @@ require "test_project"
 
 module Spoom
   module TestHelper
-    extend T::Sig
     extend T::Helpers
 
     requires_ancestor { Minitest::Test }

--- a/test/test_project.rb
+++ b/test/test_project.rb
@@ -3,8 +3,6 @@
 
 module Spoom
   class TestProject < Context
-    extend T::Helpers
-
     #: (String command) -> ExecResult
     def spoom(command)
       bundle_exec("spoom #{command}")

--- a/test/test_project.rb
+++ b/test/test_project.rb
@@ -3,7 +3,6 @@
 
 module Spoom
   class TestProject < Context
-    extend T::Sig
     extend T::Helpers
 
     #: (String command) -> ExecResult

--- a/test/test_with_project.rb
+++ b/test/test_with_project.rb
@@ -5,7 +5,6 @@ require "test_helper"
 
 module Spoom
   class TestWithProject < Minitest::Test
-    extend T::Sig
     extend T::Helpers
     include TestHelper
 


### PR DESCRIPTION
Since we now use RBS comments for signatures most of them are useless.