### PR TITLE
Avoid deleting comments when the comment is not an annotation

### DIFF
--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
@@ -132,7 +132,6 @@ module Spoom
             comments.annotations.reverse_each do |annotation|
               from = adjust_to_line_start(annotation.location.start_offset)
               to = adjust_to_line_end(annotation.location.end_offset)
-              @rewriter << Source::Delete.new(from, to)
 
               content = case annotation.string
               when "@abstract"
@@ -147,7 +146,11 @@ module Spoom
                 srb_type = ::RBS::Parser.parse_type(annotation.string.delete_prefix("@requires_ancestor: "))
                 rbs_type = RBI::RBS::TypeTranslator.translate(srb_type)
                 "requires_ancestor { #{rbs_type} }"
+              else
+                next
               end
+
+              @rewriter << Source::Delete.new(from, to)
 
               newline = node.body.nil? ? "" : "\n"
               @rewriter << Source::Insert.new(insert_pos, "\n#{indent}#{content}#{newline}")

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -283,6 +283,31 @@ module Spoom
           RB
         end
 
+        def test_translate_to_rbi_helpers_with_right_order
+          contents = <<~RB
+            # @foo
+            # @bar
+            # @requires_ancestor: Kernel
+            module Baz
+              #: -> void
+              def foo; end
+            end
+          RB
+
+          assert_equal(<<~RB, rbs_comments_to_sorbet_sigs(contents))
+            # @foo
+            # @bar
+            module Baz
+              extend T::Helpers
+
+              requires_ancestor { Kernel }
+
+              sig { void }
+              def foo; end
+            end
+          RB
+        end
+
         def test_translate_to_rbi_generics
           contents = <<~RB
             #: [in A, out B]


### PR DESCRIPTION
We should not add delete edits whenever we see `@` in the comment. This could cause incorrect ordering in the generated RBI. This commit fixes it by only adding delete edits when we see an annotation.