### PR TITLE
Reference symbol method names in nested validates option hashes

### DIFF
--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -69,9 +69,11 @@ module Spoom
 
             nested_key = assoc.key.slice.delete_suffix(":")
             next unless NESTED_METHOD_REFERENCE_KEYS.include?(nested_key)
-            next unless assoc.value.is_a?(Prism::SymbolNode)
 
-            @index.reference_method(assoc.value.unescaped, location)
+            value = assoc.value
+            next unless value.is_a?(Prism::SymbolNode)
+
+            @index.reference_method(value.unescaped, location)
           end
         end
       end

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -30,6 +30,10 @@ module Spoom
                 @index.reference_method(value.slice.delete_prefix(":"), send.location) if value
               else
                 @index.reference_constant(camelize(key), send.location)
+
+                if value.is_a?(Prism::HashNode)
+                  reference_nested_symbol_options(value, send.location)
+                end
               end
             end
           when "validates_with"
@@ -37,6 +41,37 @@ module Spoom
             if arg.is_a?(Prism::SymbolNode)
               @index.reference_constant(arg.unescaped, send.location)
             end
+          end
+        end
+
+        private
+
+        NESTED_METHOD_REFERENCE_KEYS = T.let(
+          %w[
+            if
+            unless
+            in
+            with
+            less_than
+            greater_than
+            less_than_or_equal_to
+            greater_than_or_equal_to
+            equal_to
+            other_than
+          ].freeze,
+          T::Array[String],
+        )
+
+        #: (Prism::HashNode hash_node, Location location) -> void
+        def reference_nested_symbol_options(hash_node, location)
+          hash_node.elements.each do |assoc|
+            next unless assoc.is_a?(Prism::AssocNode)
+
+            nested_key = assoc.key.slice.delete_suffix(":")
+            next unless NESTED_METHOD_REFERENCE_KEYS.include?(nested_key)
+            next unless assoc.value.is_a?(Prism::SymbolNode)
+
+            @index.reference_method(assoc.value.unescaped, location)
           end
         end
       end

--- a/lib/spoom/deadcode/plugins/active_model.rb
+++ b/lib/spoom/deadcode/plugins/active_model.rb
@@ -47,17 +47,17 @@ module Spoom
         private
 
         NESTED_METHOD_REFERENCE_KEYS = T.let(
-          %w[
-            if
-            unless
-            in
-            with
-            less_than
-            greater_than
-            less_than_or_equal_to
-            greater_than_or_equal_to
-            equal_to
-            other_than
+          [
+            "if",
+            "unless",
+            "in",
+            "with",
+            "less_than",
+            "greater_than",
+            "less_than_or_equal_to",
+            "greater_than_or_equal_to",
+            "equal_to",
+            "other_than",
           ].freeze,
           T::Array[String],
         )

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -1124,7 +1124,14 @@ class Spoom::Deadcode::Plugins::ActiveJob < ::Spoom::Deadcode::Plugins::Base; en
 class Spoom::Deadcode::Plugins::ActiveModel < ::Spoom::Deadcode::Plugins::Base
   sig { override.params(send: ::Spoom::Deadcode::Send).void }
   def on_send(send); end
+
+  private
+
+  sig { params(hash_node: ::Prism::HashNode, location: ::Spoom::Location).void }
+  def reference_nested_symbol_options(hash_node, location); end
 end
+
+Spoom::Deadcode::Plugins::ActiveModel::NESTED_METHOD_REFERENCE_KEYS = T.let(T.unsafe(nil), Array)
 
 class Spoom::Deadcode::Plugins::ActiveRecord < ::Spoom::Deadcode::Plugins::Base
   sig { override.params(send: ::Spoom::Deadcode::Send).void }

--- a/test/spoom/deadcode/plugins/active_model_test.rb
+++ b/test/spoom/deadcode/plugins/active_model_test.rb
@@ -83,6 +83,42 @@ module Spoom
           assert_alive(index, "method5")
         end
 
+        def test_alive_nested_validation_option_symbols
+          @project.write!("app/models/my_model.rb", <<~RB)
+            class MyModel
+              validates :attr1, inclusion: { in: :allowed_values }
+              validates :attr2, numericality: { less_than: :max_value, greater_than: :min_value }
+              validates :attr3, format: { with: :pattern_method }
+              validates :attr4, exclusion: { in: :excluded_values }
+              validates :attr5, numericality: { equal_to: :target_value, other_than: :avoid_value }
+              validates :attr6, numericality: { less_than_or_equal_to: :upper_bound, greater_than_or_equal_to: :lower_bound }
+
+              def allowed_values; end
+              def max_value; end
+              def min_value; end
+              def pattern_method; end
+              def excluded_values; end
+              def target_value; end
+              def avoid_value; end
+              def upper_bound; end
+              def lower_bound; end
+              def dead_method; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "allowed_values")
+          assert_alive(index, "max_value")
+          assert_alive(index, "min_value")
+          assert_alive(index, "pattern_method")
+          assert_alive(index, "excluded_values")
+          assert_alive(index, "target_value")
+          assert_alive(index, "avoid_value")
+          assert_alive(index, "upper_bound")
+          assert_alive(index, "lower_bound")
+          assert_dead(index, "dead_method")
+        end
+
         def test_dead_serializer_attribute
           @project.write!("app/model/serializers/my_serializer.rb", <<~RB)
             class MySerializer < ActiveModel::Serializer


### PR DESCRIPTION
## Problem

`validates :attr, inclusion: { in: :allowed_values }` incorrectly flags `allowed_values` as dead code. The ActiveModel plugin processes top-level keyword args but does not descend into nested option hashes where Rails validators accept symbol method references.

## Fix

When processing `validates`/`validates!` keyword args, if a value is a HashNode, the plugin now iterates its assocs and references SymbolNode values as methods for known method-reference keys:

- **inclusion/exclusion:** `in:`
- **format:** `with:`
- **numericality:** `less_than:`, `greater_than:`, `less_than_or_equal_to:`, `greater_than_or_equal_to:`, `equal_to:`, `other_than:`

All of these Rails validation options accept a symbol that is called as a method on the model instance at validation time.

## Test plan

Added minitest cases covering all nested option keys with symbol values.

Made with [Cursor](https://cursor.com)