### PR TITLE
Translate `T.bind(self, X)` calls to RBS comments

### DIFF
--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2945,7 +2945,7 @@ class Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments < ::Spoom::Sorbet:
   sig { params(node: ::Prism::Node).returns(T::Boolean) }
   def at_end_of_line?(node); end
 
-  sig { params(call: ::Prism::CallNode).void }
+  sig { params(call: ::Prism::CallNode).returns(::String) }
   def build_rbs_annotation(call); end
 
   sig { params(assign: ::Prism::Node, value: ::Prism::Node).returns(::String) }

--- a/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
@@ -498,6 +498,24 @@ module Spoom
           assert_equal(rb, rbi_to_rbs(rb))
         end
 
+        def test_translate_bind
+          rb = <<~RB
+            T.bind(self, T.class_of(String))
+
+            T.bind(foo, String)
+
+            before_enqueue { T.bind(self, String) }
+          RB
+
+          assert_equal(<<~RB, rbi_to_rbs(rb))
+            #: self as singleton(String)
+
+            T.bind(foo, String)
+
+            before_enqueue { T.bind(self, String) }
+          RB
+        end
+
         private
 
         #: (String) -> String


### PR DESCRIPTION
So we translate this:

```rb
T.bind(self, T.class_of(String))
```

into

```rb
#: self as singleton(String)
```

Note that we do not translate bind calls that are not on `self`.