### PR TITLE
Specify RBS requirement during `export` command

### DIFF
--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -145,6 +145,7 @@ module Spoom
           tapioca_context.write!("Gemfile", <<~RB)
             source "https://rubygems.org"
 
+            gem "rbs", ">= 4.0.0.dev.4"
             gem "tapioca"
             gem "#{spec.name}", path: "#{copy_context.absolute_path}"
           RB


### PR DESCRIPTION
When the gem we run the `export` command with depends on `rbi` Bundler picks `tapioca` v0.16.11 instead of the latest one. This now started erroring due to the `T::Module` error with the latest sorbet-runtime.

@paracycle pointed out that this is due to `rbs` gem version being a pre-release. Current Spoom already depends on this pre-release version and we can just make that explicit in the Gemfile of the `export` command. This way bundler will pick the correct tapioca version.
