### PR TITLE
Preserve inline comments inside sig blocks during RBS translation

### DIFF
--- a/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
+++ b/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
@@ -78,6 +78,7 @@ module Spoom
             out = rbs_print(node.location.start_column) do |printer|
               printer.print_method_sig(rbi_node, sig)
             end
+            out = add_inline_sig_comments(node, out)
             @rewriter << Source::Replace.new(node.location.start_offset, node.location.end_offset, out)
           end
 
@@ -207,6 +208,7 @@ module Spoom
             out = rbs_print(node.location.start_column) do |printer|
               printer.print_attr_sig(rbi_node, sig)
             end
+            out = add_inline_sig_comments(node, out)
             @rewriter << Source::Replace.new(node.location.start_offset, node.location.end_offset, out)
           end
         end
@@ -377,6 +379,19 @@ module Spoom
           end
 
           @extend_t_generics.clear
+        end
+
+        #: (Prism::CallNode, String) -> String
+        def add_inline_sig_comments(sig_node, out)
+          inline_comments = @comments.select do |comment|
+            comment.location.start_offset > sig_node.location.start_offset &&
+              comment.location.end_offset <= sig_node.location.end_offset
+          end
+          return out if inline_comments.empty?
+
+          indent_str = " " * sig_node.location.start_column
+          comment_string = inline_comments.map { |c| "#{c.slice}\n#{indent_str}" }.join
+          comment_string + out
         end
 
         # Collects the last signatures visited and clears the current list

--- a/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
+++ b/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
@@ -78,6 +78,7 @@ module Spoom
             out = rbs_print(node.location.start_column) do |printer|
               printer.print_method_sig(rbi_node, sig)
             end
+            out = add_sig_comments(node, out)
             @rewriter << Source::Replace.new(node.location.start_offset, node.location.end_offset, out)
           end
 
@@ -179,7 +180,7 @@ module Spoom
         def visit_sig(node)
           return unless sorbet_sig?(node)
 
-          builder = RBI::Parser::SigBuilder.new(@ruby_contents, file: @file)
+          builder = RBI::Parser::SigBuilder.new(@ruby_contents, comments_by_line: @comments_by_line, file: @file)
           builder.current.loc = node.location
           builder.visit_call_node(node)
           builder.current.comments = []
@@ -207,6 +208,7 @@ module Spoom
             out = rbs_print(node.location.start_column) do |printer|
               printer.print_attr_sig(rbi_node, sig)
             end
+            out = add_sig_comments(node, out)
             @rewriter << Source::Replace.new(node.location.start_offset, node.location.end_offset, out)
           end
         end
@@ -377,6 +379,20 @@ module Spoom
           end
 
           @extend_t_generics.clear
+        end
+
+        # `RBI::SigBuilder` consumes parameter comments and attaches them to `RBI::SigParam`.
+        # Preserve any other comments left inside the sig body, like comments before `returns`.
+        #: (Prism::CallNode, String) -> String
+        def add_sig_comments(sig_node, out)
+          comments = @comments_by_line.values.select do |comment|
+            comment.location.start_offset > sig_node.location.start_offset &&
+              comment.location.end_offset <= sig_node.location.end_offset
+          end
+          return out if comments.empty?
+
+          indent = " " * sig_node.location.start_column
+          comments.map { |comment| "#{comment.slice}\n#{indent}" }.join + out
         end
 
         # Collects the last signatures visited and clears the current list

--- a/lib/spoom/sorbet/translate/translator.rb
+++ b/lib/spoom/sorbet/translate/translator.rb
@@ -22,6 +22,7 @@ module Spoom
           node, comments = Spoom.parse_ruby(ruby_contents, file: file)
           @node = node #: Prism::Node
           @comments = comments #: Array[Prism::Comment]
+          @comments_by_line = comments.to_h { |comment| [comment.location.start_line, comment] } #: Hash[Integer, Prism::Comment]
           @ruby_bytes = ruby_contents.bytes #: Array[Integer]
           @rewriter = Spoom::Source::Rewriter.new #: Source::Rewriter
         end

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -3023,6 +3023,9 @@ class Spoom::Sorbet::Translate::SorbetSigsToRBSComments < ::Spoom::Sorbet::Trans
 
   private
 
+  sig { params(sig_node: ::Prism::CallNode, out: ::String).returns(::String) }
+  def add_inline_sig_comments(sig_node, out); end
+
   sig do
     params(
       parent: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -3023,6 +3023,9 @@ class Spoom::Sorbet::Translate::SorbetSigsToRBSComments < ::Spoom::Sorbet::Trans
 
   private
 
+  sig { params(sig_node: ::Prism::CallNode, out: ::String).returns(::String) }
+  def add_sig_comments(sig_node, out); end
+
   sig do
     params(
       parent: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),

--- a/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
@@ -466,6 +466,59 @@ module Spoom
           RBS
         end
 
+        def test_translate_to_rbs_sig_with_inline_param_comments
+          contents = <<~RB
+            sig do
+              params(
+                # First param
+                a: Integer,
+                # Second param
+                b: String
+              ).void
+            end
+            def foo(a, b); end
+
+            sig do
+              # A comment
+              returns(Integer)
+            end
+            attr_reader :x
+          RB
+
+          assert_equal(<<~RBS, sorbet_sigs_to_rbs_comments(contents))
+            # First param
+            # Second param
+            #: (Integer a, String b) -> void
+            def foo(a, b); end
+
+            # A comment
+            #: Integer
+            attr_reader :x
+          RBS
+        end
+
+        def test_translate_to_rbs_sig_with_inline_param_comments_indented
+          contents = <<~RB
+            class Foo
+              sig do
+                params(
+                  # First param
+                  a: Integer
+                ).void
+              end
+              def foo(a); end
+            end
+          RB
+
+          assert_equal(<<~RBS, sorbet_sigs_to_rbs_comments(contents))
+            class Foo
+              # First param
+              #: (Integer a) -> void
+              def foo(a); end
+            end
+          RBS
+        end
+
         def test_translate_to_rbs_defs_within_send
           contents = <<~RB
             sig { void }

--- a/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
@@ -466,6 +466,64 @@ module Spoom
           RBS
         end
 
+        def test_translate_to_rbs_sig_with_inline_param_comments
+          contents = <<~RB
+            sig do
+              params(
+                # First param
+                a: Integer,
+                # Second param
+                b: String
+              ).void
+            end
+            def foo(a, b); end
+
+            sig do
+              # A comment
+              returns(Integer)
+            end
+            attr_reader :x
+          RB
+
+          assert_equal(<<~RBS, sorbet_sigs_to_rbs_comments(contents))
+            #: (
+            #|   # First param
+            #|   Integer a,
+            #|   # Second param
+            #|   String b
+            #| ) -> void
+            def foo(a, b); end
+
+            # A comment
+            #: Integer
+            attr_reader :x
+          RBS
+        end
+
+        def test_translate_to_rbs_sig_with_inline_param_comments_indented
+          contents = <<~RB
+            class Foo
+              sig do
+                params(
+                  # First param
+                  a: Integer
+                ).void
+              end
+              def foo(a); end
+            end
+          RB
+
+          assert_equal(<<~RBS, sorbet_sigs_to_rbs_comments(contents))
+            class Foo
+              #: (
+              #|   # First param
+              #|   Integer a
+              #| ) -> void
+              def foo(a); end
+            end
+          RBS
+        end
+
         def test_translate_to_rbs_defs_within_send
           contents = <<~RB
             sig { void }


### PR DESCRIPTION
Comments inside `sig do params(...) end` blocks were silently dropped because the entire sig node byte range was replaced with the RBS string. Collect any comments within the sig node's range and prepend them to the output before the `#:` annotation.

Resolves https://github.com/Shopify/spoom/issues/900