### PR TITLE
Add rewriter option to erase generics

### DIFF
--- a/lib/spoom/cli/srb/sigs.rb
+++ b/lib/spoom/cli/srb/sigs.rb
@@ -26,6 +26,10 @@ module Spoom
         option :translate_generics, type: :boolean, desc: "Translate generics", default: false
         option :translate_helpers, type: :boolean, desc: "Translate helpers", default: false
         option :translate_abstract_methods, type: :boolean, desc: "Translate abstract methods", default: false
+        option :erase_generic_types,
+          type: :boolean,
+          desc: "Drop generic types when translating from RBS to RBI",
+          default: false
         def translate(*paths)
           from = options[:from]
           to = options[:to]
@@ -70,6 +74,7 @@ module Spoom
                 contents,
                 file: file,
                 max_line_length: max_line_length,
+                erase_generic_types: options[:erase_generic_types],
               )
             end
           end

--- a/lib/spoom/sorbet/translate.rb
+++ b/lib/spoom/sorbet/translate.rb
@@ -68,6 +68,7 @@ module Spoom
             file: file,
             max_line_length: max_line_length,
             overloads_strategy: overloads_strategy,
+            erase_generic_types: erase_generic_types,
           )
         end
 

--- a/lib/spoom/sorbet/translate.rb
+++ b/lib/spoom/sorbet/translate.rb
@@ -59,8 +59,10 @@ module Spoom
 
         # Converts all the RBS comments in the given Ruby code to `sig` nodes.
         # It also handles type members and class annotations.
-        #: (String ruby_contents, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> String
-        def rbs_comments_to_sorbet_sigs(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
+        #: (String ruby_contents, file: String, ?max_line_length: Integer?,
+        #| ?overloads_strategy: Symbol, ?erase_generic_types: bool) -> String
+        def rbs_comments_to_sorbet_sigs(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all,
+          erase_generic_types: false)
           RBSCommentsToSorbetSigs.rewrite_if_needed(
             ruby_contents,
             file: file,

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
@@ -28,17 +28,20 @@ module Spoom
           #|   String ruby_contents,
           #|   file: String,
           #|   ?max_line_length: Integer?,
-          #|   ?overloads_strategy: Symbol) -> String
+          #|   ?overloads_strategy: Symbol,
+          #|   ?erase_generic_types: bool) -> String
           def rewrite_if_needed(
             ruby_contents,
             file:,
             max_line_length: nil,
-            overloads_strategy: :translate_all
+            overloads_strategy: :translate_all,
+            erase_generic_types: false
           )
             return ruby_contents unless contains_rbs_syntax?(ruby_contents)
 
             options = Options.new(
               overloads_strategy:,
+              erase_generic_types:,
               output_format: HumanReadableRBIFormat.new(
                 max_line_length:,
               ),

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -475,7 +475,7 @@ module Spoom
               )
 
               @rewriter << Source::Delete.new(from, to)
-              content = "#{indent}#{alias_name} = T.type_alias { #{sorbet_type.to_rbi} }\n"
+              content = "#{indent}#{alias_name} = ::T.type_alias { #{sorbet_type.to_rbi} }\n"
               content = pad_out_line_count(of: content, to_height_of: type_alias)
               @rewriter << Source::Insert.new(insert_pos, content)
             rescue ::RBS::ParsingError, ::RBI::Error

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -26,7 +26,8 @@ module Spoom
 
             @overloads_strategy = options.overloads_strategy #: Symbol
             @translate_abstract_methods = options.translate_abstract_methods #: bool
-            @type_translator = RBI::RBS::TypeTranslator.new #: RBI::RBS::TypeTranslator
+            @options = options #: Options
+            @type_translator = RBI::RBS::TypeTranslator.new(options: options.rbi_options) #: RBI::RBS::TypeTranslator
           end
 
           # @override
@@ -163,7 +164,7 @@ module Spoom
                 next
               end
 
-              translator = RBI::RBS::MethodTypeTranslator.new(rbi_node)
+              translator = RBI::RBS::MethodTypeTranslator.new(rbi_node, options: @options.rbi_options)
 
               begin
                 translator.visit(method_type)
@@ -272,6 +273,18 @@ module Spoom
                 type_params = ::RBS::Parser.parse_type_params(signature.string)
                 rewrite_type_params_signature(signature, type_params:)
                 next if type_params.empty?
+
+                if @options.erase_generic_types
+                  type_params.each do |type_param|
+                    insert_type_member(
+                      "#{type_param.name} = ::T.type_alias { ::T.anything }",
+                      parent_node: node,
+                      insert_pos:,
+                    )
+                  end
+
+                  next
+                end
 
                 unless already_extends?(node, /^(::)?T::Generic$/)
                   extend_with("T::Generic", into: node, at: insert_pos)

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
@@ -47,6 +47,9 @@ module Spoom
           #: bool
           attr_reader :erase_generic_types
 
+          #: RBI::RBS::MethodTypeTranslator::Options
+          attr_reader :rbi_options
+
           #: BaseRBIFormat
           attr_reader :output_format
 
@@ -72,6 +75,7 @@ module Spoom
 
             @overloads_strategy = overloads_strategy
             @erase_generic_types = erase_generic_types
+            @rbi_options = RBI::RBS::MethodTypeTranslator::Options.new(erase_generic_types:) #: RBI::RBS::MethodTypeTranslator::Options
             @output_format = output_format
             @translate_abstract_methods = translate_abstract_methods
 

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2926,10 +2926,11 @@ module Spoom::Sorbet::Translate
         ruby_contents: ::String,
         file: ::String,
         max_line_length: T.nilable(::Integer),
-        overloads_strategy: ::Symbol
+        overloads_strategy: ::Symbol,
+        erase_generic_types: T::Boolean
       ).returns(::String)
     end
-    def rbs_comments_to_sorbet_sigs(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil)); end
+    def rbs_comments_to_sorbet_sigs(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil), erase_generic_types: T.unsafe(nil)); end
 
     sig do
       params(
@@ -3008,10 +3009,11 @@ module Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs
         ruby_contents: ::String,
         file: ::String,
         max_line_length: T.nilable(::Integer),
-        overloads_strategy: ::Symbol
+        overloads_strategy: ::Symbol,
+        erase_generic_types: T::Boolean
       ).returns(::String)
     end
-    def rewrite_if_needed(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil)); end
+    def rewrite_if_needed(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil), erase_generic_types: T.unsafe(nil)); end
   end
 end
 
@@ -3253,6 +3255,9 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options
 
   sig { returns(::Symbol) }
   def overloads_strategy; end
+
+  sig { returns(::RBI::RBS::MethodTypeTranslator::Options) }
+  def rbi_options; end
 
   sig { returns(T::Boolean) }
   def translate_abstract_methods; end

--- a/test/spoom/cli/srb/sigs_test.rb
+++ b/test/spoom/cli/srb/sigs_test.rb
@@ -223,7 +223,7 @@ module Spoom
             # typed: true
 
             class Box
-              E = T.type_alias { ::T.anything }
+              E = ::T.type_alias { ::T.anything }
 
               sig { returns(Array) }
               def values

--- a/test/spoom/cli/srb/sigs_test.rb
+++ b/test/spoom/cli/srb/sigs_test.rb
@@ -197,6 +197,46 @@ module Spoom
           RB
         end
 
+        def test_translate_rbs_to_rbi_with_erase_generic_types
+          @project.write!("file.rb", <<~RB)
+            # typed: true
+
+            #: [E]
+            class Box
+              #: -> Array[E]
+              def values
+                []
+              end
+
+              #: (E) -> void
+              def push(value)
+              end
+            end
+          RB
+
+          result = @project.spoom("srb sigs translate --from rbs --to rbi --no-color --erase-generic-types")
+
+          assert_empty(result.err)
+          assert(result.status)
+
+          assert_equal(<<~RB, @project.read("file.rb"))
+            # typed: true
+
+            class Box
+              E = T.type_alias { ::T.anything }
+
+              sig { returns(Array) }
+              def values
+                []
+              end
+
+              sig { params(value: E).void }
+              def push(value)
+              end
+            end
+          RB
+        end
+
         def test_translate_includes_rbi_files
           @project.write!("file.rb", <<~RB)
             sig { void }

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -924,8 +924,8 @@ module Spoom
 
             to_pretty_format_for_humans: <<~RUBY,
               module Aliases
-                Foo = T.type_alias { ::T.any(Integer, String) }
-                MultiLine = T.type_alias { ::T.any(Integer, String) }
+                Foo = ::T.type_alias { ::T.any(Integer, String) }
+                MultiLine = ::T.type_alias { ::T.any(Integer, String) }
               end
 
               sig { params(a: Aliases::Foo).returns(Aliases::MultiLine) }
@@ -936,8 +936,8 @@ module Spoom
 
             to_line_matched_format_for_machines: <<~RUBY,
               module Aliases
-                Foo = T.type_alias { ::T.any(Integer, String) }
-                MultiLine = T.type_alias { ::T.any(Integer, String) }
+                Foo = ::T.type_alias { ::T.any(Integer, String) }
+                MultiLine = ::T.type_alias { ::T.any(Integer, String) }
 
 
               end
@@ -963,8 +963,8 @@ module Spoom
             RUBY
 
             to_pretty_format_for_humans: <<~RUBY,
-              Foo::UserId = T.type_alias { Integer }
-              ::Bar::UserData = T.type_alias { { id: Foo::UserId, name: String } }
+              Foo::UserId = ::T.type_alias { Integer }
+              ::Bar::UserData = ::T.type_alias { { id: Foo::UserId, name: String } }
 
               sig { params(data: ::Bar::UserData).returns(Foo::UserId) }
               def process_user(data)
@@ -991,7 +991,7 @@ module Spoom
 
             to_pretty_format_for_humans: <<~RUBY,
               class Example
-                Status = T.type_alias { Symbol }
+                Status = ::T.type_alias { Symbol }
 
                 sig { returns(Status) }
                 def get_status
@@ -1016,7 +1016,7 @@ module Spoom
 
             to_pretty_format_for_humans: <<~RUBY,
               class Example
-                Status = T.type_alias { Symbol }
+                Status = ::T.type_alias { Symbol }
                 sig { returns(Status) }
                 def status; end
               end
@@ -1040,7 +1040,7 @@ module Spoom
             RUBY
 
             to_pretty_format_for_humans: <<~RUBY,
-              List = T.type_alias { ::T::Array[Integer] }
+              List = ::T.type_alias { ::T::Array[Integer] }
 
               sig { params(items: List).returns(List) }
               def double_items(items)
@@ -1093,7 +1093,7 @@ module Spoom
             RUBY
 
             to_pretty_format_for_humans: <<~RUBY,
-              NullableString = T.type_alias { ::T.nilable(String) }
+              NullableString = ::T.type_alias { ::T.nilable(String) }
 
               sig { params(text: NullableString).returns(String) }
               def ensure_string(text)
@@ -1139,7 +1139,7 @@ module Spoom
             RUBY
 
             to_pretty_format_for_humans: <<~RUBY,
-              MultiLine = T.type_alias { ::T.any(String, Integer) }
+              MultiLine = ::T.type_alias { ::T.any(String, Integer) }
               # foo bar baz
               #| | Symbol
 
@@ -1150,7 +1150,7 @@ module Spoom
             RUBY
 
             to_line_matched_format_for_machines: <<~RUBY,
-              MultiLine = T.type_alias { ::T.any(String, Integer) }
+              MultiLine = ::T.type_alias { ::T.any(String, Integer) }
 
 
               # foo bar baz
@@ -1190,7 +1190,7 @@ module Spoom
 
             to_pretty_format_for_humans: <<~RUBY,
               module Foo
-                SerializedRange = T.type_alias { [Integer, Integer] }
+                SerializedRange = ::T.type_alias { [Integer, Integer] }
                 class Range
                 end
               end

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -622,6 +622,176 @@ module Spoom
           )
         end
 
+        def test_translate_to_rbi_preserves_generic_types
+          contents = <<~RB
+            #: -> Array[Integer]
+            def foo
+              []
+            end
+          RB
+
+          assert_equal(<<~RB, rbs_comments_to_sorbet_sigs(contents))
+            sig { returns(::T::Array[Integer]) }
+            def foo
+              []
+            end
+          RB
+        end
+
+        def test_translate_to_rbi_with_erase_generic_class_types
+          assert_rewrites_rbs(
+            erase_generic_types: true,
+            from: <<~RB,
+              #: [T, in A, out B, C < Numeric, D > Numeric, E = String]
+              class Result
+                #: (T, E?) -> void
+                def initialize(value, error)
+                  @value = value
+                  @error = error
+                end
+
+                #: T
+                attr_reader :value
+
+                #: E?
+                attr_writer :error
+              end
+
+              #: (String) -> Result[Integer, String]
+              def parse_int(str)
+                Result.new(Integer(str), nil) #: Result[Integer, String]
+              end
+            RB
+
+            to_pretty_format_for_humans: <<~RB,
+              class Result
+                T = ::T.type_alias { ::T.anything }
+
+                A = ::T.type_alias { ::T.anything }
+
+                B = ::T.type_alias { ::T.anything }
+
+                C = ::T.type_alias { ::T.anything }
+
+                D = ::T.type_alias { ::T.anything }
+
+                E = ::T.type_alias { ::T.anything }
+
+                sig { params(value: T, error: ::T.nilable(E)).void }
+                def initialize(value, error)
+                  @value = value
+                  @error = error
+                end
+
+                sig { returns(T) }
+                attr_reader :value
+
+                sig { params(error: ::T.nilable(E)).returns(::T.nilable(E)) }
+                attr_writer :error
+              end
+
+              sig { params(str: String).returns(Result) }
+              def parse_int(str)
+                Result.new(Integer(str), nil) #: Result[Integer, String]
+              end
+            RB
+
+            to_line_matched_format_for_machines: <<~RB,
+              # RBS_WRITTEN_ANNOTATION: [T, in A, out B, C < Numeric, D > Numeric, E = String]
+              class Result; T = ::T.type_alias { ::T.anything }; A = ::T.type_alias { ::T.anything }; B = ::T.type_alias { ::T.anything }; C = ::T.type_alias { ::T.anything }; D = ::T.type_alias { ::T.anything }; E = ::T.type_alias { ::T.anything }
+                sig { params(value: T, error: ::T.nilable(E)).void }
+                def initialize(value, error)
+                  @value = value
+                  @error = error
+                end
+
+                sig { returns(T) }
+                attr_reader :value
+
+                sig { params(error: ::T.nilable(E)).returns(::T.nilable(E)) }
+                attr_writer :error
+              end
+
+              sig { params(str: String).returns(Result) }
+              def parse_int(str)
+                Result.new(Integer(str), nil) #: Result[Integer, String]
+              end
+            RB
+          )
+        end
+
+        def test_translate_to_rbi_with_erase_generic_method_types
+          assert_rewrites_rbs(
+            erase_generic_types: true,
+            from: <<~RB,
+              class Factory
+                #: [T] (T?) -> T?
+                def self.identity(value)
+                  value
+                end
+
+                class << self
+                  #: [U] (U) -> U
+                  def wrap(value)
+                    value
+                  end
+                end
+
+                #: [V]
+                class << self
+                  #: -> V
+                  def build; end
+                end
+              end
+            RB
+
+            to_pretty_format_for_humans: <<~RB,
+              class Factory
+                sig { params(value: ::T.nilable(::T.anything)).returns(::T.nilable(::T.anything)) }
+                def self.identity(value)
+                  value
+                end
+
+                class << self
+                  sig { params(value: ::T.anything).returns(::T.anything) }
+                  def wrap(value)
+                    value
+                  end
+                end
+
+                class << self
+                  V = ::T.type_alias { ::T.anything }
+
+                  sig { returns(V) }
+                  def build; end
+                end
+              end
+            RB
+
+            to_line_matched_format_for_machines: <<~RB,
+              class Factory
+                sig { params(value: ::T.nilable(::T.anything)).returns(::T.nilable(::T.anything)) }
+                def self.identity(value)
+                  value
+                end
+
+                class << self
+                  sig { params(value: ::T.anything).returns(::T.anything) }
+                  def wrap(value)
+                    value
+                  end
+                end
+
+                # RBS_WRITTEN_ANNOTATION: [V]
+                class << self; V = ::T.type_alias { ::T.anything }
+                  sig { returns(V) }
+                  def build; end
+                end
+              end
+            RB
+          )
+        end
+
         def test_translate_to_rbi_in_block
           assert_rewrites_rbs(
             from: <<~RUBY,
@@ -877,6 +1047,35 @@ module Spoom
                 items.map { |x| x * 2 }
               end
             RUBY
+
+            to_line_matched_format_for_machines: :same_as_pretty_output,
+          )
+        end
+
+        def test_translate_type_alias_with_erase_generic_types
+          assert_rewrites_rbs(
+            erase_generic_types: true,
+            from: <<~RB,
+              class Box; end
+
+              #: type boxed_string = Box[String]
+
+              #: () -> boxed_string
+              def build_box
+                Box.new
+              end
+            RB
+
+            to_pretty_format_for_humans: <<~RB,
+              class Box; end
+
+              BoxedString = ::T.type_alias { Box }
+
+              sig { returns(BoxedString) }
+              def build_box
+                Box.new
+              end
+            RB
 
             to_line_matched_format_for_machines: :same_as_pretty_output,
           )
@@ -1343,19 +1542,22 @@ module Spoom
         #: (String,
         #|   ?max_line_length: Integer?,
         #|   ?overloads_strategy: Symbol,
-        #|   ?translate_abstract_methods: bool
+        #|   ?translate_abstract_methods: bool,
+        #|   ?erase_generic_types: bool
         #| ) -> String
         def rbs_comments_to_sorbet_sigs(
           ruby_contents,
           max_line_length: nil,
           overloads_strategy: :translate_all,
-          translate_abstract_methods: true
+          translate_abstract_methods: true,
+          erase_generic_types: false
         )
           RBSCommentsToSorbetSigs::HumanReadableTranslator.new(
             ruby_contents,
             file: "test.rb",
             options: RBSCommentsToSorbetSigs::Options.new(
               overloads_strategy:,
+              erase_generic_types: erase_generic_types,
               translate_abstract_methods:,
               output_format: RBSCommentsToSorbetSigs::HumanReadableRBIFormat.new(
                 max_line_length:,
@@ -1370,7 +1572,8 @@ module Spoom
         #|   to_line_matched_format_for_machines: String | Symbol,
         #|   ?max_line_length: Integer?,
         #|   ?overloads_strategy: Symbol,
-        #|   ?translate_abstract_methods: bool
+        #|   ?translate_abstract_methods: bool,
+        #|   ?erase_generic_types: bool
         #| ) -> void
         def assert_rewrites_rbs(
           from:,
@@ -1378,7 +1581,8 @@ module Spoom
           to_line_matched_format_for_machines:,
           max_line_length: nil,
           overloads_strategy: :translate_all,
-          translate_abstract_methods: true
+          translate_abstract_methods: true,
+          erase_generic_types: false
         )
           source_with_rbs = from
           expected_pretty_format = to_pretty_format_for_humans
@@ -1390,6 +1594,7 @@ module Spoom
               max_line_length:,
               overloads_strategy:,
               translate_abstract_methods:,
+              erase_generic_types:,
             )
 
             assert_equal(expected_pretty_format, rewritten_output)
@@ -1421,6 +1626,7 @@ module Spoom
               options: RBSCommentsToSorbetSigs::Options.new(
                 overloads_strategy:,
                 translate_abstract_methods:,
+                erase_generic_types:,
                 output_format: RBSCommentsToSorbetSigs::LineMatchedRBIFormat.default,
               ),
             ).rewrite


### PR DESCRIPTION
- part of https://github.com/Shopify/spoom/issues/924

> May be easier to review by commit :)

Sorbet ignores generic types at runtime as they [cannot be enforced](https://sorbet.org/docs/stdlib-generics#generics-and-runtime-checks). This means in runtime contexts we can drop generic types entirely, simplifying the RBS to Sorbet signature translation

This PR adds an `erase_generic_types` option to the `RBSCommentsToSorbetSigs` rewriter and `--erase-generic-types flag` to CLI. When enabled generic `Foo[Bar]` will become `Foo` and type members will become type aliases of `T.anything`