### PR TITLE
docs: add translate command examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ Count the number of type-checking errors if all files were bumped to true:
 $ spoom srb bump --count-errors --dry
 ```
 
+#### Translate sigs between RBI and RBS
+
+Translate all file sigs from RBI to RBS:
+
+```
+$ spoom srb sigs translate
+```
+
+Translate one file's sigs from RBS to RBI:
+
+```
+$ spoom srb sigs translate --from rbs --to rbi /path/to/file.rb
+```
+
 #### Interact with Sorbet LSP mode
 
 **Experimental**


### PR DESCRIPTION
I remembered that there was a way to use spoom to translate sigs, but had to hunt for the exact command. This PR just adds a call out to the README to make it more discoverable. Happy to close if we don't want to expose this command on the README yet.