### PR TITLE
Add `erase_generic_types` option

### DIFF
--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
@@ -44,6 +44,9 @@ module Spoom
 
           ALLOWED_OVERLOAD_STRATEGIES = [:translate_all, :translate_last, :raise].freeze
 
+          #: bool
+          attr_reader :erase_generic_types
+
           #: BaseRBIFormat
           attr_reader :output_format
 
@@ -52,11 +55,13 @@ module Spoom
 
           #: (
           #|   ?overloads_strategy: Symbol,
+          #|   ?erase_generic_types: bool,
           #|   ?output_format: BaseRBIFormat,
           #|   ?translate_abstract_methods: bool,
           #| ) -> void
           def initialize(
             overloads_strategy: :translate_all,
+            erase_generic_types: false,
             output_format: HumanReadableRBIFormat.default,
             translate_abstract_methods: true
           )
@@ -66,6 +71,7 @@ module Spoom
             end
 
             @overloads_strategy = overloads_strategy
+            @erase_generic_types = erase_generic_types
             @output_format = output_format
             @translate_abstract_methods = translate_abstract_methods
 

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -3238,11 +3238,15 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options
   sig do
     params(
       overloads_strategy: ::Symbol,
+      erase_generic_types: T::Boolean,
       output_format: ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat,
       translate_abstract_methods: T::Boolean
     ).void
   end
-  def initialize(overloads_strategy: T.unsafe(nil), output_format: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
+  def initialize(overloads_strategy: T.unsafe(nil), erase_generic_types: T.unsafe(nil), output_format: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
+
+  sig { returns(T::Boolean) }
+  def erase_generic_types; end
 
   sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat) }
   def output_format; end


### PR DESCRIPTION
- part of https://github.com/Shopify/spoom/issues/924

This PR adds `erase_generic_types` to the `RBSCommentsToSorbetSigs` options to prepare for  [Add rewriter option to erase generics](https://github.com/Shopify/spoom/pull/946#top)#946