### PR TITLE
Fix incorrect `extend T::Helpers` for foreign annotations

### DIFF
--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
@@ -48,7 +48,7 @@ module Spoom
             translator = RBI::RBS::MethodTypeTranslator.new(rbi_node)
             translator.visit(method_type)
             sig = translator.result
-            apply_member_annotations(comments.annotations, sig)
+            apply_member_annotations(comments.method_annotations, sig)
 
             @rewriter << Source::Replace.new(
               signature.location.start_offset,
@@ -99,7 +99,7 @@ module Spoom
 
             sig.return_type = RBI::RBS::TypeTranslator.translate(attr_type)
 
-            apply_member_annotations(comments.annotations, sig)
+            apply_member_annotations(comments.method_annotations, sig)
 
             @rewriter << Source::Replace.new(
               signature.location.start_offset,
@@ -127,12 +127,13 @@ module Spoom
             node.expression.location.end_offset
           end
 
-          if comments.annotations.any?
+          class_annotations = comments.class_annotations
+          if class_annotations.any?
             unless already_extends?(node, /^(::)?T::Helpers$/)
               @rewriter << Source::Insert.new(insert_pos, "\n#{indent}extend T::Helpers\n")
             end
 
-            comments.annotations.reverse_each do |annotation|
+            class_annotations.reverse_each do |annotation|
               from = adjust_to_line_start(annotation.location.start_offset)
               to = adjust_to_line_end(annotation.location.end_offset)
 
@@ -209,7 +210,7 @@ module Spoom
           end
         end
 
-        #: (Array[RBS::Annotations], RBI::Sig) -> void
+        #: (Array[RBS::Annotation], RBI::Sig) -> void
         def apply_member_annotations(annotations, sig)
           annotations.each do |annotation|
             case annotation.string

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2579,7 +2579,7 @@ class Spoom::Printer
 end
 
 module Spoom::RBS; end
-class Spoom::RBS::Annotations < ::Spoom::RBS::Comment; end
+class Spoom::RBS::Annotation < ::Spoom::RBS::Comment; end
 
 class Spoom::RBS::Comment
   sig { params(string: ::String, location: ::Prism::Location).void }
@@ -2596,11 +2596,17 @@ class Spoom::RBS::Comments
   sig { void }
   def initialize; end
 
-  sig { returns(T::Array[::Spoom::RBS::Annotations]) }
+  sig { returns(T::Array[::Spoom::RBS::Annotation]) }
   def annotations; end
+
+  sig { returns(T::Array[::Spoom::RBS::Annotation]) }
+  def class_annotations; end
 
   sig { returns(T::Boolean) }
   def empty?; end
+
+  sig { returns(T::Array[::Spoom::RBS::Annotation]) }
+  def method_annotations; end
 
   sig { returns(T::Array[::Spoom::RBS::Signature]) }
   def signatures; end
@@ -2914,7 +2920,7 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs < ::Spoom::Sorbet::Trans
   sig { params(node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode)).void }
   def apply_class_annotations(node); end
 
-  sig { params(annotations: T::Array[::Spoom::RBS::Annotations], sig: ::RBI::Sig).void }
+  sig { params(annotations: T::Array[::Spoom::RBS::Annotation], sig: ::RBI::Sig).void }
   def apply_member_annotations(annotations, sig); end
 
   sig { params(node: ::Prism::CallNode).void }

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -283,6 +283,16 @@ module Spoom
           RB
         end
 
+        def test_translate_to_rbi_does_not_insert_t_helpers_for_random_annotations
+          contents = <<~RB
+            # @private
+            class Foo
+            end
+          RB
+
+          assert_equal(contents, rbs_comments_to_sorbet_sigs(contents))
+        end
+
         def test_translate_to_rbi_helpers_with_right_order
           contents = <<~RB
             # @foo


### PR DESCRIPTION
Ran into some gems that specify `# @private` which was causing us to insert `extend T::Sig`.

Also a small refactor `Annotations -> Annotation`