### PR TITLE
Allow translation of abstract methods

### DIFF
--- a/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
+++ b/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
@@ -44,7 +44,6 @@ module Spoom
         def visit_def_node(node)
           last_sigs = collect_last_sigs
           return if last_sigs.empty?
-          return if last_sigs.any? { |_, sig| sig.is_abstract }
 
           apply_member_annotations(last_sigs)
 
@@ -237,23 +236,25 @@ module Spoom
           node, _sig = sigs.first #: as [Prism::CallNode, RBI::Sig]
           insert_pos = node.location.start_offset
 
+          indent = " " * node.location.start_column
+
           if sigs.any? { |_, sig| sig.without_runtime }
-            @rewriter << Source::Insert.new(insert_pos, "# @without_runtime\n")
+            @rewriter << Source::Insert.new(insert_pos, "# @without_runtime\n#{indent}")
           end
 
           if sigs.any? { |_, sig| sig.is_final }
-            @rewriter << Source::Insert.new(insert_pos, "# @final\n")
+            @rewriter << Source::Insert.new(insert_pos, "# @final\n#{indent}")
           end
 
           if sigs.any? { |_, sig| sig.is_abstract }
-            @rewriter << Source::Insert.new(insert_pos, "# @abstract\n")
+            @rewriter << Source::Insert.new(insert_pos, "# @abstract\n#{indent}")
           end
 
           if sigs.any? { |_, sig| sig.is_override }
             @rewriter << if sigs.any? { |_, sig| sig.allow_incompatible_override }
-              Source::Insert.new(insert_pos, "# @override(allow_incompatible: true)\n")
+              Source::Insert.new(insert_pos, "# @override(allow_incompatible: true)\n#{indent}")
             else
-              Source::Insert.new(insert_pos, "# @override\n")
+              Source::Insert.new(insert_pos, "# @override\n#{indent}")
             end
           end
 

--- a/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
@@ -74,19 +74,29 @@ module Spoom
 
         def test_does_not_translate_to_rbs_abstract_methods
           contents = <<~RB
-            sig { abstract.void }
-            def foo; end
+            class Foo
+              sig { abstract.void }
+              def foo; end
 
-            sig { void }
-            def bar; end
+              class Bar
+                sig { abstract.void }
+                def bar; end
+              end
+            end
           RB
 
           assert_equal(<<~RBS, sorbet_sigs_to_rbs_comments(contents))
-            sig { abstract.void }
-            def foo; end
+            class Foo
+              # @abstract
+              #: -> void
+              def foo; end
 
-            #: -> void
-            def bar; end
+              class Bar
+                # @abstract
+                #: -> void
+                def bar; end
+              end
+            end
           RBS
         end
 


### PR DESCRIPTION
Goes from this:

```rb
class Foo
  sig { abstract.void }
  def foo; end
end
```

to this:

```rb
class Foo
  # @abstract
  #: -> void
  def foo; end
end
```

Should we also insert the `raise` in the body while at it?