### PR TITLE
Add feature to generate JUnit XML output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
       rbi (>= 0.3.1)
+      rexml (>= 3.2.6)
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
 
@@ -57,6 +58,7 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    rexml (3.4.1)
     rubocop (1.75.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2725,6 +2725,9 @@ module Spoom::Sorbet::Errors
   class << self
     sig { params(errors: T::Array[::Spoom::Sorbet::Errors::Error]).returns(T::Array[::Spoom::Sorbet::Errors::Error]) }
     def sort_errors_by_code(errors); end
+
+    sig { params(errors: T::Array[::Spoom::Sorbet::Errors::Error]).returns(::REXML::Document) }
+    def to_junit_xml(errors); end
   end
 end
 
@@ -2762,6 +2765,9 @@ class Spoom::Sorbet::Errors::Error
 
   sig { returns(T::Array[::String]) }
   def more; end
+
+  sig { returns(::REXML::Element) }
+  def to_junit_xml_element; end
 
   sig { returns(::String) }
   def to_s; end

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("erubi", ">= 1.10.0")
   spec.add_dependency("prism", ">= 0.28.0")
   spec.add_dependency("rbi", ">= 0.3.1")
+  spec.add_dependency("rexml", ">= 3.2.6")
   spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.10187")
   spec.add_dependency("thor", ">= 0.19.2")
 


### PR DESCRIPTION
# Background

It's common to use the [JUnit plugin](https://plugins.jenkins.io/junit/) on Jenkins to consume machine-readable output about the tests in your CI builds. For example, on our Ruby app tests we use the [rspec_junit_formatter](https://rubygems.org/gems/rspec_junit_formatter/) to output results from RSpec in a format that Jenkins can consume.

# What

This PR adds JUnit style XML output as an option to Spoom so that running Sorbet in CI on Jenkins can output error information that can be displayed natively by Jenkins (and then, in turn, passed along to e.g. Github's interface).

With these changes Sorbet failures on a build look like this:

![Screenshot 2025-04-03 at 3 04 34 PM](https://github.com/user-attachments/assets/a33a0ecb-8115-4d92-946a-4e5ba073ef8b)

and a clean Sorbet build looks like this:

![Screenshot 2025-04-03 at 2 53 32 PM](https://github.com/user-attachments/assets/ac714e4b-ed0c-44cf-ac52-f1ebdaaf8d78)

# TODO

I'm happy to add docs for this feature as well, but I wanted to get initial review of the feature going sooner rather than later.

