### PR TITLE
Bump RBS dependency to 4.0.0.dev.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
       rbi (>= 0.3.3)
-      rbs (>= 4.0.0.dev.4)
+      rbs (>= 4.0.0.dev.5)
       rexml (>= 3.2.6)
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
@@ -58,9 +58,10 @@ GEM
     rbi (0.3.9)
       prism (~> 1.0)
       rbs (>= 3.4.4)
-    rbs (4.0.0.dev.4)
+    rbs (4.0.0.dev.5)
       logger
       prism (>= 1.3.0)
+      tsort
     rdoc (7.0.3)
       erb
       psych (>= 4.0.0)

--- a/spoom.gemspec
+++ b/spoom.gemspec
@@ -34,9 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("erubi", ">= 1.10.0")
   spec.add_dependency("prism", ">= 0.28.0")
   spec.add_dependency("rbi", ">= 0.3.3")
-  # Any version constraint changes to `rbs` should be reflected in the Gemfile used by the `export` command
-  # https://github.com/Shopify/spoom/blob/c094851a8aff3760d06b85655eba624dc2ad769b/lib/spoom/cli/srb/sigs.rb#L148
-  spec.add_dependency("rbs", ">= 4.0.0.dev.4")
+  spec.add_dependency("rbs", ">= 4.0.0.dev.5")
   spec.add_dependency("rexml", ">= 3.2.6")
   spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.10187")
   spec.add_dependency("thor", ">= 0.19.2")


### PR DESCRIPTION
Since `tsort` is a bundled gem now, we need to update our runtime dependency on RBS to 4.0.0.dev.5 to bring in its explicit dependency to `tsort`.

Also, we no longer need to comment on top of the RBS dependency version line, since we've been dynamically looking up the RBS dependency version at runtime for some time now. So, I removed that comment while I am at it.