### PR TITLE
Add `#public_send` support to Ruby dead code plugin

### DIFF
--- a/lib/spoom/deadcode/plugins/ruby.rb
+++ b/lib/spoom/deadcode/plugins/ruby.rb
@@ -24,7 +24,7 @@ module Spoom
           case send.name
           when "const_defined?", "const_get", "const_source_location"
             reference_symbol_as_constant(send, T.must(send.args.first))
-          when "send", "__send__", "try"
+          when "send", "__send__", "public_send", "try"
             arg = send.args.first
             @index.reference_method(arg.unescaped, send.location) if arg.is_a?(Prism::SymbolNode)
           when "alias_method"

--- a/test/spoom/deadcode/plugins/ruby_test.rb
+++ b/test/spoom/deadcode/plugins/ruby_test.rb
@@ -82,6 +82,20 @@ module Spoom
           assert_dead(index, "dead")
         end
 
+        def test_alive_public_sends
+          @project.write!("foo.rb", <<~RB)
+            class Foo
+              def foo; end
+            end
+
+            obj = Foo.new
+            obj.public_send(:foo)
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "foo")
+        end
+
         def test_alive_aliases
           @project.write!("foo.rb", <<~RB)
             def dead1; end


### PR DESCRIPTION
The Ruby plugin already handles `send`, `__send__`, and `try` by referencing their first symbol argument as a method. `public_send` was missing from this list, causing methods invoked via `obj.public_send(:method_name)` to be incorrectly flagged as dead code.

This is a one-line fix adding `"public_send"` to the existing condition.

## Test plan
Added a minitest case verifying that `public_send(:foo)` keeps `foo` alive.

Made with [Cursor](https://cursor.com)