### PR TITLE
Add GraphQL `argument`, `builds`, and `prepare` support to dead code plugin

### DIFF
--- a/lib/spoom/deadcode/plugins/graphql.rb
+++ b/lib/spoom/deadcode/plugins/graphql.rb
@@ -22,22 +22,59 @@ module Spoom
           "unsubscribed",
         )
 
+        FIELD_SYMBOL_OPTION_KEYS = ["resolver_method", "method"].freeze #: Array[String]
+        ARGUMENT_SYMBOL_OPTION_KEYS = ["prepare", "method"].freeze #: Array[String]
+
         # @override
         #: (Send send) -> void
         def on_send(send)
-          return unless send.recv.nil? && send.name == "field"
+          return unless send.recv.nil?
 
+          case send.name
+          when "field"
+            on_field(send)
+          when "argument"
+            on_argument(send)
+          when "builds"
+            on_builds(send)
+          end
+        end
+
+        private
+
+        #: (Send send) -> void
+        def on_field(send)
           arg = send.args.first
           return unless arg.is_a?(Prism::SymbolNode)
 
           @index.reference_method(arg.unescaped, send.location)
 
           send.each_arg_assoc do |key, value|
-            key = key.slice.delete_suffix(":")
-            next unless key == "resolver_method"
+            key_name = key.slice.delete_suffix(":")
+            next unless FIELD_SYMBOL_OPTION_KEYS.include?(key_name)
             next unless value
 
             @index.reference_method(value.slice.delete_prefix(":"), send.location)
+          end
+        end
+
+        #: (Send send) -> void
+        def on_argument(send)
+          send.each_arg_assoc do |key, value|
+            key_name = key.slice.delete_suffix(":")
+            next unless ARGUMENT_SYMBOL_OPTION_KEYS.include?(key_name)
+            next unless value
+
+            @index.reference_method(value.slice.delete_prefix(":"), send.location)
+          end
+        end
+
+        #: (Send send) -> void
+        def on_builds(send)
+          send.args.each do |arg|
+            next unless arg.is_a?(Prism::SymbolNode)
+
+            @index.reference_method("build_#{arg.unescaped}", send.location)
           end
         end
       end

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -1248,7 +1248,21 @@ end
 class Spoom::Deadcode::Plugins::GraphQL < ::Spoom::Deadcode::Plugins::Base
   sig { override.params(send: ::Spoom::Deadcode::Send).void }
   def on_send(send); end
+
+  private
+
+  sig { params(send: ::Spoom::Deadcode::Send).void }
+  def on_argument(send); end
+
+  sig { params(send: ::Spoom::Deadcode::Send).void }
+  def on_builds(send); end
+
+  sig { params(send: ::Spoom::Deadcode::Send).void }
+  def on_field(send); end
 end
+
+Spoom::Deadcode::Plugins::GraphQL::ARGUMENT_SYMBOL_OPTION_KEYS = T.let(T.unsafe(nil), Array)
+Spoom::Deadcode::Plugins::GraphQL::FIELD_SYMBOL_OPTION_KEYS = T.let(T.unsafe(nil), Array)
 
 class Spoom::Deadcode::Plugins::Minitest < ::Spoom::Deadcode::Plugins::Base
   sig { override.params(definition: ::Spoom::Model::Method).void }

--- a/test/spoom/deadcode/plugins/graphql_test.rb
+++ b/test/spoom/deadcode/plugins/graphql_test.rb
@@ -65,6 +65,66 @@ module Spoom
           assert_dead(index, "dead")
         end
 
+        def test_alive_argument_prepare
+          @project.write!("foo.rb", <<~RB)
+            class SomeMutation
+              argument :input, String, required: true, prepare: :transform_input
+
+              def transform_input(value); end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "transform_input")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_builds
+          @project.write!("foo.rb", <<~RB)
+            class SomeMutation
+              builds :thing
+
+              def build_thing; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "build_thing")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_field_method
+          @project.write!("foo.rb", <<~RB)
+            class SomeType
+              field :name, String, null: false, method: :custom_name
+
+              def custom_name; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "custom_name")
+          assert_dead(index, "dead")
+        end
+
+        def test_alive_argument_method
+          @project.write!("foo.rb", <<~RB)
+            class SomeMutation
+              argument :input, String, required: true, method: :custom_input
+
+              def custom_input; end
+              def dead; end
+            end
+          RB
+
+          index = index_with_plugins
+          assert_alive(index, "custom_input")
+          assert_dead(index, "dead")
+        end
+
         def test_ignore_method_splats
           @project.write!("foo.rb", <<~RB)
             field(:field1)


### PR DESCRIPTION
## Problem

The GraphQL plugin only handles `field :name` (and `resolver_method:`). Methods referenced through other graphql-ruby DSL patterns are incorrectly flagged as dead:

- `argument :name, prepare: :method` — the prepare method is called by graphql-ruby when processing the input
- `builds :thing` — graphql-ruby convention that calls `build_thing` on the mutation
- `argument :name, method: :method` — custom method for argument resolution

## Fix

Extended the GraphQL plugin's `on_send` to handle `argument` (with `prepare:` and `method:` keywords) and `builds` (with convention-based `build_#{name}` method reference).

## Test plan

Added minitest cases for each new pattern.

Made with [Cursor](https://cursor.com)