### PR TITLE
Rename `RBSCommentsToSorbetSigs` to `HumanReadableTranslator`

### DIFF
--- a/lib/spoom/sorbet/translate.rb
+++ b/lib/spoom/sorbet/translate.rb
@@ -5,7 +5,7 @@ require "rbi"
 
 require "spoom/source/rewriter"
 require "spoom/sorbet/translate/translator"
-require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs"
+require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator"
 require "spoom/sorbet/translate/sorbet_assertions_to_rbs_comments"
 require "spoom/sorbet/translate/sorbet_sigs_to_rbs_comments"
 require "spoom/sorbet/translate/strip_sorbet_sigs"

--- a/lib/spoom/sorbet/translate.rb
+++ b/lib/spoom/sorbet/translate.rb
@@ -5,7 +5,7 @@ require "rbi"
 
 require "spoom/source/rewriter"
 require "spoom/sorbet/translate/translator"
-require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator"
+require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs"
 require "spoom/sorbet/translate/sorbet_assertions_to_rbs_comments"
 require "spoom/sorbet/translate/sorbet_sigs_to_rbs_comments"
 require "spoom/sorbet/translate/strip_sorbet_sigs"

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
@@ -1,0 +1,39 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Sorbet
+    module Translate
+      module RBSCommentsToSorbetSigs
+        class << self
+          RBS_ANNOTATION_MARKERS = [
+            "# @abstract",
+            "# @interface",
+            "# @sealed",
+            "# @final",
+            "# @requires_ancestor:",
+            "# @override",
+            "# @overridable",
+            "# @without_runtime",
+          ].freeze #: Array[String]
+          RBS_REWRITE_PATTERN = Regexp.union(["#:", "#|", *RBS_ANNOTATION_MARKERS]).freeze #: Regexp
+          private_constant :RBS_ANNOTATION_MARKERS, :RBS_REWRITE_PATTERN
+
+          #: (String source) -> bool
+          def contains_rbs_syntax?(source)
+            Sigils.contains_valid_sigil?(source) && source.match?(RBS_REWRITE_PATTERN)
+          end
+
+          #: (String ruby_contents, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> String
+          def rewrite_if_needed(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
+            return ruby_contents unless contains_rbs_syntax?(ruby_contents)
+
+            HumanReadableTranslator.new(ruby_contents, file:, max_line_length:, overloads_strategy:).rewrite
+          end
+        end
+      end
+    end
+  end
+end
+
+require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator"

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -4,9 +4,7 @@
 module Spoom
   module Sorbet
     module Translate
-      class RBSCommentsToSorbetSigs < Translator
-        include Spoom::RBS::ExtractRBSComments
-
+      module RBSCommentsToSorbetSigs
         RBS_ANNOTATION_MARKERS = [
           "# @abstract",
           "# @interface",
@@ -20,8 +18,6 @@ module Spoom
         RBS_REWRITE_PATTERN = Regexp.union(["#:", "#|", *RBS_ANNOTATION_MARKERS]).freeze #: Regexp
         private_constant :RBS_ANNOTATION_MARKERS, :RBS_REWRITE_PATTERN
 
-        ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze #: Array[Symbol]
-
         class << self
           #: (String source) -> bool
           def contains_rbs_syntax?(source)
@@ -32,9 +28,15 @@ module Spoom
           def rewrite_if_needed(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
             return ruby_contents unless contains_rbs_syntax?(ruby_contents)
 
-            new(ruby_contents, file:, max_line_length:, overloads_strategy:).rewrite
+            BaseTranslator.new(ruby_contents, file:, max_line_length:, overloads_strategy:).rewrite
           end
         end
+      end
+
+      class RBSCommentsToSorbetSigs::BaseTranslator < Translator # rubocop:disable Style/ClassAndModuleChildren
+        include Spoom::RBS::ExtractRBSComments
+
+        ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze #: Array[Symbol]
 
         #: (String, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> void
         def initialize(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -4,36 +4,8 @@
 module Spoom
   module Sorbet
     module Translate
-      module RBSCommentsToSorbetSigs
-        RBS_ANNOTATION_MARKERS = [
-          "# @abstract",
-          "# @interface",
-          "# @sealed",
-          "# @final",
-          "# @requires_ancestor:",
-          "# @override",
-          "# @overridable",
-          "# @without_runtime",
-        ].freeze #: Array[String]
-        RBS_REWRITE_PATTERN = Regexp.union(["#:", "#|", *RBS_ANNOTATION_MARKERS]).freeze #: Regexp
-        private_constant :RBS_ANNOTATION_MARKERS, :RBS_REWRITE_PATTERN
-
-        class << self
-          #: (String source) -> bool
-          def contains_rbs_syntax?(source)
-            Sigils.contains_valid_sigil?(source) && source.match?(RBS_REWRITE_PATTERN)
-          end
-
-          #: (String ruby_contents, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> String
-          def rewrite_if_needed(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
-            return ruby_contents unless contains_rbs_syntax?(ruby_contents)
-
-            BaseTranslator.new(ruby_contents, file:, max_line_length:, overloads_strategy:).rewrite
-          end
-        end
-      end
-
-      class RBSCommentsToSorbetSigs::BaseTranslator < Translator # rubocop:disable Style/ClassAndModuleChildren
+      # @abstract
+      class RBSCommentsToSorbetSigs::BaseTranslator < Translator
         include Spoom::RBS::ExtractRBSComments
 
         ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze #: Array[Symbol]

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -4,409 +4,411 @@
 module Spoom
   module Sorbet
     module Translate
-      # @abstract
-      class RBSCommentsToSorbetSigs::BaseTranslator < Translator
-        include Spoom::RBS::ExtractRBSComments
+      module RBSCommentsToSorbetSigs
+        # @abstract
+        class BaseTranslator < Translator
+          include Spoom::RBS::ExtractRBSComments
 
-        ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze #: Array[Symbol]
+          ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze #: Array[Symbol]
 
-        #: (String, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> void
-        def initialize(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
-          super(ruby_contents, file: file)
+          #: (String, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> void
+          def initialize(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
+            super(ruby_contents, file: file)
 
-          unless ALLOWED_OVERLOAD_STRATEGIES.include?(overloads_strategy)
-            raise ArgumentError, "Unknown overloads_strategy: #{overloads_strategy.inspect}. " \
-              "Must be one of: #{ALLOWED_OVERLOAD_STRATEGIES.map(&:inspect).join(", ")}"
+            unless ALLOWED_OVERLOAD_STRATEGIES.include?(overloads_strategy)
+              raise ArgumentError, "Unknown overloads_strategy: #{overloads_strategy.inspect}. " \
+                "Must be one of: #{ALLOWED_OVERLOAD_STRATEGIES.map(&:inspect).join(", ")}"
+            end
+
+            @max_line_length = max_line_length
+            @overloads_strategy = overloads_strategy
           end
 
-          @max_line_length = max_line_length
-          @overloads_strategy = overloads_strategy
-        end
+          # @override
+          #: (Prism::ProgramNode node) -> void
+          def visit_program_node(node)
+            # Process all type aliases from the entire file first
+            apply_type_aliases(@comments)
 
-        # @override
-        #: (Prism::ProgramNode node) -> void
-        def visit_program_node(node)
-          # Process all type aliases from the entire file first
-          apply_type_aliases(@comments)
+            # Now process the rest of the file with type aliases available
+            super
+          end
 
-          # Now process the rest of the file with type aliases available
-          super
-        end
-
-        # @override
-        #: (Prism::ClassNode node) -> void
-        def visit_class_node(node)
-          apply_class_annotations(node)
-
-          super
-        end
-
-        # @override
-        #: (Prism::ModuleNode node) -> void
-        def visit_module_node(node)
-          apply_class_annotations(node)
-
-          super
-        end
-
-        # @override
-        #: (Prism::SingletonClassNode node) -> void
-        def visit_singleton_class_node(node)
-          apply_class_annotations(node)
-
-          super
-        end
-
-        # @override
-        #: (Prism::DefNode node) -> void
-        def visit_def_node(node)
-          rewrite_def(node, node_rbs_comments(node))
-        end
-
-        # @override
-        #: (Prism::CallNode node) -> void
-        def visit_call_node(node)
-          case node.message
-          when "attr_reader", "attr_writer", "attr_accessor"
-            visit_attr(node)
-          else
-            def_node = node.arguments&.arguments&.first
-            if def_node&.is_a?(Prism::DefNode)
-              rewrite_def(def_node, node_rbs_comments(node))
-              return
-            end
+          # @override
+          #: (Prism::ClassNode node) -> void
+          def visit_class_node(node)
+            apply_class_annotations(node)
 
             super
           end
-        end
 
-        private
+          # @override
+          #: (Prism::ModuleNode node) -> void
+          def visit_module_node(node)
+            apply_class_annotations(node)
 
-        #: (Prism::CallNode) -> void
-        def visit_attr(node)
-          comments = node_rbs_comments(node)
-          return if comments.empty?
+            super
+          end
 
-          return if comments.signatures.empty?
+          # @override
+          #: (Prism::SingletonClassNode node) -> void
+          def visit_singleton_class_node(node)
+            apply_class_annotations(node)
 
-          signatures = apply_overloads_strategy(
-            comments.signatures,
-            method_name: node.message.to_s,
-            location: "#{@file}:#{node.location.start_line}",
-          )
+            super
+          end
 
-          signatures.each do |signature|
-            attr_type = ::RBS::Parser.parse_type(signature.string)
-            sig = RBI::Sig.new
+          # @override
+          #: (Prism::DefNode node) -> void
+          def visit_def_node(node)
+            rewrite_def(node, node_rbs_comments(node))
+          end
 
-            if node.message == "attr_writer"
-              if node.arguments&.arguments&.size != 1
-                raise Error, "AttrWriter must have exactly one name"
+          # @override
+          #: (Prism::CallNode node) -> void
+          def visit_call_node(node)
+            case node.message
+            when "attr_reader", "attr_writer", "attr_accessor"
+              visit_attr(node)
+            else
+              def_node = node.arguments&.arguments&.first
+              if def_node&.is_a?(Prism::DefNode)
+                rewrite_def(def_node, node_rbs_comments(node))
+                return
               end
 
-              name = node.arguments&.arguments&.first #: as Prism::SymbolNode
-              sig.params << RBI::SigParam.new(
-                name.slice[1..-1], #: as String
-                RBI::RBS::TypeTranslator.translate(attr_type),
+              super
+            end
+          end
+
+          private
+
+          #: (Prism::CallNode) -> void
+          def visit_attr(node)
+            comments = node_rbs_comments(node)
+            return if comments.empty?
+
+            return if comments.signatures.empty?
+
+            signatures = apply_overloads_strategy(
+              comments.signatures,
+              method_name: node.message.to_s,
+              location: "#{@file}:#{node.location.start_line}",
+            )
+
+            signatures.each do |signature|
+              attr_type = ::RBS::Parser.parse_type(signature.string)
+              sig = RBI::Sig.new
+
+              if node.message == "attr_writer"
+                if node.arguments&.arguments&.size != 1
+                  raise Error, "AttrWriter must have exactly one name"
+                end
+
+                name = node.arguments&.arguments&.first #: as Prism::SymbolNode
+                sig.params << RBI::SigParam.new(
+                  name.slice[1..-1], #: as String
+                  RBI::RBS::TypeTranslator.translate(attr_type),
+                )
+              end
+
+              sig.return_type = RBI::RBS::TypeTranslator.translate(attr_type)
+
+              apply_member_annotations(comments.method_annotations, sig)
+
+              @rewriter << Source::Replace.new(
+                signature.location.start_offset,
+                signature.location.end_offset,
+                sig.string(max_line_length: @max_line_length),
+              )
+            rescue ::RBS::ParsingError, ::RBI::Error
+              # Ignore signatures with errors
+              next
+            end
+          end
+
+          #: (Prism::DefNode, RBS::Comments) -> void
+          def rewrite_def(def_node, comments)
+            return if comments.empty?
+            return if comments.signatures.empty?
+
+            signatures = apply_overloads_strategy(
+              comments.signatures,
+              method_name: def_node.name.to_s,
+              location: "#{@file}:#{def_node.location.start_line}",
+            )
+
+            builder = RBI::Parser::TreeBuilder.new(@ruby_contents, comments: [], file: @file)
+            builder.visit(def_node)
+            rbi_node = builder.tree.nodes.first #: as RBI::Method
+
+            signatures.each do |signature|
+              begin
+                method_type = ::RBS::Parser.parse_method_type(signature.string)
+              rescue ::RBS::ParsingError
+                next
+              end
+
+              translator = RBI::RBS::MethodTypeTranslator.new(rbi_node)
+
+              begin
+                translator.visit(method_type)
+              rescue ::RBI::Error
+                next
+              end
+
+              sig = translator.result
+
+              apply_member_annotations(comments.method_annotations, sig)
+
+              # Sorbet runtime doesn't support `sig` on `method_added` or
+              # `singleton_method_added`, so we always use `without_runtime` for them.
+              if def_node.name == :method_added || def_node.name == :singleton_method_added
+                sig.without_runtime = true
+              end
+
+              @rewriter << Source::Replace.new(
+                signature.location.start_offset,
+                signature.location.end_offset,
+                sig.string(max_line_length: @max_line_length),
               )
             end
-
-            sig.return_type = RBI::RBS::TypeTranslator.translate(attr_type)
-
-            apply_member_annotations(comments.method_annotations, sig)
-
-            @rewriter << Source::Replace.new(
-              signature.location.start_offset,
-              signature.location.end_offset,
-              sig.string(max_line_length: @max_line_length),
-            )
-          rescue ::RBS::ParsingError, ::RBI::Error
-            # Ignore signatures with errors
-            next
-          end
-        end
-
-        #: (Prism::DefNode, RBS::Comments) -> void
-        def rewrite_def(def_node, comments)
-          return if comments.empty?
-          return if comments.signatures.empty?
-
-          signatures = apply_overloads_strategy(
-            comments.signatures,
-            method_name: def_node.name.to_s,
-            location: "#{@file}:#{def_node.location.start_line}",
-          )
-
-          builder = RBI::Parser::TreeBuilder.new(@ruby_contents, comments: [], file: @file)
-          builder.visit(def_node)
-          rbi_node = builder.tree.nodes.first #: as RBI::Method
-
-          signatures.each do |signature|
-            begin
-              method_type = ::RBS::Parser.parse_method_type(signature.string)
-            rescue ::RBS::ParsingError
-              next
-            end
-
-            translator = RBI::RBS::MethodTypeTranslator.new(rbi_node)
-
-            begin
-              translator.visit(method_type)
-            rescue ::RBI::Error
-              next
-            end
-
-            sig = translator.result
-
-            apply_member_annotations(comments.method_annotations, sig)
-
-            # Sorbet runtime doesn't support `sig` on `method_added` or
-            # `singleton_method_added`, so we always use `without_runtime` for them.
-            if def_node.name == :method_added || def_node.name == :singleton_method_added
-              sig.without_runtime = true
-            end
-
-            @rewriter << Source::Replace.new(
-              signature.location.start_offset,
-              signature.location.end_offset,
-              sig.string(max_line_length: @max_line_length),
-            )
-          end
-        end
-
-        #: (Array[RBS::Signature], method_name: String, location: String) -> Array[RBS::Signature]
-        def apply_overloads_strategy(signatures, method_name:, location:)
-          return signatures if signatures.size <= 1
-
-          case @overloads_strategy
-          when :translate_all
-            signatures
-          when :translate_last
-            kept = signatures.last #: as RBS::Signature
-            others = signatures[0...-1] #: as !nil
-
-            # Delete all the signatures we didn't keep
-            others.each do |signature|
-              from = adjust_to_line_start(signature.location.start_offset)
-              to = adjust_to_line_end(signature.location.end_offset)
-              @rewriter << Source::Delete.new(from, to)
-            end
-            [kept]
-          else # :raise
-            raise Error, "Method `#{method_name}` at #{location} has multiple overloaded signatures"
-          end
-        end
-
-        #: (Prism::ClassNode | Prism::ModuleNode | Prism::SingletonClassNode) -> void
-        def apply_class_annotations(node)
-          comments = node_rbs_comments(node)
-          return if comments.empty?
-
-          indent = " " * (node.location.start_column + 2)
-          insert_pos = case node
-          when Prism::ClassNode
-            (node.superclass || node.constant_path).location.end_offset
-          when Prism::ModuleNode
-            node.constant_path.location.end_offset
-          when Prism::SingletonClassNode
-            node.expression.location.end_offset
           end
 
-          class_annotations = comments.class_annotations
-          if class_annotations.any?
-            unless already_extends?(node, /^(::)?T::Helpers$/)
-              @rewriter << Source::Insert.new(insert_pos, "\n#{indent}extend T::Helpers\n")
+          #: (Array[RBS::Signature], method_name: String, location: String) -> Array[RBS::Signature]
+          def apply_overloads_strategy(signatures, method_name:, location:)
+            return signatures if signatures.size <= 1
+
+            case @overloads_strategy
+            when :translate_all
+              signatures
+            when :translate_last
+              kept = signatures.last #: as RBS::Signature
+              others = signatures[0...-1] #: as !nil
+
+              # Delete all the signatures we didn't keep
+              others.each do |signature|
+                from = adjust_to_line_start(signature.location.start_offset)
+                to = adjust_to_line_end(signature.location.end_offset)
+                @rewriter << Source::Delete.new(from, to)
+              end
+              [kept]
+            else # :raise
+              raise Error, "Method `#{method_name}` at #{location} has multiple overloaded signatures"
+            end
+          end
+
+          #: (Prism::ClassNode | Prism::ModuleNode | Prism::SingletonClassNode) -> void
+          def apply_class_annotations(node)
+            comments = node_rbs_comments(node)
+            return if comments.empty?
+
+            indent = " " * (node.location.start_column + 2)
+            insert_pos = case node
+            when Prism::ClassNode
+              (node.superclass || node.constant_path).location.end_offset
+            when Prism::ModuleNode
+              node.constant_path.location.end_offset
+            when Prism::SingletonClassNode
+              node.expression.location.end_offset
             end
 
-            class_annotations.reverse_each do |annotation|
-              from = adjust_to_line_start(annotation.location.start_offset)
-              to = adjust_to_line_end(annotation.location.end_offset)
-
-              content = case annotation.string
-              when "@abstract"
-                "abstract!"
-              when "@interface"
-                "interface!"
-              when "@sealed"
-                "sealed!"
-              when "@final"
-                "final!"
-              when /^@requires_ancestor: /
-                srb_type = ::RBS::Parser.parse_type(annotation.string.delete_prefix("@requires_ancestor: "))
-                rbs_type = RBI::RBS::TypeTranslator.translate(srb_type)
-                "requires_ancestor { #{rbs_type} }"
-              else
-                next
+            class_annotations = comments.class_annotations
+            if class_annotations.any?
+              unless already_extends?(node, /^(::)?T::Helpers$/)
+                @rewriter << Source::Insert.new(insert_pos, "\n#{indent}extend T::Helpers\n")
               end
 
-              @rewriter << Source::Delete.new(from, to)
+              class_annotations.reverse_each do |annotation|
+                from = adjust_to_line_start(annotation.location.start_offset)
+                to = adjust_to_line_end(annotation.location.end_offset)
 
-              newline = node.body.nil? ? "" : "\n"
-              @rewriter << Source::Insert.new(insert_pos, "\n#{indent}#{content}#{newline}")
-            rescue ::RBS::ParsingError, ::RBI::Error
-              # Ignore annotations with errors
-              next
-            end
-          end
-
-          signatures = comments.signatures
-          if signatures.any?
-            signatures.each do |signature|
-              # Only type param signatures (e.g. `#: [A, B]`) are valid on class/module nodes
-              next unless signature.string.start_with?("[")
-
-              type_params = ::RBS::Parser.parse_type_params(signature.string)
-              next if type_params.empty?
-
-              from = adjust_to_line_start(signature.location.start_offset)
-              to = adjust_to_line_end(signature.location.end_offset)
-              @rewriter << Source::Delete.new(from, to)
-
-              unless already_extends?(node, /^(::)?T::Generic$/)
-                @rewriter << Source::Insert.new(insert_pos, "\n#{indent}extend T::Generic\n")
-              end
-
-              type_params.each do |type_param|
-                type_member = "#{type_param.name} = type_member"
-
-                case type_param.variance
-                when :covariant
-                  type_member = "#{type_member}(:out)"
-                when :contravariant
-                  type_member = "#{type_member}(:in)"
+                content = case annotation.string
+                when "@abstract"
+                  "abstract!"
+                when "@interface"
+                  "interface!"
+                when "@sealed"
+                  "sealed!"
+                when "@final"
+                  "final!"
+                when /^@requires_ancestor: /
+                  srb_type = ::RBS::Parser.parse_type(annotation.string.delete_prefix("@requires_ancestor: "))
+                  rbs_type = RBI::RBS::TypeTranslator.translate(srb_type)
+                  "requires_ancestor { #{rbs_type} }"
+                else
+                  next
                 end
 
-                if type_param.upper_bound || type_param.default_type
-                  if type_param.upper_bound
-                    rbs_type = RBI::RBS::TypeTranslator.translate(type_param.upper_bound)
-                    type_member = "#{type_member} {{ upper: #{rbs_type} }}"
-                  end
-
-                  if type_param.default_type
-                    rbs_type = RBI::RBS::TypeTranslator.translate(type_param.default_type)
-                    type_member = "#{type_member} {{ fixed: #{rbs_type} }}"
-                  end
-                end
+                @rewriter << Source::Delete.new(from, to)
 
                 newline = node.body.nil? ? "" : "\n"
-                @rewriter << Source::Insert.new(insert_pos, "\n#{indent}#{type_member}#{newline}")
+                @rewriter << Source::Insert.new(insert_pos, "\n#{indent}#{content}#{newline}")
               rescue ::RBS::ParsingError, ::RBI::Error
-                # Ignore signatures with errors
+                # Ignore annotations with errors
                 next
               end
             end
-          end
-        end
 
-        #: (Array[RBS::Annotation], RBI::Sig) -> void
-        def apply_member_annotations(annotations, sig)
-          annotations.each do |annotation|
-            case annotation.string
-            when "@abstract"
-              sig.is_abstract = true
-            when "@final"
-              sig.is_final = true
-            when "@override"
-              sig.is_override = true
-            when "@override(allow_incompatible: true)"
-              sig.is_override = true
-              sig.allow_incompatible_override = true
-            when "@override(allow_incompatible: :visibility)"
-              sig.is_override = true
-              sig.allow_incompatible_override_visibility = true
-            when "@overridable"
-              sig.is_overridable = true
-            when "@without_runtime"
-              sig.without_runtime = true
-            end
-          end
-        end
+            signatures = comments.signatures
+            if signatures.any?
+              signatures.each do |signature|
+                # Only type param signatures (e.g. `#: [A, B]`) are valid on class/module nodes
+                next unless signature.string.start_with?("[")
 
-        #: (Prism::ClassNode | Prism::ModuleNode | Prism::SingletonClassNode, Regexp) -> bool
-        def already_extends?(node, constant_regex)
-          node.child_nodes.any? do |c|
-            next false unless c.is_a?(Prism::CallNode)
-            next false unless c.message == "extend"
-            next false unless c.receiver.nil? || c.receiver.is_a?(Prism::SelfNode)
-            next false unless c.arguments&.arguments&.size == 1
+                type_params = ::RBS::Parser.parse_type_params(signature.string)
+                next if type_params.empty?
 
-            arg = c.arguments&.arguments&.first
-            next false unless arg.is_a?(Prism::ConstantPathNode)
-            next false unless arg.slice.match?(constant_regex)
+                from = adjust_to_line_start(signature.location.start_offset)
+                to = adjust_to_line_end(signature.location.end_offset)
+                @rewriter << Source::Delete.new(from, to)
 
-            true
-          end
-        end
-
-        #: (Array[Prism::Comment]) -> Array[RBS::TypeAlias]
-        def collect_type_aliases(comments)
-          type_aliases = [] #: Array[RBS::TypeAlias]
-
-          return type_aliases if comments.empty?
-
-          continuation_comments = [] #: Array[Prism::Comment]
-
-          comments.reverse_each do |comment|
-            string = comment.slice
-
-            if string.start_with?("#:")
-              string = string.delete_prefix("#:").strip
-              location = comment.location
-
-              if string.start_with?("type ")
-                continuation_comments.reverse_each do |continuation_comment|
-                  string = "#{string}#{continuation_comment.slice.delete_prefix("#|")}"
-                  location = location.join(continuation_comment.location)
+                unless already_extends?(node, /^(::)?T::Generic$/)
+                  @rewriter << Source::Insert.new(insert_pos, "\n#{indent}extend T::Generic\n")
                 end
 
-                type_aliases << Spoom::RBS::TypeAlias.new(string, location)
-              end
+                type_params.each do |type_param|
+                  type_member = "#{type_param.name} = type_member"
 
-              # Clear the continuation comments regardless of whether we found a type alias or not
-              continuation_comments.clear
-            elsif string.start_with?("#|")
-              continuation_comments << comment
-            else
-              continuation_comments.clear
+                  case type_param.variance
+                  when :covariant
+                    type_member = "#{type_member}(:out)"
+                  when :contravariant
+                    type_member = "#{type_member}(:in)"
+                  end
+
+                  if type_param.upper_bound || type_param.default_type
+                    if type_param.upper_bound
+                      rbs_type = RBI::RBS::TypeTranslator.translate(type_param.upper_bound)
+                      type_member = "#{type_member} {{ upper: #{rbs_type} }}"
+                    end
+
+                    if type_param.default_type
+                      rbs_type = RBI::RBS::TypeTranslator.translate(type_param.default_type)
+                      type_member = "#{type_member} {{ fixed: #{rbs_type} }}"
+                    end
+                  end
+
+                  newline = node.body.nil? ? "" : "\n"
+                  @rewriter << Source::Insert.new(insert_pos, "\n#{indent}#{type_member}#{newline}")
+                rescue ::RBS::ParsingError, ::RBI::Error
+                  # Ignore signatures with errors
+                  next
+                end
+              end
             end
           end
 
-          type_aliases
-        end
+          #: (Array[RBS::Annotation], RBI::Sig) -> void
+          def apply_member_annotations(annotations, sig)
+            annotations.each do |annotation|
+              case annotation.string
+              when "@abstract"
+                sig.is_abstract = true
+              when "@final"
+                sig.is_final = true
+              when "@override"
+                sig.is_override = true
+              when "@override(allow_incompatible: true)"
+                sig.is_override = true
+                sig.allow_incompatible_override = true
+              when "@override(allow_incompatible: :visibility)"
+                sig.is_override = true
+                sig.allow_incompatible_override_visibility = true
+              when "@overridable"
+                sig.is_overridable = true
+              when "@without_runtime"
+                sig.without_runtime = true
+              end
+            end
+          end
 
-        #: (Array[Prism::Comment]) -> void
-        def apply_type_aliases(comments)
-          type_aliases = collect_type_aliases(comments)
+          #: (Prism::ClassNode | Prism::ModuleNode | Prism::SingletonClassNode, Regexp) -> bool
+          def already_extends?(node, constant_regex)
+            node.child_nodes.any? do |c|
+              next false unless c.is_a?(Prism::CallNode)
+              next false unless c.message == "extend"
+              next false unless c.receiver.nil? || c.receiver.is_a?(Prism::SelfNode)
+              next false unless c.arguments&.arguments&.size == 1
 
-          type_aliases.each do |type_alias|
-            indent = " " * type_alias.location.start_column
-            insert_pos = adjust_to_line_start(type_alias.location.start_offset)
+              arg = c.arguments&.arguments&.first
+              next false unless arg.is_a?(Prism::ConstantPathNode)
+              next false unless arg.slice.match?(constant_regex)
 
-            from = insert_pos
-            to = adjust_to_line_end(type_alias.location.end_offset)
+              true
+            end
+          end
 
-            *, decls = ::RBS::Parser.parse_signature(type_alias.string)
+          #: (Array[Prism::Comment]) -> Array[RBS::TypeAlias]
+          def collect_type_aliases(comments)
+            type_aliases = [] #: Array[RBS::TypeAlias]
 
-            # We only expect there to be a single type alias declaration
-            next unless decls.size == 1 && decls.first.is_a?(::RBS::AST::Declarations::TypeAlias)
+            return type_aliases if comments.empty?
 
-            rbs_type = decls.first
-            sorbet_type = RBI::RBS::TypeTranslator.translate(rbs_type.type)
+            continuation_comments = [] #: Array[Prism::Comment]
 
-            alias_name = ::RBS::TypeName.new(
-              namespace: rbs_type.name.namespace,
-              name: rbs_type.name.name.to_s.gsub(/(?:^|_)([a-z\d]*)/i) do |match|
-                match = match.delete_prefix("_")
-                !match.empty? ? match[0].upcase.concat(match[1..-1]) : +""
-              end,
-            )
+            comments.reverse_each do |comment|
+              string = comment.slice
 
-            @rewriter << Source::Delete.new(from, to)
-            content = "#{indent}#{alias_name} = T.type_alias { #{sorbet_type.to_rbi} }\n"
-            @rewriter << Source::Insert.new(insert_pos, content)
-          rescue ::RBS::ParsingError, ::RBI::Error
-            # Ignore type aliases with errors
-            next
+              if string.start_with?("#:")
+                string = string.delete_prefix("#:").strip
+                location = comment.location
+
+                if string.start_with?("type ")
+                  continuation_comments.reverse_each do |continuation_comment|
+                    string = "#{string}#{continuation_comment.slice.delete_prefix("#|")}"
+                    location = location.join(continuation_comment.location)
+                  end
+
+                  type_aliases << Spoom::RBS::TypeAlias.new(string, location)
+                end
+
+                # Clear the continuation comments regardless of whether we found a type alias or not
+                continuation_comments.clear
+              elsif string.start_with?("#|")
+                continuation_comments << comment
+              else
+                continuation_comments.clear
+              end
+            end
+
+            type_aliases
+          end
+
+          #: (Array[Prism::Comment]) -> void
+          def apply_type_aliases(comments)
+            type_aliases = collect_type_aliases(comments)
+
+            type_aliases.each do |type_alias|
+              indent = " " * type_alias.location.start_column
+              insert_pos = adjust_to_line_start(type_alias.location.start_offset)
+
+              from = insert_pos
+              to = adjust_to_line_end(type_alias.location.end_offset)
+
+              *, decls = ::RBS::Parser.parse_signature(type_alias.string)
+
+              # We only expect there to be a single type alias declaration
+              next unless decls.size == 1 && decls.first.is_a?(::RBS::AST::Declarations::TypeAlias)
+
+              rbs_type = decls.first
+              sorbet_type = RBI::RBS::TypeTranslator.translate(rbs_type.type)
+
+              alias_name = ::RBS::TypeName.new(
+                namespace: rbs_type.name.namespace,
+                name: rbs_type.name.name.to_s.gsub(/(?:^|_)([a-z\d]*)/i) do |match|
+                  match = match.delete_prefix("_")
+                  !match.empty? ? match[0].upcase.concat(match[1..-1]) : +""
+                end,
+              )
+
+              @rewriter << Source::Delete.new(from, to)
+              content = "#{indent}#{alias_name} = T.type_alias { #{sorbet_type.to_rbi} }\n"
+              @rewriter << Source::Insert.new(insert_pos, content)
+            rescue ::RBS::ParsingError, ::RBI::Error
+              # Ignore type aliases with errors
+              next
+            end
           end
         end
       end

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb
@@ -1,0 +1,15 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator"
+
+module Spoom
+  module Sorbet
+    module Translate
+      module RBSCommentsToSorbetSigs
+        class HumanReadableTranslator < BaseTranslator
+        end
+      end
+    end
+  end
+end

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2918,7 +2918,24 @@ end
 
 class Spoom::Sorbet::Translate::Error < ::Spoom::Error; end
 
-class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs < ::Spoom::Sorbet::Translate::Translator
+module Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs
+  class << self
+    sig { params(source: ::String).returns(T::Boolean) }
+    def contains_rbs_syntax?(source); end
+
+    sig do
+      params(
+        ruby_contents: ::String,
+        file: ::String,
+        max_line_length: T.nilable(::Integer),
+        overloads_strategy: ::Symbol
+      ).returns(::String)
+    end
+    def rewrite_if_needed(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil)); end
+  end
+end
+
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator < ::Spoom::Sorbet::Translate::Translator
   include ::Spoom::RBS::ExtractRBSComments
 
   sig do
@@ -2985,24 +3002,10 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs < ::Spoom::Sorbet::Trans
 
   sig { params(node: ::Prism::CallNode).void }
   def visit_attr(node); end
-
-  class << self
-    sig { params(source: ::String).returns(T::Boolean) }
-    def contains_rbs_syntax?(source); end
-
-    sig do
-      params(
-        ruby_contents: ::String,
-        file: ::String,
-        max_line_length: T.nilable(::Integer),
-        overloads_strategy: ::Symbol
-      ).returns(::String)
-    end
-    def rewrite_if_needed(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil)); end
-  end
 end
 
-Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::ALLOWED_OVERLOAD_STRATEGIES = T.let(T.unsafe(nil), Array)
+Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator::ALLOWED_OVERLOAD_STRATEGIES = T.let(T.unsafe(nil), Array)
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableTranslator < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator; end
 Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::RBS_ANNOTATION_MARKERS = T.let(T.unsafe(nil), Array)
 Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::RBS_REWRITE_PATTERN = T.let(T.unsafe(nil), Regexp)
 

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2938,6 +2938,8 @@ end
 class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator < ::Spoom::Sorbet::Translate::Translator
   include ::Spoom::RBS::ExtractRBSComments
 
+  abstract!
+
   sig do
     params(
       ruby_contents: ::String,
@@ -3006,8 +3008,6 @@ end
 
 Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator::ALLOWED_OVERLOAD_STRATEGIES = T.let(T.unsafe(nil), Array)
 class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableTranslator < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator; end
-Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::RBS_ANNOTATION_MARKERS = T.let(T.unsafe(nil), Array)
-Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::RBS_REWRITE_PATTERN = T.let(T.unsafe(nil), Regexp)
 
 class Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments < ::Spoom::Sorbet::Translate::Translator
   sig do

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -976,7 +976,7 @@ module Spoom
             end
           RB
 
-          RBSCommentsToSorbetSigs.stub(:new, ->(*) { flunk("should not be called") }) do
+          RBSCommentsToSorbetSigs::HumanReadableTranslator.stub(:new, ->(*) { flunk("should not be called") }) do
             assert_equal(source, RBSCommentsToSorbetSigs.rewrite_if_needed(source, file: "test.rb"))
           end
         end
@@ -985,7 +985,7 @@ module Spoom
 
         #: (String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> String
         def rbs_comments_to_sorbet_sigs(ruby_contents, max_line_length: nil, overloads_strategy: :translate_all)
-          RBSCommentsToSorbetSigs.new(
+          RBSCommentsToSorbetSigs::HumanReadableTranslator.new(
             ruby_contents,
             file: "test.rb",
             max_line_length: max_line_length,


### PR DESCRIPTION
## Breaking change

This PR makes a breaking change of renaming the `RBSCommentsToSorbetSigs` class to `RBSCommentsToSorbetSigs::HumanReadableTranslator`

These two APIs will still work as before:

* `RBSCommentsToSorbetSigs.contains_rbs_syntax?`
* `RBSCommentsToSorbetSigs.rewrite_if_needed`

But you can no longer do `RBSCommentsToSorbetSigs.new`. Instead, you must pick a particular translation strategy. There's currently just one: `RBSCommentsToSorbetSigs::HumanReadableTranslator.new`.

## Why?

For #787 wrote a second strategy called `RBSCommentsToSorbetSigs::LineMatchingTranslator`, and it's easier to pick the class than to make a complicated wrapper that tries to pick for you.

# How

This PR does this refactor in 3 green steps, which preserve the git history intact.

Review the 3 commits separately, and the diff is minimal.