### PR TITLE
Only translate top level assertions

### DIFF
--- a/lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb
+++ b/lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb
@@ -9,6 +9,27 @@ module Spoom
         LINE_BREAK = "\n".ord #: Integer
 
         # @override
+        #: (Prism::IfNode) -> void
+        def visit_if_node(node)
+          if node.if_keyword_loc
+            # We do not translate assertions in ternary expressions to avoid altering the semantic of the code.
+            #
+            # For example:
+            # ```rb
+            # a = T.must(b) ? T.must(c) : T.must(d)
+            # ```
+            #
+            # would become
+            # ```rb
+            # a = T.must(b) ? T.must(c) : d #: !nil
+            # ```
+            #
+            # which does not match the original intent.
+            super
+          end
+        end
+
+        # @override
         #: (Prism::CallNode) -> void
         def visit_call_node(node)
           return super unless t_annotation?(node)

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2937,6 +2937,9 @@ class Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments < ::Spoom::Sorbet:
   sig { override.params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end
 
+  sig { override.params(node: ::Prism::IfNode).void }
+  def visit_if_node(node); end
+
   private
 
   sig { params(node: ::Prism::Node).returns(T::Boolean) }

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2934,11 +2934,11 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs < ::Spoom::Sorbet::Trans
 end
 
 class Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments < ::Spoom::Sorbet::Translate::Translator
-  sig { override.params(node: ::Prism::CallNode).void }
-  def visit_call_node(node); end
-
   sig { override.params(node: ::Prism::IfNode).void }
   def visit_if_node(node); end
+
+  sig { override.params(node: ::Prism::StatementsNode).void }
+  def visit_statements_node(node); end
 
   private
 
@@ -2950,6 +2950,9 @@ class Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments < ::Spoom::Sorbet:
 
   sig { params(assign: ::Prism::Node, value: ::Prism::Node).returns(::String) }
   def dedent_value(assign, value); end
+
+  sig { params(node: ::Prism::Node).returns(T::Boolean) }
+  def maybe_translate_assertion(node); end
 
   sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
   def t?(node); end

--- a/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
@@ -482,6 +482,14 @@ module Spoom
           assert_equal(rb, rbi_to_rbs(rb))
         end
 
+        def test_doesnt_translate_in_expressions
+          rb = <<~RB
+            a - T.must(b)
+          RB
+
+          assert_equal(rb, rbi_to_rbs(rb))
+        end
+
         def test_doesnt_translate_in_ternary_expressions
           rb = <<~RB
             a = T.must(b) ? T.must(c) : T.must(d)

--- a/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
@@ -482,6 +482,14 @@ module Spoom
           assert_equal(rb, rbi_to_rbs(rb))
         end
 
+        def test_doesnt_translate_in_ternary_expressions
+          rb = <<~RB
+            a = T.must(b) ? T.must(c) : T.must(d)
+          RB
+
+          assert_equal(rb, rbi_to_rbs(rb))
+        end
+
         private
 
         #: (String) -> String


### PR DESCRIPTION
We shouldn't blindly translate assertions when they are at the end of the line.

Consider this example:

```rb
a - T.must(b)
```

before this change it would get translated to this:

```rb
a - b #: as !nil
```

which would actually get type checked as this:

```rb
T.must(a - b)
```