### PR TITLE
Skip RBS type aliases as node signatures

### DIFF
--- a/lib/spoom/rbs.rb
+++ b/lib/spoom/rbs.rb
@@ -105,6 +105,9 @@ module Spoom
               location = location.join(continuation_comment.location)
             end
             continuation_comments.clear
+
+            next if string.start_with?("type ")
+
             res.signatures.prepend(Signature.new(string, location))
           elsif string.start_with?("#|")
             continuation_comments << comment

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -629,6 +629,28 @@ module Spoom
           )
         end
 
+        def test_translate_type_alias_before_method_sig_with_translate_last_overloads_strategy
+          assert_rewrites_rbs(
+            from: <<~RUBY,
+              class Example
+                #: type status = Symbol
+                #: () -> status
+                def status; end
+              end
+            RUBY
+
+            to_pretty_format_for_humans: <<~RUBY,
+              class Example
+                Status = T.type_alias { Symbol }
+                sig { returns(Status) }
+                def status; end
+              end
+            RUBY
+
+            overloads_strategy: :translate_last,
+          )
+        end
+
         def test_translate_type_alias_with_generics
           assert_rewrites_rbs(
             from: <<~RUBY,


### PR DESCRIPTION
Fixes https://github.com/Shopify/spoom/issues/947

Consumers of `node_rbs_comments` shouldn't receive a type alias comment. It's handled seperately in https://github.com/Shopify/spoom/blob/a2a57127c6337e368fbc6272dc7a2bbf1dcdf5a7/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb#L368