### PR TITLE
Make translation of generics, helpers and abstract methods optional

### DIFF
--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -17,6 +17,9 @@ module Spoom
           default: true
         option :include_rbi_files, type: :boolean, desc: "Include RBI files", default: false
         option :max_line_length, type: :numeric, desc: "Max line length (pass 0 to disable)", default: 120
+        option :translate_generics, type: :boolean, desc: "Translate generics", default: false
+        option :translate_helpers, type: :boolean, desc: "Translate helpers", default: false
+        option :translate_abstract_methods, type: :boolean, desc: "Translate abstract methods", default: false
         def translate(*paths)
           from = options[:from]
           to = options[:to]
@@ -49,6 +52,9 @@ module Spoom
                 file: file,
                 positional_names: options[:positional_names],
                 max_line_length: max_line_length,
+                translate_generics: options[:translate_generics],
+                translate_helpers: options[:translate_helpers],
+                translate_abstract_methods: options[:translate_abstract_methods],
               )
             end
           when "rbs"

--- a/lib/spoom/sorbet/translate.rb
+++ b/lib/spoom/sorbet/translate.rb
@@ -25,9 +25,30 @@ module Spoom
 
         # Converts all `sig` nodes to RBS comments in the given Ruby code.
         # It also handles type members and class annotations.
-        #: (String ruby_contents, file: String, ?positional_names: bool, ?max_line_length: Integer?) -> String
-        def sorbet_sigs_to_rbs_comments(ruby_contents, file:, positional_names: true, max_line_length: nil)
-          SorbetSigsToRBSComments.new(ruby_contents, file: file, positional_names: positional_names, max_line_length: max_line_length).rewrite
+        #: (
+        #|   String,
+        #|   file: String,
+        #|   ?positional_names: bool,
+        #|   ?max_line_length: Integer?,
+        #|   ?translate_generics: bool,
+        #|   ?translate_helpers: bool,
+        #|   ?translate_abstract_methods: bool
+        #| ) -> String
+        def sorbet_sigs_to_rbs_comments(
+          ruby_contents, file:, positional_names: true, max_line_length: nil,
+          translate_generics: true,
+          translate_helpers: true,
+          translate_abstract_methods: true
+        )
+          SorbetSigsToRBSComments.new(
+            ruby_contents,
+            file: file,
+            positional_names: positional_names,
+            max_line_length: max_line_length,
+            translate_generics: translate_generics,
+            translate_helpers: translate_helpers,
+            translate_abstract_methods: translate_abstract_methods,
+          ).rewrite
         end
 
         # Converts all the RBS comments in the given Ruby code to `sig` nodes.

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2850,10 +2850,13 @@ module Spoom::Sorbet::Translate
         ruby_contents: ::String,
         file: ::String,
         positional_names: T::Boolean,
-        max_line_length: T.nilable(::Integer)
+        max_line_length: T.nilable(::Integer),
+        translate_generics: T::Boolean,
+        translate_helpers: T::Boolean,
+        translate_abstract_methods: T::Boolean
       ).returns(::String)
     end
-    def sorbet_sigs_to_rbs_comments(ruby_contents, file:, positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
+    def sorbet_sigs_to_rbs_comments(ruby_contents, file:, positional_names: T.unsafe(nil), max_line_length: T.unsafe(nil), translate_generics: T.unsafe(nil), translate_helpers: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
 
     sig { params(ruby_contents: ::String, file: ::String).returns(::String) }
     def strip_sorbet_sigs(ruby_contents, file:); end
@@ -2939,10 +2942,13 @@ class Spoom::Sorbet::Translate::SorbetSigsToRBSComments < ::Spoom::Sorbet::Trans
       ruby_contents: ::String,
       file: ::String,
       positional_names: T::Boolean,
-      max_line_length: T.nilable(::Integer)
+      max_line_length: T.nilable(::Integer),
+      translate_generics: T::Boolean,
+      translate_helpers: T::Boolean,
+      translate_abstract_methods: T::Boolean
     ).void
   end
-  def initialize(ruby_contents, file:, positional_names:, max_line_length: T.unsafe(nil)); end
+  def initialize(ruby_contents, file:, positional_names:, max_line_length: T.unsafe(nil), translate_generics: T.unsafe(nil), translate_helpers: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
 
   sig { override.params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end

--- a/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
@@ -96,6 +96,8 @@ module Spoom
             end
           RB
 
+          assert_equal(contents, sorbet_sigs_to_rbs_comments(contents, translate_abstract_methods: false))
+
           assert_equal(<<~RBS, sorbet_sigs_to_rbs_comments(contents))
             class Foo
               # @abstract
@@ -265,6 +267,8 @@ module Spoom
             end
           RB
 
+          assert_equal(contents, sorbet_sigs_to_rbs_comments(contents, translate_helpers: false))
+
           assert_equal(<<~RB, sorbet_sigs_to_rbs_comments(contents))
             # @abstract
             # @requires_ancestor: singleton(Foo::Bar)
@@ -326,26 +330,28 @@ module Spoom
           contents = <<~RB
             class A
               extend T::Generic
-              A = type_member(:in)
-              B = type_member(:out)
+              X = type_member(:in)
+              Y = type_member(:out)
               module B
                 extend T::Generic
-                A = type_member
-                B = type_member {{ upper: C }}
+                X = type_member
+                Y = type_member {{ upper: C }}
                 class << self
                   extend T::Generic
-                  A = type_member {{ fixed: T.class_of(Numeric) }}
+                  X = type_member {{ fixed: T.class_of(Numeric) }}
                 end
               end
             end
           RB
 
+          assert_equal(contents, sorbet_sigs_to_rbs_comments(contents, translate_generics: false))
+
           assert_equal(<<~RB, sorbet_sigs_to_rbs_comments(contents))
-            #: [in A, out B]
+            #: [in X, out Y]
             class A
-              #: [A, B < C]
+              #: [X, Y < C]
               module B
-                #: [A = singleton(Numeric)]
+                #: [X = singleton(Numeric)]
                 class << self
                 end
               end
@@ -443,13 +449,30 @@ module Spoom
 
         private
 
-        #: (String, ?positional_names: bool, ?max_line_length: Integer?) -> String
-        def sorbet_sigs_to_rbs_comments(ruby_contents, positional_names: true, max_line_length: nil)
+        #: (
+        #|   String,
+        #|   ?positional_names: bool,
+        #|   ?max_line_length: Integer?,
+        #|   ?translate_generics: bool,
+        #|   ?translate_helpers: bool,
+        #|   ?translate_abstract_methods: bool
+        #| ) -> String
+        def sorbet_sigs_to_rbs_comments(
+          ruby_contents,
+          positional_names: true,
+          max_line_length: nil,
+          translate_generics: true,
+          translate_helpers: true,
+          translate_abstract_methods: true
+        )
           Translate.sorbet_sigs_to_rbs_comments(
             ruby_contents,
             file: "test.rb",
             positional_names: positional_names,
             max_line_length: max_line_length,
+            translate_generics: translate_generics,
+            translate_helpers: translate_helpers,
+            translate_abstract_methods: translate_abstract_methods,
           )
         end
       end


### PR DESCRIPTION
By default we won't translate generics, helpers and abstract methods to RBS.

It can be enabled separately:

```
$ spoom srb sigs translate --translate-generics --translate-helpers --translate-abstract-methods
```