### PR TITLE
Collect T::Struct and T::Enum code metrics

### DIFF
--- a/lib/spoom/sorbet/metrics/code_metrics_visitor.rb
+++ b/lib/spoom/sorbet/metrics/code_metrics_visitor.rb
@@ -75,9 +75,9 @@ module Spoom
         def visit_class_node(node)
           case node.superclass&.slice
           when /^(::)?T::Struct$/
-            @counters.increment("structs")
+            @counters.increment("t_structs")
           when /^(::)?T::Enum$/
-            @counters.increment("enums")
+            @counters.increment("t_enums")
           end
 
           visit_scope(node) do

--- a/lib/spoom/sorbet/metrics/code_metrics_visitor.rb
+++ b/lib/spoom/sorbet/metrics/code_metrics_visitor.rb
@@ -73,6 +73,13 @@ module Spoom
         # @override
         #: (Prism::ClassNode) -> void
         def visit_class_node(node)
+          case node.superclass&.slice
+          when /^(::)?T::Struct$/
+            @counters.increment("structs")
+          when /^(::)?T::Enum$/
+            @counters.increment("enums")
+          end
+
           visit_scope(node) do
             super
           end

--- a/test/spoom/sorbet/metrics/code_metrics_visitor_test.rb
+++ b/test/spoom/sorbet/metrics/code_metrics_visitor_test.rb
@@ -34,6 +34,22 @@ module Spoom
           assert_equal(1, metrics["accessors"])
         end
 
+        def test_collects_metrics_about_sorbet_structs_and_enums
+          metrics = collect_metrics do |context|
+            context.write!("foo.rb", <<~RUBY)
+              class Struct < T::Struct; end
+              class RootStruct < ::T::Struct; end
+              class Enum < T::Enum; end
+              class RootEnum < ::T::Enum; end
+              class Other; end
+            RUBY
+          end
+
+          assert_equal(5, metrics["classes"])
+          assert_equal(2, metrics["structs"])
+          assert_equal(2, metrics["enums"])
+        end
+
         def test_collects_metrics_about_sigs
           metrics = collect_metrics do |context|
             context.write!("foo.rb", <<~RUBY)

--- a/test/spoom/sorbet/metrics/code_metrics_visitor_test.rb
+++ b/test/spoom/sorbet/metrics/code_metrics_visitor_test.rb
@@ -46,8 +46,8 @@ module Spoom
           end
 
           assert_equal(5, metrics["classes"])
-          assert_equal(2, metrics["structs"])
-          assert_equal(2, metrics["enums"])
+          assert_equal(2, metrics["t_structs"])
+          assert_equal(2, metrics["t_enums"])
         end
 
         def test_collects_metrics_about_sigs


### PR DESCRIPTION
## What changed

- count direct `T::Struct` children as `t_structs`
- count direct `T::Enum` children as `t_enums`
- support both `T::` and root-qualified `::T::` superclasses
