### PR TITLE
Update translation of RBS abstract methods to conditionally call super

### DIFF
--- a/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
+++ b/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
@@ -59,6 +59,8 @@ module Spoom
           visit_scope(node) { super }
         end
 
+        ABSTRACT_METHOD_BODY = "defined?(super) ? super : raise(NotImplementedError, \"Abstract method called\")"
+
         # @override
         #: (Prism::DefNode) -> void
         def visit_def_node(node)
@@ -87,9 +89,9 @@ module Spoom
               node.location.end_offset - 1,
               if node.name.end_with?("=")
                 indent = " " * node.location.start_column
-                "\n#{indent}  raise NotImplementedError, \"Abstract method called\"\n#{indent}end"
+                "\n#{indent}  #{ABSTRACT_METHOD_BODY}\n#{indent}end"
               else
-                " = raise NotImplementedError, \"Abstract method called\""
+                " = #{ABSTRACT_METHOD_BODY}"
               end,
             )
           end

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -3063,6 +3063,8 @@ class Spoom::Sorbet::Translate::SorbetSigsToRBSComments < ::Spoom::Sorbet::Trans
   def visit_sig(node); end
 end
 
+Spoom::Sorbet::Translate::SorbetSigsToRBSComments::ABSTRACT_METHOD_BODY = T.let(T.unsafe(nil), String)
+
 class Spoom::Sorbet::Translate::StripSorbetSigs < ::Spoom::Sorbet::Translate::Translator
   sig { override.params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end

--- a/test/spoom/cli/srb/sigs_test.rb
+++ b/test/spoom/cli/srb/sigs_test.rb
@@ -342,7 +342,7 @@ module Spoom
             class A
               # @abstract
               #: -> void
-              def foo = raise NotImplementedError, "Abstract method called"
+              def foo = defined?(super) ? super : raise(NotImplementedError, "Abstract method called")
             end
           RB
         end

--- a/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
@@ -102,28 +102,28 @@ module Spoom
             class Foo
               # @abstract
               #: -> void
-              def foo = raise NotImplementedError, "Abstract method called"
+              def foo = defined?(super) ? super : raise(NotImplementedError, "Abstract method called")
 
               class Bar
                 # @abstract
                 #: -> void
-                def bar = raise NotImplementedError, "Abstract method called"
+                def bar = defined?(super) ? super : raise(NotImplementedError, "Abstract method called")
               end
 
               # @abstract
               #: (Integer x) -> void
-              def baz(x) = raise NotImplementedError, "Abstract method called"
+              def baz(x) = defined?(super) ? super : raise(NotImplementedError, "Abstract method called")
 
               # @abstract
               #: (Integer x) -> void
               def foo=(x)
-                raise NotImplementedError, "Abstract method called"
+                defined?(super) ? super : raise(NotImplementedError, "Abstract method called")
               end
 
               # @abstract
               #: (Integer x) -> void
               def bar=(x)
-                raise NotImplementedError, "Abstract method called"
+                defined?(super) ? super : raise(NotImplementedError, "Abstract method called")
               end
             end
           RBS


### PR DESCRIPTION
When translating signatures into RBS on abstract methods, use the following pattern instead of a raise:

```ruby
def abstract_method = defined?(super) ? super : raise(NotImplementedError, "Abstract method called")
```

This requires sorbet support:

- https://github.com/sorbet/sorbet/pull/9846

### Questions
- When sorbet support ships, is it best to bump the minimum sorbet version to match?