### PR TITLE
Skip assigned T.bind assertion translations

### DIFF
--- a/lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb
+++ b/lib/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments.rb
@@ -69,6 +69,11 @@ module Spoom
 
         #: (Prism::Node) -> bool
         def maybe_translate_assertion(node)
+          # Most assertions can replace the value on the right-hand side of an assignment.
+          # `T.bind` becomes a standalone RBS comment instead, so replacing an assigned
+          # `T.bind` would leave invalid code such as `bound = #: self as Type`.
+          standalone_assertion = node.is_a?(Prism::CallNode)
+
           node = case node
           when Prism::MultiWriteNode,
                Prism::ClassVariableWriteNode, Prism::ClassVariableAndWriteNode, Prism::ClassVariableOperatorWriteNode, Prism::ClassVariableOrWriteNode,
@@ -89,6 +94,7 @@ module Spoom
 
           return false unless node.is_a?(Prism::CallNode)
           return false unless translatable_annotation?(node)
+          return false if node.name == :bind && !standalone_assertion
           return false unless at_end_of_line?(node)
 
           trailing_comment, comment_end_offset = extract_trailing_comment(node)

--- a/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
+++ b/test/spoom/sorbet/translate/sorbet_assertions_to_rbs_comments_test.rb
@@ -595,6 +595,14 @@ module Spoom
           RB
         end
 
+        def test_skip_bind_in_assignment
+          rb = <<~RB
+            bound = T.bind(self, FulfillmentOrderMoverTest)
+          RB
+
+          assert_equal(rb, rbi_to_rbs(rb))
+        end
+
         def test_translate_options
           rb = <<~RB
             T.bind(self, T.class_of(String))


### PR DESCRIPTION
## Why?

Given this Sorbet assertion:

```ruby
bound = T.bind(self, FulfillmentOrderMoverTest)
```

`spoom srb assertions translate` currently produces:

```ruby
bound = #: self as FulfillmentOrderMoverTest
```

This is invalid Ruby. Unlike `T.let` and `T.cast`, `T.bind` translates to a standalone RBS comment and leaves no expression that can remain on the right-hand side of the assignment. Until there is a safe translation for that shape, assignment-wrapped `T.bind` calls should be left unchanged.

## What changed?

* Leave assignment-wrapped `T.bind` calls unchanged for now.
* Add regression coverage for the failing assignment case.