### PR TITLE
Introduce `Options` object

### DIFF
--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs.rb
@@ -24,11 +24,27 @@ module Spoom
             Sigils.contains_valid_sigil?(source) && source.match?(RBS_REWRITE_PATTERN)
           end
 
-          #: (String ruby_contents, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> String
-          def rewrite_if_needed(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
+          #: (
+          #|   String ruby_contents,
+          #|   file: String,
+          #|   ?max_line_length: Integer?,
+          #|   ?overloads_strategy: Symbol) -> String
+          def rewrite_if_needed(
+            ruby_contents,
+            file:,
+            max_line_length: nil,
+            overloads_strategy: :translate_all
+          )
             return ruby_contents unless contains_rbs_syntax?(ruby_contents)
 
-            HumanReadableTranslator.new(ruby_contents, file:, max_line_length:, overloads_strategy:).rewrite
+            options = Options.new(
+              overloads_strategy:,
+              output_format: HumanReadableRBIFormat.new(
+                max_line_length:,
+              ),
+            )
+
+            HumanReadableTranslator.new(ruby_contents, file:, options:).rewrite
           end
         end
       end
@@ -36,4 +52,5 @@ module Spoom
   end
 end
 
+require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options"
 require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator"

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -9,19 +9,22 @@ module Spoom
         class BaseTranslator < Translator
           include Spoom::RBS::ExtractRBSComments
 
-          ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze #: Array[Symbol]
+          #: (String, file: String, ?options: Options) -> void
+          def initialize(
+            ruby_contents,
+            file:,
+            options: Options.default
+          )
+            super(ruby_contents, file:)
 
-          #: (String, file: String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> void
-          def initialize(ruby_contents, file:, max_line_length: nil, overloads_strategy: :translate_all)
-            super(ruby_contents, file: file)
+            @max_line_length = case (format = options.output_format)
+            when HumanReadableRBIFormat
+              format.max_line_length
+            else
+              nil
+            end #: Integer?
 
-            unless ALLOWED_OVERLOAD_STRATEGIES.include?(overloads_strategy)
-              raise ArgumentError, "Unknown overloads_strategy: #{overloads_strategy.inspect}. " \
-                "Must be one of: #{ALLOWED_OVERLOAD_STRATEGIES.map(&:inspect).join(", ")}"
-            end
-
-            @max_line_length = max_line_length
-            @overloads_strategy = overloads_strategy
+            @overloads_strategy = options.overloads_strategy #: Symbol
             @type_translator = RBI::RBS::TypeTranslator.new #: RBI::RBS::TypeTranslator
           end
 

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator"
+require "spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options"
 
 module Spoom
   module Sorbet

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
@@ -1,0 +1,70 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Spoom
+  module Sorbet
+    module Translate
+      module RBSCommentsToSorbetSigs
+        # @abstract
+        class BaseRBIFormat
+        end
+
+        class HumanReadableRBIFormat < BaseRBIFormat
+          #: Integer?
+          attr_reader :max_line_length
+
+          #: (
+          #|   ?max_line_length: Integer?,
+          #| ) -> void
+          def initialize(max_line_length: nil)
+            super()
+            @max_line_length = max_line_length
+
+            freeze
+          end
+
+          @default = new #: HumanReadableRBIFormat
+          class << self
+            #: HumanReadableRBIFormat
+            attr_reader :default
+          end
+        end
+
+        class Options
+          #: Symbol
+          attr_reader :overloads_strategy
+
+          ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze
+
+          #: BaseRBIFormat
+          attr_reader :output_format
+
+          #: (
+          #|   ?overloads_strategy: Symbol,
+          #|   ?output_format: BaseRBIFormat,
+          #| ) -> void
+          def initialize(
+            overloads_strategy: :translate_all,
+            output_format: HumanReadableRBIFormat.default
+          )
+            unless ALLOWED_OVERLOAD_STRATEGIES.include?(overloads_strategy)
+              raise ArgumentError, "Unknown overloads_strategy: #{overloads_strategy.inspect}. " \
+                "Must be one of: #{ALLOWED_OVERLOAD_STRATEGIES.map(&:inspect).join(", ")}"
+            end
+
+            @overloads_strategy = overloads_strategy
+            @output_format = output_format
+
+            freeze
+          end
+
+          @default = new #: Options
+          class << self
+            #: Options
+            attr_reader :default
+          end
+        end
+      end
+    end
+  end
+end

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2937,6 +2937,10 @@ module Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs
   end
 end
 
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat
+  abstract!
+end
+
 class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator < ::Spoom::Sorbet::Translate::Translator
   include ::Spoom::RBS::ExtractRBSComments
 
@@ -2946,11 +2950,10 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator < ::Spoo
     params(
       ruby_contents: ::String,
       file: ::String,
-      max_line_length: T.nilable(::Integer),
-      overloads_strategy: ::Symbol
+      options: ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options
     ).void
   end
-  def initialize(ruby_contents, file:, max_line_length: T.unsafe(nil), overloads_strategy: T.unsafe(nil)); end
+  def initialize(ruby_contents, file:, options: T.unsafe(nil)); end
 
   sig { override.params(node: ::Prism::CallNode).void }
   def visit_call_node(node); end
@@ -3008,8 +3011,43 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator < ::Spoo
   def visit_attr(node); end
 end
 
-Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator::ALLOWED_OVERLOAD_STRATEGIES = T.let(T.unsafe(nil), Array)
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableRBIFormat < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat
+  sig { params(max_line_length: T.nilable(::Integer)).void }
+  def initialize(max_line_length: T.unsafe(nil)); end
+
+  sig { returns(T.nilable(::Integer)) }
+  def max_line_length; end
+
+  class << self
+    sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableRBIFormat) }
+    def default; end
+  end
+end
+
 class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableTranslator < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator; end
+
+class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options
+  sig do
+    params(
+      overloads_strategy: ::Symbol,
+      output_format: ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat
+    ).void
+  end
+  def initialize(overloads_strategy: T.unsafe(nil), output_format: T.unsafe(nil)); end
+
+  sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat) }
+  def output_format; end
+
+  sig { returns(::Symbol) }
+  def overloads_strategy; end
+
+  class << self
+    sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options) }
+    def default; end
+  end
+end
+
+Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options::ALLOWED_OVERLOAD_STRATEGIES = T.let(T.unsafe(nil), Array)
 
 class Spoom::Sorbet::Translate::SorbetAssertionsToRBSComments < ::Spoom::Sorbet::Translate::Translator
   sig do

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -988,8 +988,12 @@ module Spoom
           RBSCommentsToSorbetSigs::HumanReadableTranslator.new(
             ruby_contents,
             file: "test.rb",
-            max_line_length: max_line_length,
-            overloads_strategy: overloads_strategy,
+            options: RBSCommentsToSorbetSigs::Options.new(
+              overloads_strategy:,
+              output_format: RBSCommentsToSorbetSigs::HumanReadableRBIFormat.new(
+                max_line_length:,
+              ),
+            ),
           ).rewrite
         end
 


### PR DESCRIPTION
This PR introduces a more complex `Options` object to allow us to have different sets of configuration. For example, max line length does not apply to the new line preserving format (which may need to create very long lines to preserve backtraces).

The idea is to have a base object that gets specialized for the different cases.