### PR TITLE
Use a TypeTranslator instance in RBSCommentsToSorbetSigs

### DIFF
--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -22,6 +22,7 @@ module Spoom
 
             @max_line_length = max_line_length
             @overloads_strategy = overloads_strategy
+            @type_translator = RBI::RBS::TypeTranslator.new #: RBI::RBS::TypeTranslator
           end
 
           # @override
@@ -108,11 +109,11 @@ module Spoom
                 name = node.arguments&.arguments&.first #: as Prism::SymbolNode
                 sig.params << RBI::SigParam.new(
                   name.slice[1..-1], #: as String
-                  RBI::RBS::TypeTranslator.translate(attr_type),
+                  @type_translator.translate(attr_type),
                 )
               end
 
-              sig.return_type = RBI::RBS::TypeTranslator.translate(attr_type)
+              sig.return_type = @type_translator.translate(attr_type)
 
               apply_member_annotations(comments.method_annotations, sig)
 
@@ -234,7 +235,7 @@ module Spoom
                   "final!"
                 when /^@requires_ancestor: /
                   srb_type = ::RBS::Parser.parse_type(annotation.string.delete_prefix("@requires_ancestor: "))
-                  rbs_type = RBI::RBS::TypeTranslator.translate(srb_type)
+                  rbs_type = @type_translator.translate(srb_type)
                   "requires_ancestor { #{rbs_type} }"
                 else
                   next
@@ -279,12 +280,12 @@ module Spoom
 
                   if type_param.upper_bound || type_param.default_type
                     if type_param.upper_bound
-                      rbs_type = RBI::RBS::TypeTranslator.translate(type_param.upper_bound)
+                      rbs_type = @type_translator.translate(type_param.upper_bound)
                       type_member = "#{type_member} {{ upper: #{rbs_type} }}"
                     end
 
                     if type_param.default_type
-                      rbs_type = RBI::RBS::TypeTranslator.translate(type_param.default_type)
+                      rbs_type = @type_translator.translate(type_param.default_type)
                       type_member = "#{type_member} {{ fixed: #{rbs_type} }}"
                     end
                   end
@@ -392,7 +393,7 @@ module Spoom
               next unless decls.size == 1 && decls.first.is_a?(::RBS::AST::Declarations::TypeAlias)
 
               rbs_type = decls.first
-              sorbet_type = RBI::RBS::TypeTranslator.translate(rbs_type.type)
+              sorbet_type = @type_translator.translate(rbs_type.type)
 
               alias_name = ::RBS::TypeName.new(
                 namespace: rbs_type.name.namespace,


### PR DESCRIPTION
- Part of https://github.com/Shopify/spoom/issues/924

Previously, `RBSCommentsToSorbetSigs` translated types using the `RBI::RBS::TypeTranslator` `translate` method. In order to support the ability to pass translation configuration. This PR creates a `TypeTranslator` instance and updates type translation callers to use it