### PR TITLE
Fix dead code false positives for public_send, nested validates, and GraphQL macros

### DIFF
--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -30,6 +30,18 @@ module Spoom
                 @index.reference_method(value.slice.delete_prefix(":"), send.location) if value
               else
                 @index.reference_constant(camelize(key), send.location)
+
+                if value.is_a?(Prism::HashNode)
+                  value.elements.each do |assoc|
+                    next unless assoc.is_a?(Prism::AssocNode)
+
+                    assoc_key = assoc.key.slice.delete_suffix(":")
+                    next unless assoc_key == "in" || assoc_key == "with"
+                    next unless assoc.value.is_a?(Prism::SymbolNode)
+
+                    @index.reference_method(assoc.value.unescaped, send.location)
+                  end
+                end
               end
             end
           when "validates_with"

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -37,9 +37,10 @@ module Spoom
 
                     assoc_key = assoc.key.slice.delete_suffix(":")
                     next unless assoc_key == "in" || assoc_key == "with"
-                    next unless assoc.value.is_a?(Prism::SymbolNode)
+                    value = assoc.value
+                    next unless value.is_a?(Prism::SymbolNode)
 
-                    @index.reference_method(assoc.value.unescaped, send.location)
+                    @index.reference_method(value.unescaped, send.location)
                   end
                 end
               end

--- a/lib/spoom/deadcode/plugins/graphql.rb
+++ b/lib/spoom/deadcode/plugins/graphql.rb
@@ -25,19 +25,35 @@ module Spoom
         # @override
         #: (Send send) -> void
         def on_send(send)
-          return unless send.recv.nil? && send.name == "field"
+          return if send.recv
 
-          arg = send.args.first
-          return unless arg.is_a?(Prism::SymbolNode)
+          case send.name
+          when "field"
+            arg = send.args.first
+            return unless arg.is_a?(Prism::SymbolNode)
 
-          @index.reference_method(arg.unescaped, send.location)
+            @index.reference_method(arg.unescaped, send.location)
 
-          send.each_arg_assoc do |key, value|
-            key = key.slice.delete_suffix(":")
-            next unless key == "resolver_method"
-            next unless value
+            send.each_arg_assoc do |key, value|
+              key = key.slice.delete_suffix(":")
+              next unless key == "resolver_method" || key == "method"
+              next unless value
 
-            @index.reference_method(value.slice.delete_prefix(":"), send.location)
+              @index.reference_method(value.slice.delete_prefix(":"), send.location)
+            end
+          when "argument"
+            send.each_arg_assoc do |key, value|
+              key = key.slice.delete_suffix(":")
+              next unless key == "prepare" || key == "method"
+              next unless value
+
+              @index.reference_method(value.slice.delete_prefix(":"), send.location)
+            end
+          when "builds"
+            arg = send.args.first
+            return unless arg.is_a?(Prism::SymbolNode)
+
+            @index.reference_method("build_#{arg.unescaped}", send.location)
           end
         end
       end

--- a/lib/spoom/deadcode/plugins/ruby.rb
+++ b/lib/spoom/deadcode/plugins/ruby.rb
@@ -24,7 +24,7 @@ module Spoom
           case send.name
           when "const_defined?", "const_get", "const_source_location"
             reference_symbol_as_constant(send, T.must(send.args.first))
-          when "send", "__send__", "try"
+          when "send", "__send__", "public_send", "try"
             arg = send.args.first
             @index.reference_method(arg.unescaped, send.location) if arg.is_a?(Prism::SymbolNode)
           when "alias_method"

--- a/test/spoom/deadcode/plugins/active_model_test.rb
+++ b/test/spoom/deadcode/plugins/active_model_test.rb
@@ -83,6 +83,27 @@ module Spoom
           assert_alive(index, "method5")
         end
 
+        def test_alive_nested_validation_option_symbols
+          @project.write!("app/models/my_model.rb", <<~RB)
+            class MyModel
+              validates :attr1, inclusion: { in: :allowed_values }
+              validates :attr2, numericality: { less_than: :max_value }
+              validates :attr3, format: { with: :pattern_method }
+
+              def allowed_values; end
+              def max_value; end
+              def pattern_method; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "allowed_values")
+          assert_alive(index, "pattern_method")
+          assert_dead(index, "max_value")
+          assert_dead(index, "dead")
+        end
+
         def test_dead_serializer_attribute
           @project.write!("app/model/serializers/my_serializer.rb", <<~RB)
             class MySerializer < ActiveModel::Serializer

--- a/test/spoom/deadcode/plugins/graphql_test.rb
+++ b/test/spoom/deadcode/plugins/graphql_test.rb
@@ -65,6 +65,66 @@ module Spoom
           assert_dead(index, "dead")
         end
 
+        def test_alive_argument_prepare
+          @project.write!("foo.rb", <<~RB)
+            class SomeMutation
+              argument :input, String, required: true, prepare: :transform_input
+
+              def transform_input(value); end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "transform_input")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_builds
+          @project.write!("foo.rb", <<~RB)
+            class SomeMutation
+              builds :thing
+
+              def build_thing; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "build_thing")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_field_method
+          @project.write!("foo.rb", <<~RB)
+            class SomeType
+              field :name, String, null: false, method: :custom_name
+
+              def custom_name; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "custom_name")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_argument_method
+          @project.write!("foo.rb", <<~RB)
+            class SomeMutation
+              argument :input, String, required: true, method: :custom_input
+
+              def custom_input; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "custom_input")
+          assert_dead(index, "dead")
+        end
+
         def test_ignore_method_splats
           @project.write!("foo.rb", <<~RB)
             field(:field1)

--- a/test/spoom/deadcode/plugins/ruby_test.rb
+++ b/test/spoom/deadcode/plugins/ruby_test.rb
@@ -65,6 +65,23 @@ module Spoom
           assert_dead(index, "dead")
         end
 
+        def test_alive_public_sends
+          @project.write!("foo.rb", <<~RB)
+            public_send(:alive1)
+            public_send :alive2, :dead, nil
+
+            def alive1; end
+            def alive2; end
+
+            def dead; end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "alive1")
+          assert_alive(index, "alive2")
+          assert_dead(index, "dead")
+        end
+
         def test_alive_tries
           @project.write!("foo.rb", <<~RB)
             try(:alive1)


### PR DESCRIPTION
## Summary

Fixes three sources of dead code false positives:

### 1. `public_send` support in Ruby plugin

`send`, `__send__`, and `try` already create method references for their first symbol argument, but `public_send` was missing. This caused methods invoked via `obj.public_send(:method_name)` to be incorrectly flagged as dead.

### 2. Nested validation option hashes in ActiveModel plugin

`validates :attr, inclusion: { in: :method_name }` now correctly references `:method_name` as a method. Previously, only the top-level validation key was processed (creating a constant reference for the validator class), but symbol values inside nested option hashes were ignored.

### 3. GraphQL `argument`/`builds`/`prepare:` support

- `argument :name, prepare: :method_name` now references `:method_name`
- `builds :thing` now references `build_thing` (graphql-ruby convention)
- `argument :name, method: :method_name` and `field :name, method: :method_name` now reference the method (complementing the existing `resolver_method:` support)

## Context

These patterns were discovered while running `spoom deadcode` on a large Rails monolith (46K files). Of 77 candidates investigated across 10 packs, 39 were false positives — the majority from these three categories plus app-specific patterns (AASM, routes, ArDoc YAML) that are better suited for custom plugins.

## Test plan

Added minitest cases for each fix following existing plugin test patterns.

Made with [Cursor](https://cursor.com)