### PR TITLE
Add a test showing RBS signatures are being deleted by the deadcode remover

### DIFF
--- a/test/spoom/deadcode/remover_test.rb
+++ b/test/spoom/deadcode/remover_test.rb
@@ -965,6 +965,29 @@ module Spoom
         RB
       end
 
+      def test_removes_node_rbs_comment
+        res = remove(<<~RB, "bar")
+          class Foo
+            def foo; end
+
+            #: -> void
+            def bar
+              something
+            end
+
+            def baz; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def foo; end
+
+            def baz; end
+          end
+        RB
+      end
+
       def test_removes_singleton_class_if_needed
         res = remove(<<~RB, "foo")
           class Foo


### PR DESCRIPTION
@shioyama it looks like it works. Do you have an example where it didn't?