### PR TITLE
Bump rbi requirement to v0.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     spoom (1.6.1)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
-      rbi (>= 0.2.3)
+      rbi (>= 0.3.1)
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
 

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("erubi", ">= 1.10.0")
   spec.add_dependency("prism", ">= 0.28.0")
-  spec.add_dependency("rbi", ">= 0.2.3")
+  spec.add_dependency("rbi", ">= 0.3.1")
   spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.10187")
   spec.add_dependency("thor", ">= 0.19.2")
 


### PR DESCRIPTION
We rely on some features from 0.3.0 and some fixes from 0.3.1.