### PR TITLE
Do not associate a RBS comment to a node after a blank line

### DIFF
--- a/lib/spoom/rbs.rb
+++ b/lib/spoom/rbs.rb
@@ -75,8 +75,16 @@ module Spoom
 
         continuation_comments = [] #: Array[Prism::Comment]
 
+        last_line = node.location.start_line
+
         comments.each do |comment|
           string = comment.slice
+
+          comment_line = comment.location.end_line
+
+          break if comment_line < last_line - 1
+
+          last_line = comment_line
 
           if string.start_with?("# @")
             string = string.delete_prefix("#").strip

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -426,6 +426,26 @@ module Spoom
           RBS
         end
 
+        def test_translate_to_rbi_selects_right_comments
+          contents = <<~RB
+            #: -> void
+
+            class Foo
+              #: -> void
+
+              #: -> void
+
+              class << self
+                #: -> void
+
+                def bar; end
+              end
+            end
+          RB
+
+          assert_equal(contents, rbs_comments_to_sorbet_sigs(contents))
+        end
+
         private
 
         #: (String, ?max_line_length: Integer?) -> String


### PR DESCRIPTION
Before this PR, the following example would fail because we tried to use the type alias as the generic signature of the class:

```rb
#: type foo = Integer

class Bar; end
```