### PR TITLE
Pin sorbet-static-and-runtime in sigs export temporary Gemfile

### DIFF
--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -149,6 +149,7 @@ module Spoom
 
             #{Spoom::BundlerHelper.gem_requirement_from_real_bundle("rbs")}
             #{Spoom::BundlerHelper.gem_requirement_from_real_bundle("tapioca")}
+            #{Spoom::BundlerHelper.gem_requirement_from_real_bundle("sorbet-static-and-runtime")}
 
             gem "#{spec.name}", path: "#{copy_context.absolute_path}"
           GEMFILE


### PR DESCRIPTION
## Problem

`spoom srb sigs export` creates a temporary Gemfile that pins `rbs` and `tapioca`, but does **not** pin `sorbet-static-and-runtime`. This means bundler can resolve a newer version of sorbet-runtime in the temporary context.

Starting with `sorbet-runtime >= 0.6.13149` ([sorbet/sorbet#10177](https://github.com/sorbet/sorbet/pull/10177)), the `has_rest` and `has_keyrest` methods were removed from `T::Private::Methods::Signature`. Tapioca still calls these methods in `gem/listeners/sorbet_signatures.rb`, causing:

```
undefined method `has_rest` for an instance of T::Private::Methods::Signature (NoMethodError)
```

## Solution

Pin `sorbet-static-and-runtime` in the temporary Gemfile using `BundlerHelper.gem_requirement_from_real_bundle`, the same mechanism already used for `rbs` and `tapioca`. This ensures the temporary context uses the same sorbet version as the real bundle.