### PR TITLE
Allow skipping abstract method translation

### DIFF
--- a/lib/spoom/rbs.rb
+++ b/lib/spoom/rbs.rb
@@ -68,7 +68,12 @@ module Spoom
       end
     end
 
-    class Annotation < Comment; end
+    class Annotation < Comment
+      #: () -> bool
+      def abstract?
+        @string == "@abstract"
+      end
+    end
 
     class Signature < Comment
       # Locations of the `#|` continuation comment lines that make up a multiline signature,

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -25,6 +25,7 @@ module Spoom
             end #: Integer?
 
             @overloads_strategy = options.overloads_strategy #: Symbol
+            @translate_abstract_methods = options.translate_abstract_methods #: bool
             @type_translator = RBI::RBS::TypeTranslator.new #: RBI::RBS::TypeTranslator
           end
 
@@ -141,6 +142,7 @@ module Spoom
           def rewrite_def(def_node, comments)
             return if comments.empty?
             return if comments.signatures.empty?
+            return if !@translate_abstract_methods && comments.method_annotations.any?(&:abstract?)
 
             signatures = apply_overloads_strategy(
               comments.signatures,

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/options.rb
@@ -47,13 +47,18 @@ module Spoom
           #: BaseRBIFormat
           attr_reader :output_format
 
+          #: bool
+          attr_reader :translate_abstract_methods
+
           #: (
           #|   ?overloads_strategy: Symbol,
           #|   ?output_format: BaseRBIFormat,
+          #|   ?translate_abstract_methods: bool,
           #| ) -> void
           def initialize(
             overloads_strategy: :translate_all,
-            output_format: HumanReadableRBIFormat.default
+            output_format: HumanReadableRBIFormat.default,
+            translate_abstract_methods: true
           )
             unless ALLOWED_OVERLOAD_STRATEGIES.include?(overloads_strategy)
               raise ArgumentError, "Unknown overloads_strategy: #{overloads_strategy.inspect}. " \
@@ -62,6 +67,7 @@ module Spoom
 
             @overloads_strategy = overloads_strategy
             @output_format = output_format
+            @translate_abstract_methods = translate_abstract_methods
 
             freeze
           end

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -2578,7 +2578,11 @@ end
 module Spoom::PrismTypes; end
 Spoom::PrismTypes::AnyScopeNode = T.type_alias { T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode) }
 module Spoom::RBS; end
-class Spoom::RBS::Annotation < ::Spoom::RBS::Comment; end
+
+class Spoom::RBS::Annotation < ::Spoom::RBS::Comment
+  sig { returns(T::Boolean) }
+  def abstract?; end
+end
 
 class Spoom::RBS::Comment
   sig { params(string: ::String, location: ::Prism::Location).void }
@@ -3209,16 +3213,20 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options
   sig do
     params(
       overloads_strategy: ::Symbol,
-      output_format: ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat
+      output_format: ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat,
+      translate_abstract_methods: T::Boolean
     ).void
   end
-  def initialize(overloads_strategy: T.unsafe(nil), output_format: T.unsafe(nil)); end
+  def initialize(overloads_strategy: T.unsafe(nil), output_format: T.unsafe(nil), translate_abstract_methods: T.unsafe(nil)); end
 
   sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat) }
   def output_format; end
 
   sig { returns(::Symbol) }
   def overloads_strategy; end
+
+  sig { returns(T::Boolean) }
+  def translate_abstract_methods; end
 
   class << self
     sig { returns(::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::Options) }

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -147,6 +147,66 @@ module Spoom
           )
         end
 
+        def test_translate_to_rbi_skipping_abstract_methods
+          assert_rewrites_rbs(
+            from: <<~RUBY,
+              # @abstract
+              class Foo
+                # @abstract
+                #: -> String
+                def bar; end
+              end
+
+              # @abstract
+              module Baz
+                # @abstract
+                #: -> String
+                def qux; end
+              end
+            RUBY
+
+            to_pretty_format_for_humans: <<~RUBY,
+              class Foo
+                extend T::Helpers
+
+                abstract!
+
+                # @abstract
+                #: -> String
+                def bar; end
+              end
+
+              module Baz
+                extend T::Helpers
+
+                abstract!
+
+                # @abstract
+                #: -> String
+                def qux; end
+              end
+            RUBY
+
+            to_line_matched_format_for_machines: <<~RUBY,
+              # RBS_REWRITTEN_ANNOTATION: @abstract
+              class Foo; extend T::Helpers; abstract!
+                # @abstract
+                #: -> String
+                def bar; end
+              end
+
+              # RBS_REWRITTEN_ANNOTATION: @abstract
+              module Baz; extend T::Helpers; abstract!
+                # @abstract
+                #: -> String
+                def qux; end
+              end
+            RUBY
+
+            translate_abstract_methods: false,
+          )
+        end
+
         def test_translate_to_rbi_method_sigs_without_runtime
           assert_rewrites_rbs(
             from: <<~RUBY,
@@ -1280,13 +1340,23 @@ module Spoom
 
         private
 
-        #: (String, ?max_line_length: Integer?, ?overloads_strategy: Symbol) -> String
-        def rbs_comments_to_sorbet_sigs(ruby_contents, max_line_length: nil, overloads_strategy: :translate_all)
+        #: (String,
+        #|   ?max_line_length: Integer?,
+        #|   ?overloads_strategy: Symbol,
+        #|   ?translate_abstract_methods: bool
+        #| ) -> String
+        def rbs_comments_to_sorbet_sigs(
+          ruby_contents,
+          max_line_length: nil,
+          overloads_strategy: :translate_all,
+          translate_abstract_methods: true
+        )
           RBSCommentsToSorbetSigs::HumanReadableTranslator.new(
             ruby_contents,
             file: "test.rb",
             options: RBSCommentsToSorbetSigs::Options.new(
               overloads_strategy:,
+              translate_abstract_methods:,
               output_format: RBSCommentsToSorbetSigs::HumanReadableRBIFormat.new(
                 max_line_length:,
               ),
@@ -1299,14 +1369,16 @@ module Spoom
         #|   to_pretty_format_for_humans: String,
         #|   to_line_matched_format_for_machines: String | Symbol,
         #|   ?max_line_length: Integer?,
-        #|   ?overloads_strategy: Symbol
+        #|   ?overloads_strategy: Symbol,
+        #|   ?translate_abstract_methods: bool
         #| ) -> void
         def assert_rewrites_rbs(
           from:,
           to_pretty_format_for_humans:,
           to_line_matched_format_for_machines:,
           max_line_length: nil,
-          overloads_strategy: :translate_all
+          overloads_strategy: :translate_all,
+          translate_abstract_methods: true
         )
           source_with_rbs = from
           expected_pretty_format = to_pretty_format_for_humans
@@ -1317,6 +1389,7 @@ module Spoom
               source_with_rbs,
               max_line_length:,
               overloads_strategy:,
+              translate_abstract_methods:,
             )
 
             assert_equal(expected_pretty_format, rewritten_output)
@@ -1347,6 +1420,7 @@ module Spoom
               file: "test.rb",
               options: RBSCommentsToSorbetSigs::Options.new(
                 overloads_strategy:,
+                translate_abstract_methods:,
                 output_format: RBSCommentsToSorbetSigs::LineMatchedRBIFormat.default,
               ),
             ).rewrite


### PR DESCRIPTION
This PR introduces a new option that allows skipping the translation of abstract methods.