### PR TITLE
Place generic extend last

### DIFF
--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/base_translator.rb
@@ -89,6 +89,31 @@ module Spoom
 
           private
 
+          #: (PrismTypes::anyScopeNode) -> Integer
+          def find_class_annotation_insert_pos(node)
+            # First try to find the last `extend` statement in the scope. This guarantees that we always place `extend
+            # T::Generic` after all the other extends, which makes it appear first in the ancestor chain
+            body = node.body
+
+            if body.is_a?(Prism::StatementsNode)
+              last_extend = body.body.reverse_each.find do |node|
+                node.is_a?(Prism::CallNode) && node.message == "extend" && !node.receiver
+              end
+
+              return last_extend.location.end_offset if last_extend
+            end
+
+            # If we don't find any extends, then place it immediately after the scope opening.
+            case node
+            when Prism::ClassNode
+              (node.superclass || node.constant_path).location.end_offset
+            when Prism::ModuleNode
+              node.constant_path.location.end_offset
+            when Prism::SingletonClassNode
+              node.expression.location.end_offset
+            end
+          end
+
           #: (Prism::CallNode) -> void
           def visit_attr(node)
             comments = node_rbs_comments(node)
@@ -222,14 +247,7 @@ module Spoom
             comments = node_rbs_comments(node)
             return if comments.empty?
 
-            insert_pos = case node
-            when Prism::ClassNode
-              (node.superclass || node.constant_path).location.end_offset
-            when Prism::ModuleNode
-              node.constant_path.location.end_offset
-            when Prism::SingletonClassNode
-              node.expression.location.end_offset
-            end
+            insert_pos = find_class_annotation_insert_pos(node)
 
             # Only translate (and `extend ::T::Helpers`) when there's at least one *known* class
             # annotation. A node with only unknown annotations (e.g. `@private`) is left untouched.

--- a/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb
+++ b/lib/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs/human_readable_translator.rb
@@ -36,7 +36,7 @@ module Spoom
             @rewriter << Source::Delete.new(from, to)
 
             indent = " " * (parent_node.location.start_column + 2)
-            newline = parent_node.body.nil? ? "" : "\n"
+            newline = trailing_newline(parent_node:, insert_pos:)
             @rewriter << Source::Insert.new(insert_pos, "\n#{indent}#{sorbet_replacement}#{newline}")
           end
 
@@ -52,8 +52,16 @@ module Spoom
           #: (String type_member, parent_node: PrismTypes::anyScopeNode, insert_pos: Integer) -> void
           def insert_type_member(type_member, parent_node:, insert_pos:)
             indent = " " * (parent_node.location.start_column + 2)
-            newline = parent_node.body.nil? ? "" : "\n"
+            newline = trailing_newline(parent_node:, insert_pos:)
             @rewriter << Source::Insert.new(insert_pos, "\n#{indent}#{type_member}#{newline}")
+          end
+
+          #: (parent_node: PrismTypes::anyScopeNode, insert_pos: Integer) -> String
+          def trailing_newline(parent_node:, insert_pos:)
+            # We only want to add a newline if the scope node's body is not empty or if the insertion position is not at
+            # the end of the body. This is to avoid leaving a blank line immediately before the `end`.
+            body = parent_node.body
+            body.nil? || body.location.end_offset == insert_pos ? "" : "\n"
           end
 
           # @override

--- a/rbi/spoom.rbi
+++ b/rbi/spoom.rbi
@@ -3421,6 +3421,9 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseTranslator < ::Spoo
   end
   def extend_with(mixin_name, into:, at:); end
 
+  sig { params(node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode)).returns(::Integer) }
+  def find_class_annotation_insert_pos(node); end
+
   sig do
     abstract
       .params(
@@ -3498,6 +3501,14 @@ class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableTranslator
 
   sig { override.params(signature: ::Spoom::RBS::Signature, type_params: T::Array[::RBS::AST::TypeParam]).void }
   def rewrite_type_params_signature(signature, type_params:); end
+
+  sig do
+    params(
+      parent_node: T.any(::Prism::ClassNode, ::Prism::ModuleNode, ::Prism::SingletonClassNode),
+      insert_pos: ::Integer
+    ).returns(::String)
+  end
+  def trailing_newline(parent_node:, insert_pos:); end
 end
 
 class Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::LineMatchedRBIFormat < ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::BaseRBIFormat

--- a/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
+++ b/test/spoom/sorbet/translate/rbs_comments_to_sorbet_sigs_test.rb
@@ -622,6 +622,64 @@ module Spoom
           )
         end
 
+        def test_extend_generic_appears_last
+          assert_rewrites_rbs(
+            from: <<~RUBY,
+              #: [Elem]
+              class A
+                extend OtherThing
+              end
+            RUBY
+
+            to_pretty_format_for_humans: <<~RUBY,
+              class A
+                extend OtherThing
+                extend ::T::Generic
+
+                Elem = type_member
+              end
+            RUBY
+
+            to_line_matched_format_for_machines: <<~RUBY,
+              # RBS_WRITTEN_ANNOTATION: [Elem]
+              class A
+                extend OtherThing; extend ::T::Generic; Elem = type_member
+              end
+            RUBY
+          )
+        end
+
+        def test_extend_generic_appears_last_with_statements_after_the_last_extend
+          assert_rewrites_rbs(
+            from: <<~RUBY,
+              #: [Elem]
+              class A
+                extend OtherThing
+                CONST = 1
+              end
+            RUBY
+
+            to_pretty_format_for_humans: <<~RUBY,
+              class A
+                extend OtherThing
+                extend ::T::Generic
+
+                Elem = type_member
+
+                CONST = 1
+              end
+            RUBY
+
+            to_line_matched_format_for_machines: <<~RUBY,
+              # RBS_WRITTEN_ANNOTATION: [Elem]
+              class A
+                extend OtherThing; extend ::T::Generic; Elem = type_member
+                CONST = 1
+              end
+            RUBY
+          )
+        end
+
         def test_translate_to_rbi_fully_qualifies_extend_t_generic_and_helpers
           assert_rewrites_rbs(
             from: <<~RUBY,
@@ -662,18 +720,17 @@ module Spoom
 
             to_pretty_format_for_humans: <<~RUBY,
               class Box
+                extend T::Helpers
                 extend ::T::Helpers
 
                 final!
-
-                extend T::Helpers
               end
             RUBY
 
             to_line_matched_format_for_machines: <<~RUBY,
               # RBS_REWRITTEN_ANNOTATION: @final
-              class Box; extend ::T::Helpers; final!
-                extend T::Helpers
+              class Box
+                extend T::Helpers; extend ::T::Helpers; final!
               end
             RUBY
           )


### PR DESCRIPTION
When we re-write RBS generic namespaces, we place the `extend T::Generic` first, in the very beginning of the body. This means that they appear last in the singleton class' ancestor chain, which makes it very easy to bypass Tapioca's patches for tracking generic type parameters.

```ruby
module Patch
  def [](*types)
  end
end

#: [Elem]
class Something
  extend Patch
end
```

That's enough to bypass the patch because `extend T::Generic` appears before `extend Patch`, which means the singleton ancestors are `[<Something>, <Patch>, <T::Generic>...]`. This breaks Tapioca RBI generation for generics.

Trying to ensure that Tapioca can always generate regardless of `[]` being overridden is not super straight forward, so I propose we flip the rewriter instead. This PR places `extend T::Generic` immediately after the last `extend` in a scope's body.

The idea is simply to change the insert position, which already fixes the issue, but then it also means we need to be a touch smarter about when to add line breaks in the body.