### PR TITLE
Add option to generate RBS sigs without positional names

### DIFF
--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -12,6 +12,11 @@ module Spoom
         desc "translate", "Translate signatures from/to RBI and RBS"
         option :from, type: :string, aliases: :f, desc: "From format", enum: ["rbi", "rbs"], default: "rbi"
         option :to, type: :string, aliases: :t, desc: "To format", enum: ["rbi", "rbs"], default: "rbs"
+        option :positional_names,
+          type: :boolean,
+          aliases: :p,
+          desc: "Use positional names when translating from RBI to RBS",
+          default: true
         def translate(*paths)
           from = options[:from]
           to = options[:to]
@@ -29,7 +34,7 @@ module Spoom
           case from
           when "rbi"
             transformed_files = transform_files(files) do |_file, contents|
-              Spoom::Sorbet::Sigs.rbi_to_rbs(contents)
+              Spoom::Sorbet::Sigs.rbi_to_rbs(contents, positional_names: options[:positional_names])
             end
           when "rbs"
             transformed_files = transform_files(files) do |_file, contents|

--- a/test/spoom/cli/srb/sigs_test.rb
+++ b/test/spoom/cli/srb/sigs_test.rb
@@ -51,7 +51,7 @@ module Spoom
           RB
         end
 
-        # translate
+        # translate --from rbi --to rbs
 
         def test_translate_from_and_to_cannot_be_the_same
           result = @project.spoom("srb sigs translate --from rbs --to rbs --no-color")
@@ -159,6 +159,23 @@ module Spoom
             # Some content with accentuated characters: éàèù
             #: -> void
             def foo; end
+          RB
+        end
+
+        def test_translate_without_positional_names
+          @project.write!("file.rb", <<~RB)
+            sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer).void }
+            def foo(a, b = 42, *c, d:, e: 42, **f); end
+          RB
+
+          result = @project.spoom("srb sigs translate --no-color file.rb --no-positional-names")
+
+          assert_empty(result.err)
+          assert(result.status)
+
+          assert_equal(<<~RB, @project.read("file.rb"))
+            #: (Integer, ?Integer, *Integer, d: Integer, ?e: Integer, **Integer f) -> void
+            def foo(a, b = 42, *c, d:, e: 42, **f); end
           RB
         end
 

--- a/test/spoom/sorbet/sigs_test.rb
+++ b/test/spoom/sorbet/sigs_test.rb
@@ -132,6 +132,22 @@ module Spoom
         RBS
       end
 
+      def test_translate_method_sigs_to_rbs_without_positional_names
+        contents = <<~RBI
+          class A
+            sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer).void }
+            def initialize(a, b = 42, *c, d:, e: 42, **f); end
+          end
+        RBI
+
+        assert_equal(<<~RBS, Sigs.rbi_to_rbs(contents, positional_names: false))
+          class A
+            #: (Integer, ?Integer, *Integer, d: Integer, ?e: Integer, **Integer f) -> void
+            def initialize(a, b = 42, *c, d:, e: 42, **f); end
+          end
+        RBS
+      end
+
       def test_translate_to_rbs_method_sigs_with_annotations
         contents = <<~RB
           sig(:final) { overridable.override(allow_incompatible: true).void }


### PR DESCRIPTION
In RBS, positional parameter names are optional yet we always add them when automatically translating.

This PR adds a `--no-positional-names` so they can be omitted.