### PR TITLE
Mark ActiveJob::Callbacks as alive

### DIFF
--- a/lib/spoom/deadcode/plugins/active_job.rb
+++ b/lib/spoom/deadcode/plugins/active_job.rb
@@ -7,6 +7,25 @@ module Spoom
       class ActiveJob < Base
         ignore_classes_named("ApplicationJob")
         ignore_methods_named("perform", "build_enumerator", "each_iteration")
+
+        CALLBACKS = [
+          "after_enqueue",
+          "after_perform",
+          "around_enqueue",
+          "around_perform",
+          "before_enqueue",
+          "before_perform",
+        ].freeze
+
+        # @override
+        #: (Send send) -> void
+        def on_send(send)
+          return unless send.recv.nil? && CALLBACKS.include?(send.name)
+
+          send.each_arg(Prism::SymbolNode) do |arg|
+            @index.reference_method(arg.unescaped, send.location)
+          end
+        end
       end
     end
   end

--- a/test/spoom/deadcode/plugins/active_job_test.rb
+++ b/test/spoom/deadcode/plugins/active_job_test.rb
@@ -49,6 +49,36 @@ module Spoom
           )
         end
 
+        def test_ignore_active_job_callbacks
+          @project.write!("app/jobs/foo.rb", <<~RB)
+            class FooJob
+              after_enqueue(:ignored1)
+              after_perform(:ignored2)
+              around_enqueue(:ignored3)
+              around_perform(:ignored4)
+              before_enqueue(:ignored5)
+              before_perform(:ignored6)
+
+              def ignored1; end
+              def ignored2; end
+              def ignored3; end
+              def ignored4; end
+              def ignored5; end
+              def ignored6; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "ignored1")
+          assert_alive(index, "ignored2")
+          assert_alive(index, "ignored3")
+          assert_alive(index, "ignored4")
+          assert_alive(index, "ignored5")
+          assert_alive(index, "ignored6")
+          assert_dead(index, "dead")
+        end
+
         private
 
         #: -> Deadcode::Index


### PR DESCRIPTION
See https://api.rubyonrails.org/v7.1/classes/ActiveJob/Callbacks/ClassMethods.html.