### PR TITLE
Remove redundant trailing comment test

### DIFF
--- a/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
@@ -458,17 +458,6 @@ module Spoom
           assert_equal(rb, rbi_to_rbs(rb))
         end
 
-        def test_does_not_translate_assertions_already_with_comments
-          rb = <<~RB
-            a = T.let(42, Integer) # as Integer
-          RB
-
-          # Now translates and preserves the comment
-          assert_equal(<<~RB, rbi_to_rbs(rb))
-            a = 42 #: Integer # as Integer
-          RB
-        end
-
         def test_translate_cast_in_oneliners
           rb = <<~RB
             arr.map { |x| T.must(x) }


### PR DESCRIPTION
Remove redundant test already covered by https://github.com/Shopify/spoom/blob/e4ca92bbdbca5b57044c6211f730b0a5c508f4ea/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb#L621-L633.