### PR TITLE
Fix missing indentation for @overridable annotation in RBS translation

### DIFF
--- a/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
+++ b/lib/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments.rb
@@ -305,7 +305,7 @@ module Spoom
           end
 
           if sigs.any? { |_, sig| sig.is_overridable }
-            @rewriter << Source::Insert.new(insert_pos, "# @overridable\n")
+            @rewriter << Source::Insert.new(insert_pos, "# @overridable\n#{indent}")
           end
         end
 

--- a/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_sigs_to_rbs_comments_test.rb
@@ -159,6 +159,23 @@ module Spoom
           RBS
         end
 
+        def test_translate_to_rbs_method_sigs_with_overridable_annotation_indented
+          contents = <<~RB
+            class Foo
+              sig { overridable.params(x: Integer).returns(String) }
+              def foo(x); end
+            end
+          RB
+
+          assert_equal(<<~RBS, sorbet_sigs_to_rbs_comments(contents))
+            class Foo
+              # @overridable
+              #: (Integer x) -> String
+              def foo(x); end
+            end
+          RBS
+        end
+
         def test_translate_to_rbs_method_sigs_with_override_annotations
           contents = <<~RB
             sig { override(allow_incompatible: true).void }


### PR DESCRIPTION
## Summary

* The `@overridable` annotation insert was missing the `#{indent}` suffix after the newline, causing the subsequent `#:` signature line to start at column 0 instead of matching the method's indentation level
* All other annotations (`@without_runtime`, `@final`, `@abstract`, `@override`) already included the indent
* Added a test case that exercises `overridable` inside a class to catch the indentation bug

## Test plan

* Added `test_translate_to_rbs_method_sigs_with_overridable_annotation_indented` which verifies correct indentation when translating an overridable sig inside a class

cc. @jesse-shopify 