### PR TITLE
Remove sigs attached to methods defined with modifier calls

### DIFF
--- a/lib/spoom/deadcode/remover.rb
+++ b/lib/spoom/deadcode/remover.rb
@@ -67,20 +67,15 @@ module Spoom
 
         private
 
-        # When a method is defined as the argument of a modifier call (e.g. `private def foo; end`,
-        # `private_class_method def self.foo; end`, or `abstract def foo; end`), the `def` node's
-        # parent is the modifier call rather than the enclosing class or module body. The sigs and
-        # comments attached to the method are siblings of the outermost such call, so return a
-        # context targeting that call to remove them together with the method.
+        # When a method is defined as the argument of a modifier call (e.g. `private def foo; end` or
+        # `private_class_method def self.foo; end`), the `def` node's parent is the call rather than the
+        # enclosing class or module body, so its sigs and comments are siblings of the call. Return a
+        # context targeting the outermost such call so they are removed together with the method.
         #
-        # Any modifier is matched structurally (rather than from a fixed list) so user-defined and
-        # future modifiers are handled too. To stay safe, a call only counts as a modifier when the
-        # wrapped node is its *sole* argument: such a call exists only to wrap that one method, so
-        # removing it whole is correct regardless of the modifier's name. A call that takes other
-        # arguments (e.g. `register(:thing, def foo; end)`) has its own purpose, so we leave it in
-        # place and remove only the `def`. The remaining ambiguous case — a single-argument
-        # user-defined macro with a side effect — is structurally indistinguishable from a real
-        # modifier and vanishingly rare, so we treat it like one.
+        # Modifiers are matched structurally rather than from a fixed list, so user-defined ones are
+        # handled too. A call only counts as a modifier when the `def` is its sole argument and it takes
+        # no block, so we never remove a call that does more than wrap the method (e.g.
+        # `register(:thing, def foo; end)`).
         #: (Prism::DefNode def_node) -> NodeContext?
         def modifier_call_context(def_node)
           wrapped = def_node #: Prism::Node
@@ -91,11 +86,11 @@ module Spoom
           while (ancestor = nesting.pop)
             case ancestor
             when Prism::ArgumentsNode
-              # An arguments node sits between a call and its arguments, keep climbing.
+              # An arguments node sits between a call and its arguments, keep climbing
               next
             when Prism::CallNode
-              # Stop unless this call wraps the node as its sole argument (and takes no block), so we
-              # never delete sibling arguments or a call doing more than wrapping the method.
+              # Stop unless the call wraps the node as its sole argument and takes no block, otherwise
+              # it does more than wrap the method and we must not remove it
               args = ancestor.arguments&.arguments
               break if ancestor.block
               break unless args && args.size == 1 && args.first.equal?(wrapped)

--- a/lib/spoom/deadcode/remover.rb
+++ b/lib/spoom/deadcode/remover.rb
@@ -74,8 +74,8 @@ module Spoom
         #
         # Modifiers are matched structurally rather than from a fixed list, so user-defined ones are
         # handled too. A call only counts as a modifier when the `def` is its sole argument and it takes
-        # no block, so we never remove a call that does more than wrap the method (e.g.
-        # `register(:thing, def foo; end)`).
+        # no block and is a standalone statement, so we never remove a call that does more than wrap
+        # the method (e.g. `register(:thing, def foo; end)` or `FOO = register(def foo; end)`).
         #: (Prism::DefNode def_node) -> NodeContext?
         def modifier_call_context(def_node)
           wrapped = def_node #: Prism::Node
@@ -103,6 +103,7 @@ module Spoom
             end
           end
           return unless outer_call && outer_nesting
+          return unless outer_nesting.last.is_a?(Prism::StatementsNode)
 
           NodeContext.new(@old_source, @node_context.comments, outer_call, outer_nesting)
         end

--- a/lib/spoom/deadcode/remover.rb
+++ b/lib/spoom/deadcode/remover.rb
@@ -49,7 +49,7 @@ module Spoom
           node = @node_context.node
           case node
           when Prism::ClassNode, Prism::ModuleNode, Prism::DefNode
-            delete_node_and_comments_and_sigs(@node_context)
+            delete_node_and_comments_and_sigs(modifier_call_context || @node_context)
           when Prism::ConstantWriteNode, Prism::ConstantOperatorWriteNode,
                 Prism::ConstantAndWriteNode, Prism::ConstantOrWriteNode,
                 Prism::ConstantPathWriteNode, Prism::ConstantPathOperatorWriteNode,
@@ -64,6 +64,54 @@ module Spoom
         end
 
         private
+
+        # When a method is defined as the argument of a modifier call (e.g. `private def foo; end`,
+        # `private_class_method def self.foo; end`, or `abstract def foo; end`), the `def` node's
+        # parent is the modifier call rather than the enclosing class or module body. The sigs and
+        # comments attached to the method are siblings of the outermost such call, so return a
+        # context targeting that call to remove them together with the method.
+        #
+        # Any modifier is matched structurally (rather than from a fixed list) so user-defined and
+        # future modifiers are handled too. To stay safe, a call only counts as a modifier when the
+        # wrapped node is its *sole* argument: such a call exists only to wrap that one method, so
+        # removing it whole is correct regardless of the modifier's name. A call that takes other
+        # arguments (e.g. `register(:thing, def foo; end)`) has its own purpose, so we leave it in
+        # place and remove only the `def`. The remaining ambiguous case — a single-argument
+        # user-defined macro with a side effect — is structurally indistinguishable from a real
+        # modifier and vanishingly rare, so we treat it like one.
+        #: -> NodeContext?
+        def modifier_call_context
+          wrapped = @node_context.node #: Prism::Node
+          return unless wrapped.is_a?(Prism::DefNode)
+
+          nesting = @node_context.nesting
+          call_index = nil #: Integer?
+
+          index = nesting.size - 1
+          while index >= 0
+            ancestor = nesting.fetch(index)
+            case ancestor
+            when Prism::ArgumentsNode
+              # An arguments node sits between a call and its arguments, keep climbing.
+            when Prism::CallNode
+              # Stop unless this call wraps the node as its sole argument (and takes no block), so we
+              # never delete sibling arguments or a call doing more than wrapping the method.
+              args = ancestor.arguments&.arguments
+              break if ancestor.block
+              break unless args && args.size == 1 && args.first.equal?(wrapped)
+
+              wrapped = ancestor
+              call_index = index
+            else
+              break
+            end
+            index -= 1
+          end
+          return unless call_index
+
+          call = nesting.fetch(call_index)
+          NodeContext.new(@old_source, @node_context.comments, call, nesting[0...call_index] || [])
+        end
 
         #: (NodeContext context) -> void
         def delete_constant_assignment(context)

--- a/lib/spoom/deadcode/remover.rb
+++ b/lib/spoom/deadcode/remover.rb
@@ -48,8 +48,10 @@ module Spoom
 
           node = @node_context.node
           case node
-          when Prism::ClassNode, Prism::ModuleNode, Prism::DefNode
-            delete_node_and_comments_and_sigs(modifier_call_context || @node_context)
+          when Prism::ClassNode, Prism::ModuleNode
+            delete_node_and_comments_and_sigs(@node_context)
+          when Prism::DefNode
+            delete_node_and_comments_and_sigs(modifier_call_context(node) || @node_context)
           when Prism::ConstantWriteNode, Prism::ConstantOperatorWriteNode,
                 Prism::ConstantAndWriteNode, Prism::ConstantOrWriteNode,
                 Prism::ConstantPathWriteNode, Prism::ConstantPathOperatorWriteNode,
@@ -79,20 +81,18 @@ module Spoom
         # place and remove only the `def`. The remaining ambiguous case — a single-argument
         # user-defined macro with a side effect — is structurally indistinguishable from a real
         # modifier and vanishingly rare, so we treat it like one.
-        #: -> NodeContext?
-        def modifier_call_context
-          wrapped = @node_context.node #: Prism::Node
-          return unless wrapped.is_a?(Prism::DefNode)
+        #: (Prism::DefNode def_node) -> NodeContext?
+        def modifier_call_context(def_node)
+          wrapped = def_node #: Prism::Node
+          nesting = @node_context.nesting.dup
+          outer_call = nil #: Prism::CallNode?
+          outer_nesting = nil #: Array[Prism::Node]?
 
-          nesting = @node_context.nesting
-          call_index = nil #: Integer?
-
-          index = nesting.size - 1
-          while index >= 0
-            ancestor = nesting.fetch(index)
+          while (ancestor = nesting.pop)
             case ancestor
             when Prism::ArgumentsNode
               # An arguments node sits between a call and its arguments, keep climbing.
+              next
             when Prism::CallNode
               # Stop unless this call wraps the node as its sole argument (and takes no block), so we
               # never delete sibling arguments or a call doing more than wrapping the method.
@@ -101,16 +101,15 @@ module Spoom
               break unless args && args.size == 1 && args.first.equal?(wrapped)
 
               wrapped = ancestor
-              call_index = index
+              outer_call = ancestor
+              outer_nesting = nesting.dup
             else
               break
             end
-            index -= 1
           end
-          return unless call_index
+          return unless outer_call && outer_nesting
 
-          call = nesting.fetch(call_index)
-          NodeContext.new(@old_source, @node_context.comments, call, nesting[0...call_index] || [])
+          NodeContext.new(@old_source, @node_context.comments, outer_call, outer_nesting)
         end
 
         #: (NodeContext context) -> void

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -1519,6 +1519,9 @@ class Spoom::Deadcode::Remover::NodeRemover
   end
   def insert_accessor(node, send_context, was_removed:); end
 
+  sig { returns(T.nilable(::Spoom::Deadcode::Remover::NodeContext)) }
+  def modifier_call_context; end
+
   sig { params(start_char: ::Integer, end_char: ::Integer, replacement: ::String).void }
   def replace_chars(start_char, end_char, replacement); end
 

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -1519,8 +1519,8 @@ class Spoom::Deadcode::Remover::NodeRemover
   end
   def insert_accessor(node, send_context, was_removed:); end
 
-  sig { returns(T.nilable(::Spoom::Deadcode::Remover::NodeContext)) }
-  def modifier_call_context; end
+  sig { params(def_node: ::Prism::DefNode).returns(T.nilable(::Spoom::Deadcode::Remover::NodeContext)) }
+  def modifier_call_context(def_node); end
 
   sig { params(start_char: ::Integer, end_char: ::Integer, replacement: ::String).void }
   def replace_chars(start_char, end_char, replacement); end

--- a/test/spoom/deadcode/remover_test.rb
+++ b/test/spoom/deadcode/remover_test.rb
@@ -1120,6 +1120,29 @@ module Spoom
         RB
       end
 
+      def test_keeps_parent_expression_when_sole_argument_call_is_not_a_statement
+        res = remove(<<~RB, "bar")
+          class Foo
+            FOO = register(
+              def bar
+                x
+              end
+            )
+
+            def keep; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            FOO = register(
+            )
+
+            def keep; end
+          end
+        RB
+      end
+
       def test_removes_node_sig_and_comments
         res = remove(<<~RB, "bar")
           class Foo

--- a/test/spoom/deadcode/remover_test.rb
+++ b/test/spoom/deadcode/remover_test.rb
@@ -940,6 +940,186 @@ module Spoom
         RB
       end
 
+      def test_removes_node_sig_with_visibility_modifier
+        res = remove(<<~RB, "bar")
+          class Foo
+            def foo; end
+
+            sig { void }
+            private_class_method def self.bar
+              something
+            end
+
+            def baz; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def foo; end
+
+            def baz; end
+          end
+        RB
+      end
+
+      def test_removes_node_sig_with_custom_modifier
+        res = remove(<<~RB, "bar")
+          class Foo
+            def foo; end
+
+            # A comment
+            sig { void }
+            some_custom_modifier def bar
+              something
+            end
+
+            def baz; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def foo; end
+
+            def baz; end
+          end
+        RB
+      end
+
+      def test_removes_node_sig_with_nested_modifiers
+        res = remove(<<~RB, "bar")
+          class Foo
+            def foo; end
+
+            sig { void }
+            private abstract def bar
+              something
+            end
+
+            def baz; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def foo; end
+
+            def baz; end
+          end
+        RB
+      end
+
+      def test_removes_node_sig_with_modifier_as_last_statement
+        res = remove(<<~RB, "bar")
+          class Foo
+            def foo; end
+
+            sig { void }
+            private def bar
+              something
+            end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def foo; end
+          end
+        RB
+      end
+
+      def test_removes_single_line_def_with_modifier
+        res = remove(<<~RB, "bar")
+          class Foo
+            def foo; end
+            private def bar; end
+            def baz; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def foo; end
+            def baz; end
+          end
+        RB
+      end
+
+      def test_removes_def_with_modifier_without_sig
+        res = remove(<<~RB, "bar")
+          class Foo
+            def foo; end
+
+            private_class_method def self.bar
+              something
+            end
+
+            def baz; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            def foo; end
+
+            def baz; end
+          end
+        RB
+      end
+
+      def test_keeps_call_when_def_is_not_the_sole_argument
+        # `bar` is a positional argument to `register`, not wrapped by a modifier, so only the `def`
+        # is removed and the call (along with its other arguments) is preserved.
+        res = remove(<<~RB, "bar")
+          class Foo
+            register(
+              :thing,
+              def bar
+                x
+              end,
+            )
+
+            def keep; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            register(
+              :thing,
+            )
+
+            def keep; end
+          end
+        RB
+      end
+
+      def test_keeps_sibling_arguments_when_def_is_not_the_sole_argument
+        res = remove(<<~RB, "bar")
+          class Foo
+            memoize(
+              def bar
+                x
+              end,
+              ttl: 60,
+            )
+
+            def keep; end
+          end
+        RB
+
+        assert_equal(<<~RB, res)
+          class Foo
+            memoize(
+              ttl: 60,
+            )
+
+            def keep; end
+          end
+        RB
+      end
+
       def test_removes_node_sig_and_comments
         res = remove(<<~RB, "bar")
           class Foo


### PR DESCRIPTION
### Motivation

When the deadcode remover removes a method defined as the argument of a modifier
call — e.g. `private def foo; end`, `private_class_method def self.foo; end`, or
`abstract def foo; end` — it removes the method but leaves the method's `sig`
(and any attached comments) behind:

```ruby
class Foo
  sig { params(value: Integer).void }
  private_class_method def self.bar(value)
    something
  end

  def baz; end
end
```

Removing `bar` currently produces:

```ruby
class Foo
  sig { params(value: Integer).void }

  def baz; end
end
```

The orphaned `sig` then attaches to the *next* method definition (`baz`). This
goes wrong in a few ways:

- It's a Sorbet error when the leftover sig doesn't match the following method —
  here `baz` has no `value` parameter.
- When the following method has its *own* sig, removal leaves two `sig`s with no
  method definition between them, which is also a Sorbet error.
- When the leftover sig happens to be compatible with the following method, it's
  arguably worse: it silently re-types an unrelated method with no error at all.

### Cause

For `private_class_method def self.bar`, the `def` node's parent in the nesting
is the modifier call's arguments rather than the enclosing class/module body.
`attached_sigs` walks the `def`'s siblings, so it never sees the `sig` (and
comments) that are declared as siblings of the modifier *call*.

### Fix

When removing a `def` that is wrapped in a modifier call, target the (outermost)
wrapping call instead of the `def`, so its attached sigs and comments are removed
together with the method.

The wrapping call is detected **structurally** (a call that takes the method as an
argument, climbing through nested modifiers) rather than by matching a fixed list of
names. This way user-defined modifiers and future ones — e.g. Sorbet's proposed
[`abstract def`](https://github.com/sorbet/sorbet/pull/10276) — are handled without
maintaining an allowlist.

To stay safe, a call only counts as a modifier when the `def` is its **sole**
argument (and it takes no block). Such a call exists only to wrap that one method,
so removing it whole is correct regardless of the modifier's name. A call that takes
other arguments — e.g. `register(:thing, def bar; end)` or `memoize def bar; end, ttl: 60`
— has its own purpose, so we leave the call (and its sibling arguments) in place and
remove only the `def`. The only remaining ambiguous case, a single-argument
user-defined macro with a side effect, is structurally indistinguishable from a real
modifier and vanishingly rare, so we treat it like one.

After the fix the example above becomes:

```ruby
class Foo
  def baz; end
end
```

### Tests

Added tests covering:

- a visibility modifier (`private_class_method def self.bar`), an arbitrary custom
  modifier, and nested modifiers (`private abstract def bar`) — the sole-argument
  cases where the whole wrapping call (and its sigs/comments) is removed;
- a modifier-wrapped def as the last statement in the body;
- single-line and sig-less modifier forms;
- a `def` passed as a non-sole argument (`register(:thing, def bar; end)`) and a call
  with a trailing keyword argument (`memoize(def bar…, ttl: 60)`) — confirming the
  call and its sibling arguments are preserved and only the `def` is removed.

The full remover suite and `srb tc`/RuboCop pass.
