### PR TITLE
Fix RBS rewriting to preserve line numbers

### DIFF
--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -256,9 +256,14 @@ module Spoom
 
           assert_equal(<<~RB, rbs_comments_to_sorbet_sigs(contents))
             sig { returns(::T::Array[Integer]) }
+
+
             attr_accessor :foo
 
             sig { params(a: Integer, b: Integer).returns(Integer) }
+
+
+
             def foo(a, b); end
           RB
         end


### PR DESCRIPTION
Fixes #787 

## Problem

When using `Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sig`, line numbers weren't preserved. Multi-line RBS comments were replaced with single-line sigs, causing method definitions to shift up in the file. This made errors and stacktraces misalign with the original source.

**Example:**
```ruby
# Original (method at line 6)
#: (
#| Integer
#| ) -> void
def foo(i); end

# After translation (method moved to line 4)
sig { params(i: Integer).void }
def foo(i); end
```

## Solution

Added a `preserve_line_numbers` helper that:
1. Calculates how many lines the original RBS comment spans
2. Calculates how many lines the generated sig will have
3. Adds blank lines after the sig to match the original line count

**Result:**
```ruby
# After fix (method stays at line 6)
sig { params(i: Integer).void }


def foo(i); end
```

## Testing

* All existing tests pass
* Updated `test_translate_to_rbi_multiline_sigs` to expect preserved line numbers
* Manually tested with various RBS comment sizes (single-line, multi-line, complex signatures)

## Changes

* `lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb`:
  * Added `preserve_line_numbers` helper method
  * Updated `rewrite_def` to use line preservation
  * Updated `visit_attr` to use line preservation
* `test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb`:
  * Updated `test_translate_to_rbi_multiline_sigs` expectations